### PR TITLE
fix: 通过npm run gen创建组件缺少style的入口文件

### DIFF
--- a/scripts/gen/generate.ts
+++ b/scripts/gen/generate.ts
@@ -11,6 +11,7 @@ import { mkdir, pathExistsSync, readFile, writeFile } from 'fs-extra'
 import {
   getIndexTemplate,
   getLessTemplate,
+  getStyleIndexTemplate,
   getTestTemplate,
   getTypesTemplate,
   getDocsTemplate,
@@ -171,6 +172,7 @@ class Generate {
     const camelCaseName = camelCase(name)
     const upperFirstName = upperFirst(camelCaseName)
     const lessTemplate = getLessTemplate(kebabCase(name))
+    const styleIndexTemplate = getStyleIndexTemplate()
     const typesTemplate = getTypesTemplate(upperFirstName, camelCaseName)
     const tsxTemplate = getTsxTemplate(upperFirstName, camelCaseName)
     const vueTemplate = getVueTemplate(upperFirstName, camelCaseName)
@@ -179,6 +181,7 @@ class Generate {
 
     await Promise.all([
       writeFile(`${this.dirPath}/style/index.less`, lessTemplate),
+      writeFile(`${this.dirPath}/style/index.ts`, styleIndexTemplate),
       writeFile(`${this.dirPath}/src/types.ts`, typesTemplate),
       this.useTsx
         ? writeFile(`${this.dirPath}/src/${upperFirstName}.tsx`, tsxTemplate)

--- a/scripts/gen/template.ts
+++ b/scripts/gen/template.ts
@@ -9,6 +9,12 @@ export function getLessTemplate(compName: string): string {
 `
 }
 
+export function getStyleIndexTemplate(): string {
+  return `import '../../style/index.less'
+import './index.less'
+`
+}
+
 export function getTypesTemplate(upperFirstName: string, camelCaseName: string): string {
   return `import type { DefineComponent, HTMLAttributes } from 'vue'
 import type { IxInnerPropTypes, IxPublicPropTypes } from '@idux/cdk/utils'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
通过npm run gen 创建一个组件 xxx , npm run start 运行页面，发现无法进去新创建的组件demo展示页面

## What is the new behavior?
可以正常进去新组件demo页面

## Other information