### PR TITLE
fix(cdk: click-outside): compatible with null exclude elements

### DIFF
--- a/packages/cdk/click-outside/src/useClickOutside.ts
+++ b/packages/cdk/click-outside/src/useClickOutside.ts
@@ -3,7 +3,7 @@ import type { ObjectDirective } from 'vue'
 import { isFunction, isObject, noop, on } from '@idux/cdk/utils'
 
 interface ClickOutsideOptions {
-  exclude: HTMLElement[]
+  exclude: (HTMLElement | null)[]
   handler: ClickOutsideHandler
 }
 
@@ -40,7 +40,7 @@ function createHandler(el: HTMLElement, binding: ClickOutsideBinding): void {
   if (isFunction(binding)) {
     handler = binding as ClickOutsideHandler
   } else if (isObject<ClickOutsideOptions>(binding)) {
-    exclude.push(...binding.exclude)
+    exclude.push(...(binding.exclude.filter(Boolean) as HTMLElement[]))
     handler = binding.handler
   }
 


### PR DESCRIPTION
## PR Checklist

Fix overlay class components that use portal with `load` prop.

When `load = false` that directive `click-outside`'s exclude is recived null that throw erros.

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IduxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Other information
