### PR TITLE
fix(overlay): fix warn of "Maximum recursive updates exceeded in component <IxOverlay>"

### DIFF
--- a/packages/cdk/click-outside/src/useClickOutside.ts
+++ b/packages/cdk/click-outside/src/useClickOutside.ts
@@ -3,7 +3,7 @@ import type { ObjectDirective } from 'vue'
 import { isFunction, isObject } from 'lodash-es'
 import { noop, on } from '@idux/cdk/utils'
 
-interface ClickOutsideOptions {
+export interface ClickOutsideOptions {
   exclude: (HTMLElement | null)[]
   handler: ClickOutsideHandler
 }


### PR DESCRIPTION
…onent <IxOverlay>"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
when i running test of component time-picker, it throw a warning
![image](https://user-images.githubusercontent.com/22521237/132119796-fc57e143-4a6b-456c-9fc6-5803547d3487.png)

i think the reason of this problem is it calling the popperRef in renderTrigger function
https://github.com/IDuxFE/idux/blob/95e649ce2ad7cfc7c0551f8bc0a5ea0f12f63e95/packages/components/_private/overlay/src/Overlay.tsx#L128


## What is the new behavior?
It doesn't throw this warning anymore

## Other information
