### PR TITLE
feat(comp:all): 提取所有组件的类前缀到全局config中

### DIFF
--- a/packages/cdk/overlay/src/useOverlay.ts
+++ b/packages/cdk/overlay/src/useOverlay.ts
@@ -240,7 +240,7 @@ export const useOverlay = <
     hide,
     update,
     destroy,
-    id: uniqueId('ix-overlay'),
+    id: uniqueId(`ix-overlay`),
     visibility,
     triggerEventHandler,
     overlayEventHandler,

--- a/packages/cdk/scroll/src/virtual/VirtualHolder.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualHolder.tsx
@@ -5,6 +5,7 @@ import { computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, wat
 import { isNil, throttle } from 'lodash-es'
 import { isFirefox } from '@idux/cdk/platform'
 import { callEmit, cancelRAF, off, offResize, on, onResize, rAF } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { virtualScrollToken } from './token'
 
 export default defineComponent({
@@ -21,6 +22,7 @@ export default defineComponent({
       syncScrollTop,
       originScroll,
     } = inject(virtualScrollToken)!
+    const { prefixCls } = useGlobalConfig('common')
 
     const style = computed<StyleValue | undefined>(() => {
       const { height, fullHeight } = props
@@ -81,9 +83,9 @@ export default defineComponent({
     return () => {
       const children = props.contentRender ? props.contentRender(slots.default!()) : slots.default!()
       return (
-        <div ref={holderRef} class="ix-virtual-scroll-holder" style={style.value} onScroll={onScroll}>
-          <div ref={fillerRef} class="ix-virtual-scroll-filler" style={fillerStyle.value}>
-            <div ref={contentRef} class="ix-virtual-scroll-content" style={contentStyle.value}>
+        <div ref={holderRef} class={`${prefixCls}-virtual-scroll-holder`} style={style.value} onScroll={onScroll}>
+          <div ref={fillerRef} class={`${prefixCls}-virtual-scroll-filler`} style={fillerStyle.value}>
+            <div ref={contentRef} class={`${prefixCls}-virtual-scroll-content`} style={contentStyle.value}>
               {children}
             </div>
           </div>

--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, provide, ref } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { useGetKey } from './composables/useGetKey'
 import { useItemHeights } from './composables/useItemHeights'
 import { useScroll } from './composables/useScroll'
@@ -13,6 +14,8 @@ export default defineComponent({
   name: 'IxVirtualScroll',
   props: virtualListProps,
   setup(props, { expose, slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const useVirtual = computed(() => props.height > 0 && props.itemHeight > 0)
     const getKey = useGetKey(props)
     const { heights, collectHeights, setItemElement } = useItemHeights(getKey)
@@ -52,7 +55,7 @@ export default defineComponent({
       })
 
       return (
-        <div class="ix-virtual-scroll" style={{ position: 'relative' }}>
+        <div class={`${prefixCls}-virtual-scroll`} style={{ position: 'relative' }}>
           <VirtualHolder>{children}</VirtualHolder>
           {useVirtual.value && <VirtualScrollBar />}
         </div>

--- a/packages/cdk/scroll/src/virtual/VirtualScrollBar.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScrollBar.tsx
@@ -2,12 +2,14 @@ import type { ComputedRef, Ref, StyleValue } from 'vue'
 
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { on, off, rAF, cancelRAF } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { virtualScrollToken } from './token'
 import { VirtualScrollProps } from './types'
 import { ScrollBarState, SyncScrollTop } from './composables/useScroll'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, scrollState, scrollTop, hideScrollBar, syncScrollTop, setScrollMoving, scrollBarVisible } =
       inject(virtualScrollToken)!
 
@@ -30,7 +32,7 @@ export default defineComponent({
     const thumbStyle = useThumbStyle(thumbHight, thumbTop)
 
     return () => (
-      <div ref={scrollBarRef} class="ix-virtual-scroll-bar" style={style.value}>
+      <div ref={scrollBarRef} class={`${prefixCls}-virtual-scroll-bar`} style={style.value}>
         <div ref={thumbRef} class={thumbClass.value} style={thumbStyle.value} />
       </div>
     )
@@ -183,10 +185,11 @@ const useStyle = (visible: ComputedRef<boolean>) => {
 }
 
 const useThumbClass = (dragging: Ref<boolean>) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-virtual-scroll-thumb': true,
-      'ix-virtual-scroll-thumb-moving': dragging.value,
+      [`${prefixCls}-virtual-scroll-thumb`]: true,
+      [`${prefixCls}-virtual-scroll-thumb-moving`]: dragging.value,
     }
   })
 }

--- a/packages/components/_private/mask/src/Mask.tsx
+++ b/packages/components/_private/mask/src/Mask.tsx
@@ -1,9 +1,12 @@
 import { defineComponent, Transition } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { maskProps } from './types'
 
 export default defineComponent({
   props: maskProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
+
     return () => {
       const { mask, transitionName, visible, zIndex } = props
       if (!mask) {
@@ -12,7 +15,7 @@ export default defineComponent({
 
       return (
         <Transition appear name={transitionName}>
-          <div v-show={visible} class="ix-mask" style={{ zIndex }}></div>
+          <div v-show={visible} class={`${prefixCls}-mask`} style={{ zIndex }}></div>
         </Transition>
       )
     }

--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -1,5 +1,6 @@
 import type { ComputedRef, Ref, VNode } from 'vue'
 import type { PopperElement, PopperEvents } from '@idux/cdk/popper'
+import { useGlobalConfig } from '@idux/components/config'
 import type { OverlayProps } from './types'
 
 import {
@@ -103,11 +104,12 @@ function renderContent(
   if (props.destroyOnHide && !visibility.value) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
 
-  const arrow = props.showArrow ? <div ref={arrowRef} class="ix-overlay-arrow"></div> : null
+  const arrow = props.showArrow ? <div ref={arrowRef} class={`${prefixCls}-overlay-arrow`}></div> : null
 
   const overlay = (
-    <div ref={popperRef} class="ix-overlay" {...popperEvents.value} {...attrs}>
+    <div ref={popperRef} class={`${prefixCls}-overlay`} {...popperEvents.value} {...attrs}>
       {contentNode}
       {arrow}
     </div>

--- a/packages/components/affix/src/Affix.tsx
+++ b/packages/components/affix/src/Affix.tsx
@@ -3,6 +3,7 @@ import type { AffixStyle } from './utils'
 
 import { defineComponent, computed, watch, ref, onMounted, nextTick, onUnmounted } from 'vue'
 import { throttleRAF } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { getTarget } from '@idux/components/utils'
 import { affixProps } from './types'
 import {
@@ -92,9 +93,11 @@ export default defineComponent({
     }
   },
   render() {
+    const { prefixCls } = useGlobalConfig('common')
+
     return (
-      <div ref="affixRef" style={this.wrapperStyle} class="ix-affix">
-        <div ref="contentRef" class="ix-affix-content" style={this.affixStyle}>
+      <div ref="affixRef" style={this.wrapperStyle} class={`${prefixCls}-affix`}>
+        <div ref="contentRef" class={`${prefixCls}-affix-content`} style={this.affixStyle}>
           {this.$slots.default?.()}
         </div>
       </div>

--- a/packages/components/anchor/src/Anchor.tsx
+++ b/packages/components/anchor/src/Anchor.tsx
@@ -15,6 +15,7 @@ export default defineComponent({
   name: 'IxAnchor',
   props: anchorProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('anchor')
     const hideLinkBall = computed(() => props.hideLinkBall ?? config.hideLinkBall)
     const wrapperStyle = computed(() => {
@@ -31,9 +32,9 @@ export default defineComponent({
       )
 
       const anchorNode = (
-        <div class="ix-anchor-wrapper" style={wrapperStyle.value}>
-          <div class="ix-anchor" ref={anchorRef}>
-            <div class="ix-anchor-ink">{linkBall}</div>
+        <div class={`${prefixCls}-anchor-wrapper`} style={wrapperStyle.value}>
+          <div class={`${prefixCls}-anchor`} ref={anchorRef}>
+            <div class={`${prefixCls}-anchor-ink`}>{linkBall}</div>
             {slots.default?.()}
           </div>
         </div>
@@ -88,11 +89,12 @@ const useLinks = (props: AnchorProps, config: AnchorConfig) => {
 }
 
 const useInkBall = (activeLink: Ref<string | undefined>) => {
+  const { prefixCls } = useGlobalConfig('common')
   const anchorRef = ref<HTMLDivElement>()
   const inkBallClasses = computed(() => {
     return {
-      'ix-anchor-ink-ball': true,
-      'ix-anchor-ink-ball-visible': !!activeLink.value,
+      [`${prefixCls}-anchor-ink-ball`]: true,
+      [`${prefixCls}-anchor-ink-ball-visible`]: !!activeLink.value,
     }
   })
 

--- a/packages/components/anchor/src/AnchorLink.tsx
+++ b/packages/components/anchor/src/AnchorLink.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted, watch } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { linkProps } from './types'
 import { anchorToken } from './token'
 
@@ -6,6 +7,7 @@ export default defineComponent({
   name: 'IxAnchorLink',
   props: linkProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { registerLink, unregisterLink, activeLink, handleLinkClick } = inject(anchorToken)!
     watch(
       () => props.href,
@@ -20,8 +22,8 @@ export default defineComponent({
     const isActive = computed(() => activeLink.value === props.href)
     const classes = computed(() => {
       return {
-        'ix-anchor-link-title': true,
-        'ix-anchor-link-title-active': isActive.value,
+        [`${prefixCls}-anchor-link-title`]: true,
+        [`${prefixCls}-anchor-link-title-active`]: isActive.value,
       }
     })
 
@@ -30,7 +32,7 @@ export default defineComponent({
     return () => {
       const { href, title } = props
       return (
-        <div class="ix-anchor-link">
+        <div class={`${prefixCls}-anchor-link`}>
           <a class={classes.value} href={href} data-href={href} title={title} onClick={onClick}>
             {slots.title?.() ?? title}
           </a>

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -15,6 +15,7 @@ export default defineComponent({
   name: 'IxAvatar',
   props: avatarProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('avatar')
 
     const showText = ref(false)
@@ -44,10 +45,11 @@ export default defineComponent({
       }
     }
 
-    return { avatarRef, textRef, showText, showIcon, icon$$, classes, avatarStyle, textStyle, handleError }
+    return { prefixCls, avatarRef, textRef, showText, showIcon, icon$$, classes, avatarStyle, textStyle, handleError }
   },
 
   render() {
+    const { prefixCls } = this
     let child: VNodeTypes
 
     if (this.showIcon) {
@@ -55,7 +57,7 @@ export default defineComponent({
     } else if (this.showText) {
       const textChild = this.$slots.default?.() ?? this.text
       child = (
-        <span ref="textRef" class="ix-avatar-text" style={this.textStyle}>
+        <span ref="textRef" class={`${prefixCls}-avatar-text`} style={this.textStyle}>
           {textChild}
         </span>
       )
@@ -78,14 +80,15 @@ const useClasses = (
   showText: Ref<boolean>,
   showIcon: Ref<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const shape = props.shape ?? config.shape
     const sizeValue = size.value
     return {
-      'ix-avatar': true,
-      'ix-avatar-image': !!props.src && !showText.value && !showIcon.value,
-      [`ix-avatar-${shape}`]: true,
-      [`ix-avatar-${sizeValue}`]: isString(sizeValue),
+      [`${prefixCls}-avatar`]: true,
+      [`${prefixCls}-avatar-image`]: !!props.src && !showText.value && !showIcon.value,
+      [`${prefixCls}-avatar-${shape}`]: true,
+      [`${prefixCls}-avatar-${sizeValue}`]: isString(sizeValue),
     }
   })
 }

--- a/packages/components/back-top/src/BackTop.vue
+++ b/packages/components/back-top/src/BackTop.vue
@@ -1,6 +1,6 @@
 <template>
-  <transition name="ix-fade">
-    <div v-show="visible" class="ix-back-top" @click.stop="handleClick">
+  <transition :name="`${prefixCls}-fade`">
+    <div v-show="visible" :class="`${prefixCls}-back-top`" @click.stop="handleClick">
       <slot>
         <IxIcon name="vertical-align-top" />
       </slot>
@@ -24,6 +24,7 @@ export default defineComponent({
   props: backTopProps,
   emits: ['click'],
   setup(props, { emit }) {
+    const { prefixCls } = useGlobalConfig('common')
     const backTopConfig = useGlobalConfig('backTop')
     const eventType = 'scroll'
     const visible = ref(false)
@@ -54,6 +55,7 @@ export default defineComponent({
     })
 
     return {
+      prefixCls,
       visible,
       handleClick,
     }

--- a/packages/components/badge/src/Badge.vue
+++ b/packages/components/badge/src/Badge.vue
@@ -1,7 +1,7 @@
 <template>
-  <span class="ix-badge-wrapper">
+  <span :class="`${prefixCls}-badge-wrapper`">
     <slot />
-    <sup class="ix-badge" :class="classes" :style="styles">
+    <sup :class="classes" :style="styles">
       <slot v-if="hasCountSlot" name="count" />
       <template v-else-if="countValue">{{ countValue }}</template>
     </sup>
@@ -20,6 +20,7 @@ export default defineComponent({
   name: 'IxBadge',
   props: backTopProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const badgeConfig = useGlobalConfig('badge')
 
     const showZero = computed(() => props.showZero ?? badgeConfig.showZero)
@@ -34,6 +35,7 @@ export default defineComponent({
     const countValue = useCountValue(props, hasCountSlot, showZero, dot, overflowCount)
 
     return {
+      prefixCls,
       classes,
       styles,
       countValue,
@@ -85,13 +87,15 @@ const useClasses = (
   showZero: ComputedRef<boolean>,
   dot: ComputedRef<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-badge-empty': !hasDefaultSlot.value,
-      'ix-badge-slot-count': hasCountSlot.value,
-      'ix-badge-dot': !hasCountSlot.value && dot.value,
-      'ix-badge-count': !hasCountSlot.value && !dot.value,
-      'ix-badge-hide-zero': !hasCountSlot.value && !dot.value && !showZero.value && +props.count === 0,
+      [`${prefixCls}-badge`]: true,
+      [`${prefixCls}-badge-empty`]: !hasDefaultSlot.value,
+      [`${prefixCls}-badge-slot-count`]: hasCountSlot.value,
+      [`${prefixCls}-badge-dot`]: !hasCountSlot.value && dot.value,
+      [`${prefixCls}-badge-count`]: !hasCountSlot.value && !dot.value,
+      [`${prefixCls}-badge-hide-zero`]: !hasCountSlot.value && !dot.value && !showZero.value && +props.count === 0,
     }
   })
 }

--- a/packages/components/button/src/Button.tsx
+++ b/packages/components/button/src/Button.tsx
@@ -46,20 +46,21 @@ const useClasses = (
   mode: ComputedRef<ButtonMode>,
   hasDefaultSlot: Ref<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const size = props.size ?? (groupProps.size || config.size)
     const shape = props.shape ?? groupProps.shape
     return {
-      'ix-button': true,
-      'ix-button-danger': props.danger,
-      'ix-button-ghost': props.ghost,
-      'ix-button-disabled': props.disabled || props.loading,
-      'ix-button-loading': props.loading,
-      'ix-button-block': props.block,
-      'ix-button-icon-only': !hasDefaultSlot.value && (!!props.icon || props.loading),
-      [`ix-button-${mode.value}`]: mode.value !== 'default',
-      [`ix-button-${size}`]: size !== 'medium',
-      [`ix-button-${shape}`]: !!shape,
+      [`${prefixCls}-button`]: true,
+      [`${prefixCls}-button-danger`]: props.danger,
+      [`${prefixCls}-button-ghost`]: props.ghost,
+      [`${prefixCls}-button-disabled`]: props.disabled || props.loading,
+      [`${prefixCls}-button-loading`]: props.loading,
+      [`${prefixCls}-button-block`]: props.block,
+      [`${prefixCls}-button-icon-only`]: !hasDefaultSlot.value && (!!props.icon || props.loading),
+      [`${prefixCls}-button-${mode.value}`]: mode.value !== 'default',
+      [`${prefixCls}-button-${size}`]: size !== 'medium',
+      [`${prefixCls}-button-${shape}`]: !!shape,
     }
   })
 }

--- a/packages/components/button/src/ButtonGroup.tsx
+++ b/packages/components/button/src/ButtonGroup.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, provide } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { buttonGroupProps } from './types'
 import { buttonToken } from './token'
 
@@ -6,8 +7,9 @@ export default defineComponent({
   name: 'IxButtonGroup',
   props: buttonGroupProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     provide(buttonToken, props)
 
-    return () => <div class="ix-button-group">{slots.default?.()}</div>
+    return () => <div class={`${prefixCls}-button-group`}>{slots.default?.()}</div>
   },
 })

--- a/packages/components/card/src/Card.tsx
+++ b/packages/components/card/src/Card.tsx
@@ -48,16 +48,17 @@ const useClasses = (
   size: ComputedRef<CardSize>,
   hasGrid: ComputedRef<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const borderless = props.borderless ?? cardConfig.borderless
     const hasGridValue = hasGrid.value
     return {
-      'ix-card': true,
-      'ix-card-borderless': borderless,
-      'ix-card-hoverable': !hasGridValue && hoverable.value,
-      'ix-card-loading': props.loading,
-      'ix-card-has-grid': hasGridValue,
-      [`ix-card-${size.value}`]: true,
+      [`${prefixCls}-card`]: true,
+      [`${prefixCls}-card-borderless`]: borderless,
+      [`${prefixCls}-card-hoverable`]: !hasGridValue && hoverable.value,
+      [`${prefixCls}-card-loading`]: props.loading,
+      [`${prefixCls}-card-has-grid`]: hasGridValue,
+      [`${prefixCls}-card-${size.value}`]: true,
     }
   })
 }
@@ -75,14 +76,16 @@ const useChildren = (slots: Slots, hoverable: ComputedRef<boolean>) => {
 }
 
 const renderCover = (coverSlot: Slot | undefined, cover: string | CardCover | undefined) => {
+  const { prefixCls } = useGlobalConfig('common')
   let child: VNodeTypes | undefined
+
   if (coverSlot) {
     child = coverSlot()
   } else if (cover) {
     const imgProps = isString(cover) ? { src: cover } : cover
     child = <img {...imgProps} />
   }
-  return child ? <div class="ix-card-cover">{child}</div> : null
+  return child ? <div class={`${prefixCls}-card-cover`}>{child}</div> : null
 }
 
 const renderHeader = (headerSlot: Slot | undefined, header: string | HeaderProps | undefined, size: CardSize) => {
@@ -99,41 +102,44 @@ const renderHeader = (headerSlot: Slot | undefined, header: string | HeaderProps
 }
 
 const listOfLoading = [
-  ['ix-col-span-22'],
-  ['ix-col-span-8', 'ix-col-span-15'],
-  ['ix-col-span-6', 'ix-col-span-18'],
-  ['ix-col-span-13', 'ix-col-span-9'],
-  ['ix-col-span-4', 'ix-col-span-3', 'ix-col-span-16'],
-  ['ix-col-span-8', 'ix-col-span-6', 'ix-col-span-8'],
+  ['col-span-22'],
+  ['col-span-8', 'col-span-15'],
+  ['col-span-6', 'col-span-18'],
+  ['col-span-13', 'col-span-9'],
+  ['col-span-4', 'col-span-3', 'col-span-16'],
+  ['col-span-8', 'col-span-6', 'col-span-8'],
 ]
 
 const renderLoading = () => {
+  const { prefixCls } = useGlobalConfig('common')
   const loadingChild = listOfLoading.map(items => {
     const cols = items.map(col => (
-      <div class={`ix-col ${col} ix-card-loading-col`}>
-        <div class="ix-card-loading-block"></div>
+      <div class={`${prefixCls}-col ${prefixCls}-${col} ${prefixCls}-card-loading-col`}>
+        <div class={`${prefixCls}-card-loading-block`}></div>
       </div>
     ))
-    return <div class="ix-row">{cols}</div>
+    return <div class={`${prefixCls}-row`}>{cols}</div>
   })
-  return <div class="ix-card-loading">{loadingChild}</div>
+  return <div class={`${prefixCls}-card-loading`}>{loadingChild}</div>
 }
 
 const renderBody = (defaultSlot: Slot | undefined, loading: boolean, hasGrid: boolean) => {
+  const { prefixCls } = useGlobalConfig('common')
   let child: VNodeTypes | undefined
+
   if (loading) {
     child = renderLoading()
   } else if (defaultSlot) {
     child = hasGrid ? <IxRow>{defaultSlot()}</IxRow> : defaultSlot()
   }
-  return child ? <div class="ix-card-body">{child}</div> : null
+  return child ? <div class={`${prefixCls}-card-body`}>{child}</div> : null
 }
 
 const renderFooter = (footerSlot: Slot | undefined, footer: Array<CardButtonProps | VNode> | undefined) => {
   if (!footerSlot && !footer) {
     return null
   }
-
+  const { prefixCls } = useGlobalConfig('common')
   let child: VNodeTypes
   if (footerSlot) {
     child = footerSlot()
@@ -151,5 +157,5 @@ const renderFooter = (footerSlot: Slot | undefined, footer: Array<CardButtonProp
     })
   }
 
-  return <ul class="ix-card-footer">{child}</ul>
+  return <ul class={`${prefixCls}-card-footer`}>{child}</ul>
 }

--- a/packages/components/card/src/CardGrid.tsx
+++ b/packages/components/card/src/CardGrid.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCol } from '@idux/components/grid'
 import { cardToken } from './token'
 
@@ -9,11 +10,11 @@ export default defineComponent({
   props: cardGridProps,
   setup(props) {
     const { hoverable } = inject(cardToken)!
-
+    const { prefixCls } = useGlobalConfig('common')
     const classes = computed(() => {
       return {
-        'ix-card-grid': true,
-        'ix-card-grid-hoverable': props.hoverable ?? hoverable.value,
+        [`${prefixCls}-card-grid`]: true,
+        [`${prefixCls}-card-grid-hoverable`]: props.hoverable ?? hoverable.value,
       }
     })
 

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -15,6 +15,7 @@ export default defineComponent({
   inheritAttrs: false,
   props: checkboxProps,
   setup(props, { attrs, expose, slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('checkbox')
 
     const checkboxGroup = inject(checkboxGroupToken, null)
@@ -32,7 +33,7 @@ export default defineComponent({
 
     return () => {
       const child = slots.default ? slots.default() : props.label
-      const labelNode = child ? <span class="ix-checkbox-label">{child}</span> : undefined
+      const labelNode = child ? <span class={`${prefixCls}-checkbox-label`}>{child}</span> : undefined
       const { class: className, type, tabindex, ...restAttrs } = attrs
 
       return (
@@ -43,11 +44,11 @@ export default defineComponent({
           aria-checked={isChecked.value}
           aria-disabled={isDisabled.value}
         >
-          <span class="ix-checkbox-input-wrapper">
+          <span class={`${prefixCls}-checkbox-input-wrapper`}>
             <input
               ref={inputRef}
               type="checkbox"
-              class="ix-checkbox-input"
+              class={`${prefixCls}-checkbox-input`}
               aria-hidden
               {...restAttrs}
               autofocus={props.autofocus}
@@ -59,10 +60,12 @@ export default defineComponent({
               onBlur={handleBlur}
               onFocus={handleFocus}
             />
-            {isButtoned.value ? null : <span class="ix-checkbox-inner" tabindex={tabindex as number} />}
+            {isButtoned.value ? null : <span class={`${prefixCls}-checkbox-inner`} tabindex={tabindex as number} />}
           </span>
           {labelNode}
-          {isButtoned.value ? <span class="ix-checkbox-button-inner" tabindex={tabindex as number} /> : null}
+          {isButtoned.value ? (
+            <span class={`${prefixCls}-checkbox-button-inner`} tabindex={tabindex as number} />
+          ) : null}
         </label>
       )
     }
@@ -137,6 +140,7 @@ const useClasses = (
   isButtoned: ComputedRef<boolean>,
   size: ComputedRef<CheckboxSize>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const disabled = isDisabled.value
     const checked = isChecked.value
@@ -146,13 +150,13 @@ const useClasses = (
     const buttonSize = size.value
 
     return {
-      'ix-checkbox': true,
-      'ix-checkbox-button': !!buttoned,
-      'ix-checkbox-disabled': !!disabled,
-      'ix-checkbox-focused': !!focused,
-      'ix-checkbox-indeterminate': !!indeterminate,
-      'ix-checkbox-checked': !indeterminate && checked,
-      [`ix-checkbox-button-${buttonSize}`]: !!buttoned,
+      [`${prefixCls}-checkbox`]: true,
+      [`${prefixCls}-checkbox-button`]: !!buttoned,
+      [`${prefixCls}-checkbox-disabled`]: !!disabled,
+      [`${prefixCls}-checkbox-focused`]: !!focused,
+      [`${prefixCls}-checkbox-indeterminate`]: !!indeterminate,
+      [`${prefixCls}-checkbox-checked`]: !indeterminate && checked,
+      [`${prefixCls}-checkbox-button-${buttonSize}`]: !!buttoned,
     }
   })
 }

--- a/packages/components/checkbox/src/CheckboxGroup.tsx
+++ b/packages/components/checkbox/src/CheckboxGroup.tsx
@@ -1,5 +1,6 @@
 import { defineComponent, computed, provide } from 'vue'
 import { useValueAccessor } from '@idux/cdk/forms'
+import { useGlobalConfig } from '@idux/components/config'
 import { useFormItemRegister } from '@idux/components/form'
 import Checkbox from './Checkbox'
 import { checkboxGroupProps } from './types'
@@ -9,13 +10,14 @@ export default defineComponent({
   name: 'IxCheckboxGroup',
   props: checkboxGroupProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { accessor } = useValueAccessor()
     useFormItemRegister()
     provide(checkboxGroupToken, { props, accessor })
     const classes = computed(() => {
       return {
-        'ix-checkbox-group': true,
-        'ix-checkbox-group-no-gap': props.gap === 0,
+        [`${prefixCls}-checkbox-group`]: true,
+        [`${prefixCls}-checkbox-group-no-gap`]: props.gap === 0,
       }
     })
     return () => {

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -8,6 +8,7 @@ export default defineComponent({
   name: 'IxCollapse',
   props: collapseProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('collapse')
     const accordion = computed(() => props.accordion ?? config.accordion)
     const borderless = computed(() => props.borderless ?? config.borderless)
@@ -32,9 +33,9 @@ export default defineComponent({
 
     const classes = computed(() => {
       return {
-        'ix-collapse': true,
-        'ix-collapse-borderless': borderless.value,
-        'ix-collapse-ghost': ghost.value,
+        [`${prefixCls}-collapse`]: true,
+        [`${prefixCls}-collapse-borderless`]: borderless.value,
+        [`${prefixCls}-collapse-ghost`]: ghost.value,
       }
     })
 

--- a/packages/components/collapse/src/CollapsePanel.tsx
+++ b/packages/components/collapse/src/CollapsePanel.tsx
@@ -3,6 +3,7 @@ import type { CollapsePanelProps } from './types'
 
 import { computed, defineComponent, inject } from 'vue'
 import { isString } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { useKey } from '@idux/components/utils'
 import { IxCollapseTransition } from '@idux/components/_private'
 import { IxHeader } from '@idux/components/header'
@@ -15,15 +16,16 @@ export default defineComponent({
   name: 'IxCollapsePanel',
   props: collapsePanelProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { slots: collapseSlots, expandedKeys, expandIcon, handleExpand } = inject(collapseToken)!
 
     const key = useKey()
     const isExpanded = computed(() => expandedKeys.value.includes(key))
     const classes = computed(() => {
       return {
-        'ix-collapse-panel': true,
-        'ix-collapse-panel-disabled': props.disabled,
-        'ix-collapse-panel-expanded': isExpanded.value,
+        [`${prefixCls}-collapse-panel`]: true,
+        [`${prefixCls}-collapse-panel-disabled`]: props.disabled,
+        [`${prefixCls}-collapse-panel-expanded`]: isExpanded.value,
       }
     })
 
@@ -41,8 +43,8 @@ export default defineComponent({
         <div class={classes.value}>
           {headerNode}
           <IxCollapseTransition>
-            <div v-show={expanded} class="ix-collapse-panel-content">
-              <div class="ix-collapse-panel-content-box">{slots.default?.()}</div>
+            <div v-show={expanded} class={`${prefixCls}-collapse-panel-content`}>
+              <div class={`${prefixCls}-collapse-panel-content-box`}>{slots.default?.()}</div>
             </div>
           </IxCollapseTransition>
         </div>

--- a/packages/components/config/src/defaultConfig.ts
+++ b/packages/components/config/src/defaultConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  CommonConfig,
   ButtonConfig,
   CheckboxConfig,
   IconConfig,
@@ -41,10 +42,15 @@ import type {
 import { shallowReactive } from 'vue'
 import { numFormatter } from './numFormatter'
 
+// --------------------- Common ---------------------
+const common = shallowReactive<CommonConfig>({
+  prefixCls: 'ix',
+})
+
 // --------------------- General ---------------------
 const button = shallowReactive<ButtonConfig>({ size: 'medium' })
 
-const checkbox: CheckboxConfig = { size: 'medium' }
+const checkbox = shallowReactive<CheckboxConfig>({ size: 'medium' })
 
 const icon = shallowReactive<IconConfig>({})
 
@@ -272,6 +278,7 @@ const anchor = shallowReactive<AnchorConfig>({
 // --------------------- end ---------------------
 
 export const defaultConfig: GlobalConfig = {
+  common,
   // General
   button,
   icon,

--- a/packages/components/config/src/types.ts
+++ b/packages/components/config/src/types.ts
@@ -25,6 +25,12 @@ import type {
   TableSize,
 } from '@idux/components/table/src/types'
 
+// Common
+
+export interface CommonConfig {
+  prefixCls: string
+}
+
 // General
 
 export interface ButtonConfig {
@@ -304,6 +310,7 @@ export interface AnchorConfig {
 // --- end ---
 
 export interface GlobalConfig {
+  common: CommonConfig
   // General
   button: ButtonConfig
   icon: IconConfig

--- a/packages/components/divider/src/Divider.vue
+++ b/packages/components/divider/src/Divider.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="ix-divider" :class="className">
-    <span v-if="withText" class="ix-divider-inner-text">
+  <div :class="className">
+    <span v-if="withText" :class="`${prefixCls}-divider-inner-text`">
       <slot />
     </span>
   </div>
@@ -19,15 +19,17 @@ export default defineComponent({
   name: 'IxDivider',
   props: dividerProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const dividerConfig = useGlobalConfig('divider')
     const withText = computed(() => hasSlot(slots))
     const className = useClassName(props, dividerConfig, withText)
 
-    return { className, withText }
+    return { prefixCls, className, withText }
   },
 })
 
 function useClassName(props: DividerProps, config: DividerConfig, withText: ComputedRef<boolean>) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const position = props.position || config.position
     const type = props.type || config.type
@@ -35,12 +37,13 @@ function useClassName(props: DividerProps, config: DividerConfig, withText: Comp
     const plain = props.plain || config.plain
 
     return [
-      `ix-divider-${type}`,
+      `${prefixCls}-divider`,
+      `${prefixCls}-divider-${type}`,
       {
-        'ix-divider-with-text': withText.value,
-        'ix-divider-dashed': dashed,
-        'ix-divider-plain': plain && withText.value,
-        [`ix-divider-with-text-${position}`]: type === 'horizontal' && withText.value,
+        [`${prefixCls}-divider-with-text`]: withText.value,
+        [`${prefixCls}-divider-dashed`]: dashed,
+        [`${prefixCls}-divider-plain`]: plain && withText.value,
+        [`${prefixCls}-divider-with-text-${position}`]: type === 'horizontal' && withText.value,
       },
     ]
   })

--- a/packages/components/drawer/src/Drawer.tsx
+++ b/packages/components/drawer/src/Drawer.tsx
@@ -13,6 +13,7 @@ export default defineComponent({
   inheritAttrs: false,
   props: drawerProps,
   setup(props, { slots, expose, attrs }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('drawer')
     const mask = computed(() => props.mask ?? config.mask)
     const zIndex = computed(() => props.zIndex ?? config.zIndex)
@@ -30,7 +31,7 @@ export default defineComponent({
       }
 
       return (
-        <IxPortal target="ix-modal-container" load={visible.value}>
+        <IxPortal target={`${prefixCls}-modal-container`} load={visible.value}>
           <IxMask mask={mask.value} visible={visible.value} zIndex={zIndex.value}></IxMask>
           <DrawerWrapper {...attrs}></DrawerWrapper>
         </IxPortal>

--- a/packages/components/drawer/src/DrawerBody.tsx
+++ b/packages/components/drawer/src/DrawerBody.tsx
@@ -2,16 +2,18 @@ import type { Slot } from 'vue'
 
 import { computed, defineComponent, inject } from 'vue'
 import { convertCssPixel } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { drawerToken, DRAWER_TOKEN } from './token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, slots } = inject(drawerToken)!
     const { close } = inject(DRAWER_TOKEN)!
 
     const placement = computed(() => props.placement ?? 'right')
-    const classes = computed(() => `ix-drawer ix-drawer-${placement.value}`)
+    const classes = computed(() => `${prefixCls}-drawer ${prefixCls}-drawer-${placement.value}`)
     const isHorizontal = computed(() => placement.value === 'right' || placement.value === 'left')
     const drawerStyle = computed(() => {
       const width = props.width || (isHorizontal.value ? '30%' : '100%') // 不传值时水平方向宽度默认30%
@@ -30,7 +32,7 @@ export default defineComponent({
       return (
         <div class={classes.value} style={drawerStyle.value}>
           {titleElement}
-          <section class="ix-drawer-body">{slots.default?.()}</section>
+          <section class={`${prefixCls}-drawer-body`}>{slots.default?.()}</section>
           {footerElement}
         </div>
       )
@@ -47,9 +49,10 @@ const renderTitle = (
   if (!titleSlot && !title) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const child = titleSlot ? titleSlot() : <span title={title}>{title}</span>
   return (
-    <header class="ix-drawer-header">
+    <header class={`${prefixCls}-drawer-header`}>
       {child}
       {renderIcon(closable, close)}
     </header>
@@ -60,9 +63,10 @@ const renderIcon = (closable: boolean | undefined, close: (evt: Event) => void) 
   if (!closable) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   return (
-    <button class="ix-drawer-close-btn" type="button" onClick={close}>
-      <IxIcon class="ix-icon-close" name="close"></IxIcon>
+    <button class={`${prefixCls}-drawer-close-btn" type="button`} onClick={close}>
+      <IxIcon class={`${prefixCls}-icon-close" name="close`}></IxIcon>
     </button>
   )
 }
@@ -71,6 +75,7 @@ const renderFooter = (footerSlot: Slot | undefined, footer: string | undefined) 
   if (!footerSlot && !footer) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const child = footerSlot ? footerSlot() : <span title={footer}>{footer}</span>
-  return <footer class="ix-drawer-footer">{child}</footer>
+  return <footer class={`${prefixCls}-drawer-footer`}>{child}</footer>
 }

--- a/packages/components/drawer/src/DrawerWrapper.tsx
+++ b/packages/components/drawer/src/DrawerWrapper.tsx
@@ -19,10 +19,10 @@ export default defineComponent({
 
     const drawerTransition = computed(() => {
       const drawerTransitionMap = {
-        left: 'ix-move-left',
-        right: 'ix-move-right',
-        top: 'ix-move-up',
-        bottom: 'ix-move-down',
+        left: [`${prefixCls}-move-left`],
+        right: [`${prefixCls}-move-right`],
+        top: [`${prefixCls}-move-up`],
+        bottom: [`${prefixCls}-move-down`],
       }
       return drawerTransitionMap[placement.value]
     })
@@ -65,7 +65,7 @@ const useConfig = (props: DrawerProps, config: DrawerConfig) => {
 
 const useClasses = (props: DrawerProps) => {
   return computed(() => {
-    return ['ix-drawer-wrapper', props.containerClassName]
+    return [[`${prefixCls}-drawer-wrapper`], props.containerClassName]
   })
 }
 

--- a/packages/components/dropdown/src/Dropdown.tsx
+++ b/packages/components/dropdown/src/Dropdown.tsx
@@ -13,6 +13,7 @@ export default defineComponent({
   name: 'IxDropdown',
   props: dropdownProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('dropdown')
     const configProps = useConfigProps(props, config)
     const visibility = ɵUseVisibility(props)
@@ -28,10 +29,10 @@ export default defineComponent({
         <IxOverlay
           v-model={[visibility.value, 'visible']}
           v-slots={{ default: slots.default, content: slots.overlay }}
-          class="ix-dropdown"
+          class={`${prefixCls}-dropdown`}
           delay={defaultDelay}
           disabled={props.disabled}
-          transitionName="ix-fade"
+          transitionName={`${prefixCls}-fade`}
           {...configProps.value}
         />
       )

--- a/packages/components/empty/src/Empty.vue
+++ b/packages/components/empty/src/Empty.vue
@@ -1,19 +1,20 @@
 <template>
-  <div class="ix-empty">
-    <div class="ix-empty-image">
+  <div :class="`${prefixCls}-empty`">
+    <div :class="`${prefixCls}-empty-image`">
       <img v-if="image" :src="image" alt="empty image" />
       <IxIcon v-else name="empty" />
     </div>
-    <div v-if="description$$ || $slots.description" class="ix-empty-description">
+    <div v-if="description$$ || $slots.description" :class="`${prefixCls}-empty-description`">
       <slot name="description">{{ description$$ }}</slot>
     </div>
-    <div v-if="$slots.default" class="ix-empty-footer">
+    <div v-if="$slots.default" :class="`${prefixCls}-empty-footer`">
       <slot />
     </div>
   </div>
 </template>
 <script lang="ts">
 import { defineComponent, computed } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { getLocale } from '@idux/components/i18n'
 import { emptyProps } from './types'
@@ -23,9 +24,10 @@ export default defineComponent({
   components: { IxIcon },
   props: emptyProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const emptyLocale = getLocale('empty')
     const description$$ = computed(() => props.description ?? emptyLocale.value.description)
-    return { description$$ }
+    return { prefixCls, description$$ }
   },
 })
 </script>

--- a/packages/components/form/src/Form.tsx
+++ b/packages/components/form/src/Form.tsx
@@ -8,6 +8,7 @@ export default defineComponent({
   name: 'IxForm',
   props: formProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const control = useValueControl()
     watchEffect(() => provideControl(control.value!))
 
@@ -27,9 +28,9 @@ export default defineComponent({
 
     const classes = computed(() => {
       return {
-        'ix-form': true,
-        [`ix-form-${layout.value}`]: true,
-        [`ix-form-${size.value}`]: true,
+        [`${prefixCls}-form`]: true,
+        [`${prefixCls}-form-${layout.value}`]: true,
+        [`${prefixCls}-form-${size.value}`]: true,
       }
     })
 

--- a/packages/components/form/src/FormItem.tsx
+++ b/packages/components/form/src/FormItem.tsx
@@ -13,6 +13,7 @@ import type { FormItemProps, FormLabelAlign } from './types'
 
 import { computed, defineComponent, inject, provide, ref, watchEffect } from 'vue'
 import { isFunction, isNil, isNumber, isString } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCol, IxRow } from '@idux/components/grid'
 import { IxIcon } from '@idux/components/icon'
 import { getLocale } from '@idux/components/i18n'
@@ -54,6 +55,7 @@ function renderLabel(
   classes: ComputedRef<Record<string, any>>,
   labelColConfig: ComputedRef<ColProps | undefined>,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   const { label, labelFor, labelTooltip } = props
   const { label: labelSlot, labelTooltip: labelTooltipSlot } = slots
   if (!(label || labelSlot || labelTooltip || labelTooltipSlot)) {
@@ -66,7 +68,9 @@ function renderLabel(
       <IxIcon name="question-circle" />
     </IxTooltip>
   ) : undefined
-  const tooltipWrapper = tooltipNode ? <span class="ix-form-item-label-tooltip">{tooltipNode}</span> : undefined
+  const tooltipWrapper = tooltipNode ? (
+    <span class={`${prefixCls}-form-item-label-tooltip`}>{tooltipNode}</span>
+  ) : undefined
   return (
     <IxCol class={classes.value} {...labelColConfig.value}>
       <label for={labelFor}>
@@ -85,21 +89,22 @@ function renderControl(
   statusIcon: ComputedRef<string | undefined>,
   message: ComputedRef<string | undefined>,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   const { extra } = props
   const { extra: extraSlot } = slots
   const statusNode =
     hasFeedback.value && statusIcon.value ? (
-      <span class="ix-form-item-status-icon">
+      <span class={`${prefixCls}-form-item-status-icon`}>
         <IxIcon name={statusIcon.value} />
       </span>
     ) : undefined
-  const messageNode = message.value ? <div class="ix-form-item-message">{message.value}</div> : undefined
+  const messageNode = message.value ? <div class={`${prefixCls}-form-item-message`}>{message.value}</div> : undefined
   const extraNode = extraSlot?.() ?? extra
-  const extraWrapper = extraNode ? <div class="ix-form-item-extra">{extraNode}</div> : undefined
+  const extraWrapper = extraNode ? <div class={`${prefixCls}-form-item-extra`}>{extraNode}</div> : undefined
   return (
-    <IxCol class="ix-form-item-control" {...controlColConfig.value}>
-      <div class="ix-form-item-control-input">
-        <div class="ix-form-item-control-input-content">{slots.default?.()}</div>
+    <IxCol class={`${prefixCls}-form-item-control`} {...controlColConfig.value}>
+      <div class={`${prefixCls}-form-item-control-input`}>
+        <div class={`${prefixCls}-form-item-control-input-content`}>{slots.default?.()}</div>
         {statusNode}
       </div>
       {messageNode}
@@ -113,13 +118,14 @@ function useClasses(
   status: ComputedRef<ValidateStatus | undefined>,
   message: ComputedRef<string | undefined>,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const currStatus = status.value
     return {
-      'ix-form-item': true,
-      'ix-form-item-has-feedback': hasFeedback.value && currStatus,
-      'ix-form-item-has-message': message.value,
-      [`ix-form-item-${currStatus}`]: currStatus,
+      [`${prefixCls}-form-item`]: true,
+      [`${prefixCls}-form-item-has-feedback`]: hasFeedback.value && currStatus,
+      [`${prefixCls}-form-item-has-message`]: message.value,
+      [`${prefixCls}-form-item-${currStatus}`]: currStatus,
     }
   })
 }
@@ -129,13 +135,14 @@ function useLabelClasses(
   colonlessRef: ComputedRef<boolean> | undefined,
   labelAlignRef: ComputedRef<FormLabelAlign> | undefined,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const { colonless = colonlessRef?.value, labelAlign = labelAlignRef?.value, required } = props
     return {
-      'ix-form-item-label': true,
-      'ix-form-item-label-colonless': colonless,
-      'ix-form-item-label-required': required,
-      'ix-form-item-label-start': labelAlign === 'start',
+      [`${prefixCls}-form-item-label`]: true,
+      [`${prefixCls}-form-item-label-colonless`]: colonless,
+      [`${prefixCls}-form-item-label-required`]: required,
+      [`${prefixCls}-form-item-label-start`]: labelAlign === 'start',
     }
   })
 }

--- a/packages/components/grid/src/Col.tsx
+++ b/packages/components/grid/src/Col.tsx
@@ -5,6 +5,7 @@ import { inject, defineComponent, computed } from 'vue'
 import { isNumber, isString, isUndefined } from 'lodash-es'
 import { isNumeric } from '@idux/cdk/utils'
 import { BREAKPOINTS_KEYS } from '@idux/cdk/breakpoint'
+import { useGlobalConfig } from '@idux/components/config'
 import { rowToken } from './token'
 import { colProps } from './types'
 
@@ -12,9 +13,11 @@ export default defineComponent({
   name: 'IxCol',
   props: colProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { gutter } = inject(rowToken)!
 
-    const classes = useClasses(props)
+    const classes = useClasses(prefixCls, props)
     const style = useStyle(props, gutter)
 
     return () => (
@@ -25,7 +28,7 @@ export default defineComponent({
   },
 })
 
-function useClasses(props: ColProps) {
+function useClasses(prefixCls: string, props: ColProps) {
   return computed(() => generateAllCls(props))
 }
 
@@ -54,7 +57,8 @@ function useStyle(props: ColProps, gutter: ComputedRef<[number, number]>) {
 const attrKeys = ['span', 'order', 'offset', 'push', 'pull'] as const
 
 function generateAllCls(props: ColProps) {
-  const clsPrefix = 'ix-col'
+  const { prefixCls } = useGlobalConfig('common')
+  const clsPrefix = `${prefixCls}-col`
   const clsMap = new Map<string, boolean>([[clsPrefix, true]])
 
   const generateSizeCls = (sizeConfig: ColBreakpointConfig, size?: string) => {

--- a/packages/components/grid/src/Row.tsx
+++ b/packages/components/grid/src/Row.tsx
@@ -32,8 +32,9 @@ export default defineComponent({
 })
 
 function useClasses(props: RowProps, config: RowConfig) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
-    const row = 'ix-row'
+    const row = `${prefixCls}-row`
     return {
       [row]: true,
       [`${row}-no-wrap`]: !(props.wrap ?? config.wrap),

--- a/packages/components/header/src/Header.tsx
+++ b/packages/components/header/src/Header.tsx
@@ -5,6 +5,7 @@ import type { HeaderProps } from './types'
 import { computed, defineComponent, h, isVNode } from 'vue'
 import { isString } from 'lodash-es'
 import { callEmit } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxAvatar } from '@idux/components/avatar'
 import { IxIcon } from '@idux/components/icon'
 import { headerProps } from './types'
@@ -20,6 +21,7 @@ export default defineComponent({
   name: 'IxHeader',
   props: headerProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const classes = useClasses(props)
 
     const avatarSize = computed(() => avatarSizeTransformMap[props.size])
@@ -31,14 +33,14 @@ export default defineComponent({
       const { prefix, suffix, avatar, title, subTitle } = props
       return (
         <div class={classes.value}>
-          <div class="ix-header-content">
-            {renderIcon(slots.prefix, prefix, onPrefixClick, 'ix-header-prefix')}
+          <div class={`${prefixCls}-header-content`}>
+            {renderIcon(slots.prefix, prefix, onPrefixClick, `${prefixCls}-header-prefix`)}
             {renderAvatar(slots.avatar, avatar, avatarSize)}
-            {renderTitle(slots.default, title, 'ix-header-title')}
-            {renderTitle(slots.subTitle, subTitle, 'ix-header-sub-title')}
-            {renderIcon(slots.suffix, suffix, onSuffixClick, 'ix-header-suffix')}
+            {renderTitle(slots.default, title, `${prefixCls}-header-title`)}
+            {renderTitle(slots.subTitle, subTitle, `${prefixCls}-header-sub-title`)}
+            {renderIcon(slots.suffix, suffix, onSuffixClick, `${prefixCls}-header-suffix`)}
           </div>
-          {slots.description ? <div class="ix-header-description">{slots.description()}</div> : null}
+          {slots.description ? <div class={`${prefixCls}-header-description`}>{slots.description()}</div> : null}
         </div>
       )
     }
@@ -46,12 +48,13 @@ export default defineComponent({
 })
 
 const useClasses = (props: HeaderProps) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-header': true,
-      'ix-header-bar': props.showBar,
-      'ix-header-disabled': props.disabled,
-      [`ix-header-${props.size}`]: true,
+      [`${prefixCls}-header`]: true,
+      [`${prefixCls}-header-bar`]: props.showBar,
+      [`${prefixCls}-header-disabled`]: props.disabled,
+      [`${prefixCls}-header-${props.size}`]: true,
     }
   })
 }

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -76,13 +76,14 @@ function handleRotate(svg: SVGElement, rotate?: number | string | boolean): void
 }
 
 const useClasses = (props: IconProps) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const { name, rotate } = props
     const isSpin = name === 'loading' || (typeof rotate === 'boolean' && rotate)
     return {
-      'ix-icon': true,
-      [`ix-icon-${name}`]: !!name,
-      'ix-icon-spin': isSpin,
+      [`${prefixCls}-icon`]: true,
+      [`${prefixCls}-icon-${name}`]: !!name,
+      [`${prefixCls}-icon-spin`]: isSpin,
     }
   })
 }

--- a/packages/components/image/src/Image.vue
+++ b/packages/components/image/src/Image.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="ix-image">
+  <div :class="`${prefixCls}-image`">
     <img
       v-if="imageStatus !== 'failed'"
-      :class="['ix-image-img', preview ? 'ix-image-preview-is' : '']"
+      :class="[`${prefixCls}-image-img`, preview ? `${prefixCls}-image-preview-is` : '']"
       :src="src"
       :style="{ width: imageWidth, height: imageHeight, objectFit: objectFit }"
       :alt="alt"
@@ -12,7 +12,7 @@
     />
     <div
       v-else-if="imageStatus === 'failed'"
-      class="ix-image-error"
+      :class="`${prefixCls}-image-error`"
       :style="{
         width: imageWidth,
         height: imageHeight,
@@ -42,6 +42,7 @@ export default defineComponent({
   emits: ['statusChange'],
   setup(props, { emit }) {
     const isShowPreview = ref(false)
+    const { prefixCls } = useGlobalConfig('common')
     const imageConfig = useGlobalConfig('image')
     const imageWidth = computedSize(props, imageConfig, 'width')
     const imageHeight = computedSize(props, imageConfig, 'height')
@@ -69,6 +70,7 @@ export default defineComponent({
       },
     )
     return {
+      prefixCls,
       imageWidth,
       imageHeight,
       onLoaded,

--- a/packages/components/image/src/ImgPreview.vue
+++ b/packages/components/image/src/ImgPreview.vue
@@ -1,30 +1,33 @@
 <template>
-  <div class="ix-image-preview">
-    <div class="ix-image-preview-mask"></div>
-    <div class="ix-image-preview-tools">
-      <ul class="ix-preview-tools">
-        <li class="ix-tools-item ix-rotate-left" @click="rotateEvent(-1)">
+  <div :class="`${prefixCls}-image-preview`">
+    <div :class="`${prefixCls}-image-preview-mask`"></div>
+    <div :class="`${prefixCls}-image-preview-tools`">
+      <ul :class="`${prefixCls}-preview-tools`">
+        <li :class="`${prefixCls}-tools-item ${prefixCls}-rotate-left`" @click="rotateEvent(-1)">
           <IxIcon name="rotate-left" />
         </li>
-        <li class="ix-tools-item ix-rotate-right" @click="rotateEvent(1)">
+        <li :class="`${prefixCls}-tools-item ${prefixCls}-rotate-right`" @click="rotateEvent(1)">
           <IxIcon name="rotate-right" />
         </li>
-        <li class="ix-tools-item ix-zoom-in" @click="zoomEvent(1)">
+        <li :class="`${prefixCls}-tools-item ${prefixCls}-zoom-in`" @click="zoomEvent(1)">
           <IxIcon name="zoom-in" />
         </li>
         <li
-          class="ix-tools-item ix-zoom-out"
-          :class="isZoomOutDisabled ? 'ix-tools-item-disabled' : ''"
+          :class="[
+            `${prefixCls}-tools-item`,
+            `${prefixCls}-zoom-out`,
+            isZoomOutDisabled ? `${prefixCls}-tools-item-disabled` : '',
+          ]"
           @click="zoomEvent(-1)"
         >
           <IxIcon name="zoom-out" />
         </li>
-        <li class="ix-tools-item ix-close" @click="close">
+        <li :class="`${prefixCls}-tools-item ${prefixCls}-close`" @click="close">
           <IxIcon name="close" />
         </li>
       </ul>
     </div>
-    <div class="ix-image-preview-img">
+    <div :class="`${prefixCls}-image-preview-img`">
       <img :src="previewSrc" alt="" :style="{ transform: transform }" />
     </div>
   </div>
@@ -32,6 +35,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { imagePreviewProps } from './types'
 
@@ -51,6 +55,7 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
+    const { prefixCls } = useGlobalConfig('common')
     const scale = ref(initScale)
     const rotate = ref(initRotate)
     const transform = computed(() => `scale3d(${scale.value}, ${scale.value}, 1) rotate(${rotate.value}deg)`)
@@ -68,6 +73,7 @@ export default defineComponent({
     }
 
     return {
+      prefixCls,
       close,
       scale,
       rotate,

--- a/packages/components/input/src/Input.tsx
+++ b/packages/components/input/src/Input.tsx
@@ -13,6 +13,7 @@ export default defineComponent({
   props: inputProps,
   setup(props, { slots, expose, attrs }) {
     const config = useGlobalConfig('input')
+    const { prefixCls } = useGlobalConfig('common')
 
     const {
       elementRef,
@@ -47,12 +48,12 @@ export default defineComponent({
       return (
         <span class={normalizeClass([classes.value, className])} style={style as StyleValue}>
           {addonBefore}
-          <span class="ix-input-wrapper">
+          <span class={`${prefixCls}-input-wrapper`}>
             {prefix}
             <input
               {...rest}
               ref={elementRef}
-              class="ix-input-inner"
+              class={`${prefixCls}-input-inner`}
               disabled={isDisabled.value}
               readonly={props.readonly}
               onInput={handlerInput}
@@ -78,15 +79,16 @@ function useClasses(
   disabled: ComputedRef<boolean>,
 ) {
   return computed(() => {
-    const sizeClass = `ix-input-${props.size ?? config.size}`
+    const { prefixCls } = useGlobalConfig('common')
+    const sizeClass = `${prefixCls}-input-${props.size ?? config.size}`
     return {
-      'ix-input': true,
+      [`${prefixCls}-input`]: true,
       [sizeClass]: true,
-      'ix-input-disabled': disabled.value,
-      'ix-input-borderless': props.borderless ?? config.borderless,
-      'ix-input-focused': isFocused.value,
-      'ix-input-with-addon-after': props.addonAfter || slots.addonAfter,
-      'ix-input-with-addon-before': props.addonBefore || slots.addonBefore,
+      [`${prefixCls}-input-disabled`]: disabled.value,
+      [`${prefixCls}-input-borderless`]: props.borderless ?? config.borderless,
+      [`${prefixCls}-input-focused`]: isFocused.value,
+      [`${prefixCls}-input-with-addon-after`]: props.addonAfter || slots.addonAfter,
+      [`${prefixCls}-input-with-addon-before`]: props.addonBefore || slots.addonBefore,
     }
   })
 }
@@ -95,16 +97,18 @@ function renderAddon(addonSlot: Slot | undefined, addon: string | undefined) {
   if (!(addonSlot || addon)) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const child = addonSlot ? addonSlot() : addon
-  return <span class="ix-input-addon">{child}</span>
+  return <span class={`${prefixCls}-input-addon`}>{child}</span>
 }
 
 function renderPrefix(prefixSlot: Slot | undefined, icon: string | undefined) {
   if (!(prefixSlot || icon)) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const child = prefixSlot ? prefixSlot() : <IxIcon name={icon}></IxIcon>
-  return <span class="ix-input-prefix">{child}</span>
+  return <span class={`${prefixCls}-input-prefix`}>{child}</span>
 }
 
 function renderSuffix(
@@ -119,8 +123,10 @@ function renderSuffix(
     return null
   }
 
+  const { prefixCls } = useGlobalConfig('common')
+
   if (isClearable && !(slots.suffix || props.suffix)) {
-    const classes = { 'ix-input-suffix': true, 'ix-input-suffix-hidden': clearHidden }
+    const classes = { [`${prefixCls}-input-suffix`]: true, [`${prefixCls}-input-suffix-hidden`]: clearHidden }
     const child = slots.clearIcon?.({ handlerClear }) ?? <IxIcon name={clearIcon} onClick={handlerClear}></IxIcon>
     return <span class={classes}>{child}</span>
   }
@@ -132,5 +138,5 @@ function renderSuffix(
     child = slots.suffix?.() ?? <IxIcon name={props.suffix}></IxIcon>
   }
 
-  return <span class="ix-input-suffix">{child}</span>
+  return <span class={`${prefixCls}-input-suffix`}>{child}</span>
 }

--- a/packages/components/layout/src/Layout.tsx
+++ b/packages/components/layout/src/Layout.tsx
@@ -1,14 +1,16 @@
 import { computed, defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { layoutProps } from './types'
 
 export default defineComponent({
   name: 'IxLayout',
   props: layoutProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const classes = computed(() => {
       return {
-        'ix-layout': true,
-        'ix-layout-out-sider': props.outSider,
+        [`${prefixCls}-layout`]: true,
+        [`${prefixCls}-layout-out-sider`]: props.outSider,
       }
     })
     return () => {

--- a/packages/components/layout/src/LayoutContent.tsx
+++ b/packages/components/layout/src/LayoutContent.tsx
@@ -1,12 +1,14 @@
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { layoutContentProps } from './types'
 
 export default defineComponent({
   name: 'IxLayoutContent',
   props: layoutContentProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     return () => {
-      return <main class="ix-layout-content">{slots.default?.()}</main>
+      return <main class={`${prefixCls}-layout-content`}>{slots.default?.()}</main>
     }
   },
 })

--- a/packages/components/layout/src/LayoutFooter.tsx
+++ b/packages/components/layout/src/LayoutFooter.tsx
@@ -1,12 +1,14 @@
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { layoutFooterProps } from './types'
 
 export default defineComponent({
   name: 'IxLayoutFooter',
   props: layoutFooterProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     return () => {
-      return <footer class="ix-layout-footer">{slots.default?.()}</footer>
+      return <footer class={`${prefixCls}-layout-footer`}>{slots.default?.()}</footer>
     }
   },
 })

--- a/packages/components/layout/src/LayoutHeader.tsx
+++ b/packages/components/layout/src/LayoutHeader.tsx
@@ -1,12 +1,14 @@
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { layoutHeaderProps } from './types'
 
 export default defineComponent({
   name: 'IxLayoutHeader',
   props: layoutHeaderProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     return () => {
-      return <header class="ix-layout-header">{slots.default?.()}</header>
+      return <header class={`${prefixCls}-layout-header`}>{slots.default?.()}</header>
     }
   },
 })

--- a/packages/components/layout/src/LayoutSider.tsx
+++ b/packages/components/layout/src/LayoutSider.tsx
@@ -5,6 +5,7 @@ import { computed, defineComponent, ref, watch } from 'vue'
 import { layoutSiderProps } from './types'
 import { BREAKPOINTS, useBreakpoints } from '@idux/cdk/breakpoint'
 import { callEmit, hasSlot } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import Trigger from './Trigger'
 import { isUndefined } from 'lodash-es'
 
@@ -12,6 +13,7 @@ export default defineComponent({
   name: 'IxLayoutHeader',
   props: layoutSiderProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const isDefinedBreakPoint = computed(() => {
       return !isUndefined(props.breakpoint)
     })
@@ -27,9 +29,9 @@ export default defineComponent({
 
     const classes = computed(() => {
       return {
-        'ix-layout-sider': true,
-        'ix-layout-sider-end': props.placement === 'end',
-        'ix-layout-sider-collapsed': isCollapsed.value,
+        [`${prefixCls}-layout-sider`]: true,
+        [`${prefixCls}-layout-sider-end`]: props.placement === 'end',
+        [`${prefixCls}-layout-sider-collapsed`]: isCollapsed.value,
       }
     })
 
@@ -39,7 +41,7 @@ export default defineComponent({
         (slots.trigger ? slots.trigger() : <Trigger collapsed={isCollapsed.value} onClick={handleClick} />)
       return (
         <aside class={classes.value} style={style.value}>
-          <div class="ix-layout-sider-children">{slots.default?.()}</div>
+          <div class={`${prefixCls}-layout-sider-children`}>{slots.default?.()}</div>
           {trigger}
         </aside>
       )

--- a/packages/components/layout/src/Trigger.tsx
+++ b/packages/components/layout/src/Trigger.tsx
@@ -1,15 +1,17 @@
 import { computed, defineComponent } from 'vue'
 import { callEmit } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { triggerProps } from './types'
 
 export default defineComponent({
   name: 'IxLayoutSiderTrigger',
   props: triggerProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const classes = computed(() => {
       return {
-        'ix-layout-sider-trigger': true,
-        'ix-layout-sider-trigger-collapsed': props.collapsed,
+        [`${prefixCls}-layout-sider-trigger`]: true,
+        [`${prefixCls}-layout-sider-trigger-collapsed`]: props.collapsed,
       }
     })
 
@@ -20,8 +22,8 @@ export default defineComponent({
     return () => {
       return (
         <div class={classes.value} onClick={handleClick}>
-          <div class="ix-layout-sider-trigger-top"></div>
-          <div class="ix-layout-sider-trigger-bottom"></div>
+          <div class={`${prefixCls}-layout-sider-trigger-top`}></div>
+          <div class={`${prefixCls}-layout-sider-trigger-bottom`}></div>
         </div>
       )
     }

--- a/packages/components/list/src/List.vue
+++ b/packages/components/list/src/List.vue
@@ -1,24 +1,24 @@
 <template>
-  <div class="ix-list" :class="classes">
-    <div v-if="isShowHeader" class="ix-list-header">
+  <div :class="classes">
+    <div v-if="isShowHeader" :class="`${prefixCls}-list-header`">
       <slot name="header"> {{ header }} </slot>
     </div>
     <IxSpin :spinning="loading">
       <list-wrap :isUseGrid="isUseGrid" :gutter="grid?.gutter">
         <slot></slot>
       </list-wrap>
-      <div v-show="isShowEmpty" class="ix-list-empty">
+      <div v-show="isShowEmpty" :class="`${prefixCls}-list-empty`">
         <slot name="empty">
           <IxEmpty :description="empty"></IxEmpty>
         </slot>
       </div>
-      <div v-if="isShowLoadMore" class="ix-list-loadMore">
+      <div v-if="isShowLoadMore" :class="`${prefixCls}-list-loadMore`">
         <slot name="loadMore">
           <IxButton :loading="loadMoreLoading" @click="handleLoadMoreClick">{{ loadMore }}</IxButton>
         </slot>
       </div>
     </IxSpin>
-    <div v-if="isShowFooter" class="ix-list-footer">
+    <div v-if="isShowFooter" :class="`${prefixCls}-list-footer`">
       <slot name="footer"> {{ footer }} </slot>
     </div>
   </div>
@@ -57,6 +57,7 @@ export default defineComponent({
     const isShowLoadMore = computed(() => slots.loadMore || props.loadMore)
     const isShowHeader = computed(() => slots.header || props.header)
     const isShowFooter = computed(() => slots.footer || props.footer)
+    const { prefixCls } = useGlobalConfig('common')
     const listConfig = useGlobalConfig('list')
     const classes = useClasses(props, listConfig)
 
@@ -70,6 +71,7 @@ export default defineComponent({
     }
 
     return {
+      prefixCls,
       isUseGrid,
       isShowEmpty,
       isShowLoadMore,
@@ -83,15 +85,17 @@ export default defineComponent({
 })
 
 const useClasses = (props: ListProps, listConfig: ListConfig) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const borderless = props.borderless ?? listConfig.borderless
     const size = props.size ?? listConfig.size ?? 'medium'
     const split = props.split
     return [
-      `ix-list-${size}`,
-      split ? 'ix-list-split' : '',
+      `${prefixCls}-list`,
+      `${prefixCls}-list-${size}`,
+      split ? `${prefixCls}-list-split` : '',
       {
-        'ix-list-border': !borderless,
+        [`${prefixCls}-list-border`]: !borderless,
       },
     ]
   })

--- a/packages/components/list/src/ListItem.vue
+++ b/packages/components/list/src/ListItem.vue
@@ -1,12 +1,12 @@
 <template>
   <list-item-wrap :grid="gird">
-    <div class="ix-list-item-title">
+    <div :class="`${prefixCls}-list-item-title`">
       <slot name="title">{{ title }}</slot>
     </div>
-    <div class="ix-list-item-content">
+    <div :class="`${prefixCls}-list-item-content`">
       <slot>{{ content }}</slot>
     </div>
-    <div class="ix-list-item-extra">
+    <div :class="`${prefixCls}-list-item-extra`">
       <slot name="extra">{{ extra }}</slot>
     </div>
   </list-item-wrap>
@@ -15,6 +15,7 @@
 import type { ListGridProps } from './types'
 
 import { defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import ListItemWrap from './ListItemWrap.vue'
 import { listToken } from './token'
 import { listItemProps } from './types'
@@ -24,9 +25,10 @@ export default defineComponent({
   components: { ListItemWrap },
   props: listItemProps,
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const listGrid = inject(listToken, null)
     const gird = listGrid?.value && useGrid(listGrid?.value)
-    return { gird }
+    return { prefixCls, gird }
   },
 })
 

--- a/packages/components/list/src/ListItemWrap.vue
+++ b/packages/components/list/src/ListItemWrap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!grid" class="ix-list-item">
+  <div v-if="!grid" :class="`${prefixCls}-list-item`">
     <slot></slot>
   </div>
   <IxCol v-else :xs="grid.xs" :sm="grid.sm" :md="grid.md" :lg="grid.lg" :xl="grid.xl">
@@ -9,11 +9,18 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCol } from '@idux/components/grid'
 import { listItemWrapProps } from './types'
 
 export default defineComponent({
   components: { IxCol },
   props: listItemWrapProps,
+  setup() {
+    const { prefixCls } = useGlobalConfig('common')
+    return {
+      prefixCls,
+    }
+  },
 })
 </script>

--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -18,6 +18,7 @@ export default defineComponent({
     const { expandedKeys, handleExpand } = useExpanded(props)
     const { selectedKeys, handleItemClick } = useSelected(props, dropdownContext)
 
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('menu')
     const indent = computed(() => props.indent ?? config.indent)
     const mode = useMenuMode(props)
@@ -35,7 +36,7 @@ export default defineComponent({
       theme,
     })
 
-    const classes = useClasses(props, theme, mode, !!dropdownContext)
+    const classes = useClasses(prefixCls, props, theme, mode, !!dropdownContext)
     const style = computed(() => {
       if (!props.collapsed || mode.value === 'horizontal') {
         return undefined
@@ -119,14 +120,20 @@ function useMenuMode(props: MenuProps) {
   })
 }
 
-function useClasses(props: MenuProps, theme: ComputedRef<string>, mode: ComputedRef<MenuMode>, isDropdown: boolean) {
+function useClasses(
+  prefixCls: string,
+  props: MenuProps,
+  theme: ComputedRef<string>,
+  mode: ComputedRef<MenuMode>,
+  isDropdown: boolean,
+) {
   return computed(() => {
     return {
-      'ix-menu': true,
-      [`ix-menu-${theme.value}`]: true,
-      [`ix-menu-${mode.value}`]: true,
-      'ix-menu-collapsed': props.collapsed,
-      'ix-menu-dropdown': isDropdown,
+      [`${prefixCls}-menu`]: true,
+      [`${prefixCls}-menu-${theme.value}`]: true,
+      [`${prefixCls}-menu-${mode.value}`]: true,
+      [`${prefixCls}-menu-collapsed`]: props.collapsed,
+      [`${prefixCls}-menu-dropdown`]: isDropdown,
     }
   })
 }

--- a/packages/components/menu/src/MenuDivider.tsx
+++ b/packages/components/menu/src/MenuDivider.tsx
@@ -1,8 +1,10 @@
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 
 export default defineComponent({
   name: 'IxMenuDivider',
   setup() {
-    return () => <li class="ix-menu-divider"></li>
+    const { prefixCls } = useGlobalConfig('common')
+    return () => <li class={`${prefixCls}-menu-divider`}></li>
   },
 })

--- a/packages/components/menu/src/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem.tsx
@@ -2,6 +2,7 @@ import type { Ref } from 'vue'
 import type { MenuItemProps } from './types'
 
 import { computed, defineComponent, inject, watch } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { useKey } from '@idux/components/utils'
 import { menuItemGroupToken, menuToken, menuSubToken } from './token'
@@ -12,6 +13,8 @@ export default defineComponent({
   name: 'IxMenuItem',
   props: menuItemProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const key = useKey()
 
     // menuContext must exist
@@ -41,7 +44,7 @@ export default defineComponent({
       const { icon, label } = props
 
       const iconNode = slots.icon?.() ?? icon ? <IxIcon name={icon}></IxIcon> : undefined
-      const iconWrapper = iconNode ? <span class="ix-menu-item-icon">{iconNode}</span> : undefined
+      const iconWrapper = iconNode ? <span class={`${prefixCls}-menu-item-icon`}>{iconNode}</span> : undefined
 
       const labelNode = <span> {slots.default?.() ?? label}</span>
 
@@ -56,11 +59,12 @@ export default defineComponent({
 })
 
 const useClasses = (props: MenuItemProps, selected: Ref<boolean>) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-menu-item': true,
-      'ix-menu-item-disabled': props.disabled,
-      'ix-menu-item-selected': selected.value,
+      [`${prefixCls}-menu-item`]: true,
+      [`${prefixCls}-menu-item-disabled`]: props.disabled,
+      [`${prefixCls}-menu-item-selected`]: selected.value,
     }
   })
 }

--- a/packages/components/menu/src/MenuItemGroup.tsx
+++ b/packages/components/menu/src/MenuItemGroup.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, inject, provide } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { menuItemGroupToken, menuToken, menuSubToken } from './token'
 import { menuItemGroupProps } from './types'
@@ -8,6 +9,7 @@ export default defineComponent({
   name: 'IxMenuItemGroup',
   props: menuItemGroupProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     provide(menuItemGroupToken, true)
 
     // menuContext must exist
@@ -25,17 +27,19 @@ export default defineComponent({
       const { icon, label } = props
 
       const iconNode = slots.icon?.() ?? icon ? <IxIcon name={icon}></IxIcon> : undefined
-      const iconWrapper = iconNode ? <span class="ix-menu-item-group-title-icon">{iconNode}</span> : undefined
+      const iconWrapper = iconNode ? (
+        <span class={`${prefixCls}-menu-item-group-title-icon`}>{iconNode}</span>
+      ) : undefined
 
       const labelNode = <span> {slots.label?.() ?? label}</span>
 
       return (
-        <li class="ix-menu-item-group">
-          <div class="ix-menu-item-group-title" style={style.value}>
+        <li class={`${prefixCls}-menu-item-group`}>
+          <div class={`${prefixCls}-menu-item-group-title`} style={style.value}>
             {iconWrapper}
             {labelNode}
           </div>
-          <ul class="ix-menu-item-group-content">{slots.default?.()}</ul>
+          <ul class={`${prefixCls}-menu-item-group-content`}>{slots.default?.()}</ul>
         </li>
       )
     }

--- a/packages/components/menu/src/menu-sub/InlineContent.tsx
+++ b/packages/components/menu/src/menu-sub/InlineContent.tsx
@@ -1,15 +1,17 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCollapseTransition } from '@idux/components/_private'
 import { menuSubToken } from '../token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { slots, isExpanded } = inject(menuSubToken)!
 
     const classes = computed(() => {
       return {
-        'ix-menu-content': true,
-        'ix-menu-inline': true,
+        [`${prefixCls}-menu-content`]: true,
+        [`${prefixCls}-menu-inline`]: true,
       }
     })
 

--- a/packages/components/menu/src/menu-sub/MenuSub.tsx
+++ b/packages/components/menu/src/menu-sub/MenuSub.tsx
@@ -25,6 +25,7 @@ export default defineComponent({
     const menuSubContext = inject(menuSubToken, null)
     const menuItemGroupContext = inject(menuItemGroupToken, false)
 
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('menuSub')
     const key = useKey()
     const level = menuSubContext ? menuSubContext.level + 1 : 1
@@ -75,7 +76,7 @@ export default defineComponent({
           <IxOverlay
             visible={isExpanded.value}
             v-slots={{ default: trigger, content: content }}
-            class="ix-menu-sub-overlay"
+            class={`${prefixCls}-menu-sub-overlay`}
             autoAdjust
             destroyOnHide={false}
             delay={defaultDelay}
@@ -83,8 +84,8 @@ export default defineComponent({
             offset={offset.value}
             placement={placement.value}
             showArrow={false}
-            target="ix-menu-container"
-            transitionName="ix-fade"
+            target={`${prefixCls}-menu-container`}
+            transitionName={`${prefixCls}-fade`}
             trigger="manual"
           />
         )
@@ -100,13 +101,14 @@ function useClasses(
   isExpanded: Ref<boolean>,
   isSelected: Ref<boolean>,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-menu-sub': true,
-      'ix-menu-sub-disabled': props.disabled,
-      'ix-menu-sub-expanded': isExpanded.value,
-      'ix-menu-sub-selected': isSelected.value,
-      [`ix-menu-sub-${mode.value}`]: true,
+      [`${prefixCls}-menu-sub`]: true,
+      [`${prefixCls}-menu-sub-disabled`]: props.disabled,
+      [`${prefixCls}-menu-sub-expanded`]: isExpanded.value,
+      [`${prefixCls}-menu-sub-selected`]: isSelected.value,
+      [`${prefixCls}-menu-sub-${mode.value}`]: true,
     }
   })
 }

--- a/packages/components/menu/src/menu-sub/OverlayContent.tsx
+++ b/packages/components/menu/src/menu-sub/OverlayContent.tsx
@@ -1,18 +1,20 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { ɵDropdownToken } from '@idux/components/dropdown'
 import { menuSubToken } from '../token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, slots, mode, theme, handleMouseEvent } = inject(menuSubToken)!
     const dropdownContext = inject(ɵDropdownToken, null)
 
     const classes = computed(() => {
       return {
-        'ix-menu-content': true,
-        'ix-menu-vertical': true,
-        [`ix-menu-${theme.value}`]: true,
-        'ix-menu-dropdown': !!dropdownContext,
+        [`${prefixCls}-menu-content`]: true,
+        [`${prefixCls}-menu-vertical`]: true,
+        [`${prefixCls}-menu-${theme.value}`]: true,
+        [`${prefixCls}-menu-dropdown`]: !!dropdownContext,
       }
     })
 

--- a/packages/components/menu/src/menu-sub/Title.tsx
+++ b/packages/components/menu/src/menu-sub/Title.tsx
@@ -1,9 +1,11 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { menuSubToken } from '../token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, slots, config, isExpanded, changeExpanded, handleMouseEvent, mode, paddingLeft } =
       inject(menuSubToken)!
 
@@ -41,7 +43,7 @@ export default defineComponent({
       const { icon, label } = props
 
       const iconNode = slots.icon?.() ?? icon ? <IxIcon name={icon}></IxIcon> : undefined
-      const iconWrapper = iconNode ? <span class="ix-menu-sub-title-icon">{iconNode}</span> : undefined
+      const iconWrapper = iconNode ? <span class={`${prefixCls}-menu-sub-title-icon`}>{iconNode}</span> : undefined
 
       const labelNode = <span> {slots.label?.() ?? label}</span>
 
@@ -49,10 +51,12 @@ export default defineComponent({
         slots.suffix?.({ rotate: rotate.value }) ?? suffix.value ? (
           <IxIcon name={suffix.value} rotate={rotate.value}></IxIcon>
         ) : undefined
-      const suffixWrapper = suffixNode ? <span class="ix-menu-sub-title-suffix-icon">{suffixNode}</span> : undefined
+      const suffixWrapper = suffixNode ? (
+        <span class={`${prefixCls}-menu-sub-title-suffix-icon`}>{suffixNode}</span>
+      ) : undefined
 
       return (
-        <div class="ix-menu-sub-title" style={style.value} {...events.value}>
+        <div class={`${prefixCls}-menu-sub-title`} style={style.value} {...events.value}>
           {iconWrapper}
           {labelNode}
           {suffixWrapper}

--- a/packages/components/message/src/Message.tsx
+++ b/packages/components/message/src/Message.tsx
@@ -21,9 +21,10 @@ export default defineComponent({
   props: messageProps,
   setup(props, { slots }) {
     const config = useGlobalConfig('message')
+    const { prefixCls } = useGlobalConfig('common')
 
     const classes = computed(() => {
-      const clsPrefix = 'ix-message'
+      const clsPrefix = [`${prefixCls}-message`]
       return [clsPrefix, `${clsPrefix}-${props.type}`]
     })
 
@@ -38,9 +39,9 @@ export default defineComponent({
       const iconNode = isString(icon.value) ? <IxIcon name={icon.value}></IxIcon> : icon.value
       return (
         <div v-show={visible.value} class={classes.value} onMouseenter={onMouseEnter} onMouseleave={onMouseLeave}>
-          <div class="ix-message-content">
+          <div class={`${prefixCls}-message-content`}>
             {iconNode}
-            <span class="ix-message-content-text">{slots.default?.()}</span>
+            <span class={`${prefixCls}-message-content-text`}>{slots.default?.()}</span>
           </div>
         </div>
       )

--- a/packages/components/message/src/MessageProvider.tsx
+++ b/packages/components/message/src/MessageProvider.tsx
@@ -13,6 +13,8 @@ export default defineComponent({
   props: messageProviderProps,
   setup(props, { expose, slots, attrs }) {
     const config = useGlobalConfig('message')
+    const { prefixCls } = useGlobalConfig('common')
+
     const style = computed(() => ({ top: convertCssPixel(props.top ?? config.top) }))
     const maxCount = computed(() => props.maxCount ?? config.maxCount)
     const { messages, loadContainer, apis } = useMessageApis(maxCount)
@@ -35,8 +37,14 @@ export default defineComponent({
       return (
         <>
           {slots.default?.()}
-          <IxPortal target="ix-message-container" load={loadContainer.value}>
-            <TransitionGroup tag="div" name="ix-move-up" class="ix-message-wrapper" style={style.value} {...attrs}>
+          <IxPortal target={`${prefixCls}-message-container`} load={loadContainer.value}>
+            <TransitionGroup
+              tag="div"
+              name={`${prefixCls}-move-up`}
+              class={`${prefixCls}-message-wrapper`}
+              style={style.value}
+              {...attrs}
+            >
               {child}
             </TransitionGroup>
           </IxPortal>
@@ -47,6 +55,7 @@ export default defineComponent({
 })
 
 const useMessage = (maxCount: ComputedRef<number>) => {
+  const { prefixCls } = useGlobalConfig('common')
   const messages = ref<MessageOptions[]>([])
 
   const getCurrIndex = (key: string) => {
@@ -64,7 +73,7 @@ const useMessage = (maxCount: ComputedRef<number>) => {
       messages.value = messages.value.slice(-maxCount.value + 1)
     }
 
-    const key = item.key ?? uniqueId('ix-message')
+    const key = item.key ?? uniqueId(`${prefixCls}-message`)
     messages.value.push({ ...item, key })
     return key
   }

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -13,6 +13,7 @@ export default defineComponent({
   inheritAttrs: false,
   props: modalProps,
   setup(props, { slots, expose, attrs }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('modal')
     const mask = computed(() => props.mask ?? config.mask)
     const zIndex = computed(() => props.zIndex ?? config.zIndex)
@@ -30,7 +31,7 @@ export default defineComponent({
       }
 
       return (
-        <IxPortal target="ix-modal-container" load={visible.value}>
+        <IxPortal target={`${prefixCls}-modal-container`} load={visible.value}>
           <IxMask mask={mask.value} visible={visible.value} zIndex={zIndex.value}></IxMask>
           <ModalWrapper {...attrs}></ModalWrapper>
         </IxPortal>

--- a/packages/components/modal/src/ModalBody.tsx
+++ b/packages/components/modal/src/ModalBody.tsx
@@ -2,6 +2,7 @@ import type { Slot, VNode, VNodeTypes } from 'vue'
 
 import { computed, defineComponent, inject } from 'vue'
 import { isString } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { modalToken } from './token'
 
@@ -17,6 +18,7 @@ const defaultIconTypes = {
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, slots, config } = inject(modalToken)!
     const isDefault = computed(() => props.type === 'default')
     const iconName = computed(() => {
@@ -26,15 +28,15 @@ export default defineComponent({
 
     return () => {
       if (isDefault.value) {
-        return <div class="ix-modal-body">{slots.default?.()}</div>
+        return <div class={`${prefixCls}-modal-body`}>{slots.default?.()}</div>
       }
-      const classes = `ix-modal-body ix-modal-body-${props.type}`
+      const classes = `${prefixCls}-modal-body ${prefixCls}-modal-body-${props.type}`
       const icon = renderIcon(slots.icon, iconName.value)
       const title = renderTitle(slots.title, props.title)
       return (
         <div class={classes}>
           {icon}
-          <div class="ix-modal-body-content">
+          <div class={`${prefixCls}-modal-body-content`}>
             {title}
             {slots.default?.()}
           </div>
@@ -48,19 +50,21 @@ const renderIcon = (iconSlot: Slot | undefined, icon: string | VNode | undefined
   if (!iconSlot && !icon) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   let child: VNodeTypes
   if (iconSlot) {
     child = iconSlot()
   } else {
     child = isString(icon) ? <IxIcon name={icon}></IxIcon> : icon!
   }
-  return <div class="ix-modal-body-icon">{child}</div>
+  return <div class={`${prefixCls}-modal-body-icon`}>{child}</div>
 }
 
 const renderTitle = (titleSlot: Slot | undefined, title: string | VNode | undefined) => {
   if (!titleSlot && !title) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const child = titleSlot ? titleSlot() : title
-  return <div class="ix-modal-body-title">{child}</div>
+  return <div class={`${prefixCls}-modal-body-title`}>{child}</div>
 }

--- a/packages/components/modal/src/ModalFooter.tsx
+++ b/packages/components/modal/src/ModalFooter.tsx
@@ -2,12 +2,15 @@ import type { ComputedRef, Ref, VNodeTypes } from 'vue'
 import type { ModalButtonProps } from './types'
 
 import { computed, defineComponent, inject, isVNode } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { ButtonProps, IxButton } from '@idux/components/button'
 import { getLocale } from '@idux/components/i18n'
 import { modalToken, MODAL_TOKEN } from './token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props, slots, cancelLoading, okLoading } = inject(modalToken)!
     const { cancel, ok } = inject(MODAL_TOKEN)!
     const locale = getLocale('modal')
@@ -49,7 +52,7 @@ export default defineComponent({
         )
       }
 
-      return <div class="ix-modal-footer">{childNode}</div>
+      return <div class={`${prefixCls}-modal-footer`}>{childNode}</div>
     }
   },
 })

--- a/packages/components/modal/src/ModalProvider.tsx
+++ b/packages/components/modal/src/ModalProvider.tsx
@@ -2,6 +2,7 @@ import type { ModalInstance, ModalOptions, ModalRef } from './types'
 
 import { defineComponent, ref, provide } from 'vue'
 import { callEmit, noop, convertArray, uniqueId } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import Modal from './Modal'
 import { modalProviderToken } from './token'
 
@@ -66,6 +67,7 @@ const useModalRef = () => {
 }
 
 const useModal = () => {
+  const { prefixCls } = useGlobalConfig('common')
   const modals = ref<ModalOptions[]>([])
 
   const getCurrIndex = (key: string) => {
@@ -79,7 +81,7 @@ const useModal = () => {
       return item.key!
     }
 
-    const key = item.key ?? uniqueId('ix-modal')
+    const key = item.key ?? uniqueId(`${prefixCls}-modal`)
     modals.value.push({ ...item, key })
     return key
   }

--- a/packages/components/modal/src/ModalWrapper.tsx
+++ b/packages/components/modal/src/ModalWrapper.tsx
@@ -3,6 +3,7 @@ import { ComputedRef, onBeforeUnmount, onMounted, Ref, watch } from 'vue'
 import { computed, defineComponent, inject, ref, Transition } from 'vue'
 import { isFunction } from 'lodash-es'
 import { callEmit, getOffset, convertCssPixel } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import ModalHeader from './ModalHeader'
 import ModalBody from './ModalBody'
 import ModalFooter from './ModalFooter'
@@ -13,6 +14,7 @@ import { ModalProps } from './types'
 export default defineComponent({
   inheritAttrs: false,
   setup(_, { attrs }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { props, config, visible, animatedVisible } = inject(modalToken)!
     const { close } = inject(MODAL_TOKEN)!
     const { centered, width, mask, maskClosable, closeOnEsc, zIndex } = useConfig(props, config)
@@ -58,24 +60,30 @@ export default defineComponent({
           onClick={onWrapperClick}
           onKeydown={onWrapperKeydown}
         >
-          <Transition name="ix-zoom" appear onEnter={onEnter} onAfterEnter={onAfterEnter} onAfterLeave={onAfterLeave}>
+          <Transition
+            name={`${prefixCls}-zoom`}
+            appear
+            onEnter={onEnter}
+            onAfterEnter={onAfterEnter}
+            onAfterLeave={onAfterLeave}
+          >
             <div
               v-show={visible.value}
               ref={modalRef}
               role="document"
-              class="ix-modal"
+              class={`${prefixCls}-modal`}
               style={modalStyle.value}
               onMousedown={onModalMousedown}
               onMouseup={onModalMouseup}
               {...attrs}
             >
-              <div ref={sentinelStartRef} tabindex={0} class="ix-modal-sentinel" aria-hidden="true"></div>
-              <div class="ix-modal-content">
+              <div ref={sentinelStartRef} tabindex={0} class={`${prefixCls}-modal-sentinel" aria-hidden="true`}></div>
+              <div class={`${prefixCls}-modal-content`}>
                 <ModalHeader></ModalHeader>
                 <ModalBody></ModalBody>
                 <ModalFooter></ModalFooter>
               </div>
-              <div ref={sentinelEndRef} tabindex={0} class="ix-modal-sentinel" aria-hidden="true"></div>
+              <div ref={sentinelEndRef} tabindex={0} class={`${prefixCls}-modal-sentinel" aria-hidden="true`}></div>
             </div>
           </Transition>
         </div>
@@ -96,11 +104,12 @@ const useConfig = (props: ModalProps, config: ModalConfig) => {
 }
 
 const useClasses = (props: ModalProps, centered: ComputedRef<boolean>) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const containerClassName = props.containerClassName
     return {
-      'ix-modal-wrapper': true,
-      'ix-modal-centered': centered.value,
+      [`${prefixCls}-modal-wrapper`]: true,
+      [`${prefixCls}-modal-centered`]: centered.value,
       [containerClassName || '']: containerClassName,
     }
   })

--- a/packages/components/pagination/src/Item.tsx
+++ b/packages/components/pagination/src/Item.tsx
@@ -2,6 +2,7 @@ import type { VNodeTypes } from 'vue'
 
 import { computed, defineComponent, inject } from 'vue'
 import { isNil } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxButton } from '@idux/components/button'
 import { paginationItemProps } from './types'
 import { paginationToken } from './token'
@@ -24,6 +25,8 @@ const indexDiffMap = {
 export default defineComponent({
   props: paginationItemProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props: paginationProps, slots, config, locale, activeIndex, onPageIndexChange } = inject(paginationToken)!
 
     const isActive = computed(() => activeIndex.value === props.index)
@@ -33,8 +36,8 @@ export default defineComponent({
 
     const classes = computed(() => {
       return {
-        'ix-pagination-item': true,
-        'ix-pagination-item-active': isActive.value,
+        [`${prefixCls}-pagination-item`]: true,
+        [`${prefixCls}-pagination-item-active`]: isActive.value,
       }
     })
 
@@ -75,9 +78,13 @@ export default defineComponent({
       const commonButtonProps = { mode: 'text', size: 'small', shape: 'circle' } as const
       if (props.type === 'prev5' || type === 'next5') {
         original = (
-          <span class="ix-pagination-item-jumper">
+          <span class={`${prefixCls}-pagination-item-jumper`}>
             <IxButton {...commonButtonProps} icon={icon} disabled={disabled} />
-            <IxButton {...commonButtonProps} class="ix-pagination-item-ellipsis" icon="ellipsis" disabled={disabled} />
+            <IxButton
+              {...commonButtonProps}
+              class={`${prefixCls}-pagination-item-ellipsis" icon="ellipsis`}
+              disabled={disabled}
+            />
           </span>
         )
       } else if (!isNil(index)) {

--- a/packages/components/pagination/src/Jumper.tsx
+++ b/packages/components/pagination/src/Jumper.tsx
@@ -1,10 +1,13 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxInput } from '@idux/components/input'
 import { paginationToken } from './token'
 import { useJumpToIndex } from './utils'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props, config, locale } = inject(paginationToken)!
     const size = computed(() => props.size ?? config.size)
     const jumpToIndex = useJumpToIndex(true)
@@ -13,7 +16,7 @@ export default defineComponent({
       const { disabled } = props
       const { jumpTo, page } = locale.value
       return (
-        <li class="ix-pagination-jumper">
+        <li class={`${prefixCls}-pagination-jumper`}>
           {jumpTo}
           <IxInput disabled={disabled} size={size.value} onKeydown={jumpToIndex} />
           {page}

--- a/packages/components/pagination/src/Pagination.tsx
+++ b/packages/components/pagination/src/Pagination.tsx
@@ -16,13 +16,14 @@ export default defineComponent({
   name: 'IxPagination',
   props: paginationProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('pagination')
     useProvider(props, slots, config)
 
     const showTotal = computed(() => props.showTotal ?? config.showTotal)
     const simple = computed(() => props.simple ?? config.simple)
     const size = computed(() => props.size ?? config.size)
-    const classes = useClasses(props, simple, size)
+    const classes = useClasses(prefixCls, props, simple, size)
 
     return () => {
       return (
@@ -35,13 +36,18 @@ export default defineComponent({
   },
 })
 
-const useClasses = (props: PaginationProps, simple: ComputedRef<boolean>, size: ComputedRef<PaginationSize>) => {
+const useClasses = (
+  prefixCls: string,
+  props: PaginationProps,
+  simple: ComputedRef<boolean>,
+  size: ComputedRef<PaginationSize>,
+) => {
   return computed(() => {
     return {
-      'ix-pagination': true,
-      'ix-pagination-disabled': props.disabled,
-      'ix-pagination-simple': simple.value,
-      [`ix-pagination-${size.value}`]: true,
+      [`${prefixCls}-pagination`]: true,
+      [`${prefixCls}-pagination-disabled`]: props.disabled,
+      [`${prefixCls}-pagination-simple`]: simple.value,
+      [`${prefixCls}-pagination-${size.value}`]: true,
     }
   })
 }

--- a/packages/components/pagination/src/Simple.tsx
+++ b/packages/components/pagination/src/Simple.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, inject, ref, watchEffect } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxInput } from '@idux/components/input'
 import Item from './Item'
 import { paginationToken } from './token'
@@ -6,6 +7,8 @@ import { useJumpToIndex } from './utils'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props, config, activeIndex, activeSize } = inject(paginationToken)!
     const size = computed(() => props.size ?? config.size)
     const lastIndex = ref(0)
@@ -25,14 +28,14 @@ export default defineComponent({
       return (
         <>
           <Item disabled={isFirstIndex.value} type="prev" />
-          <li class="ix-pagination-item">
+          <li class={`${prefixCls}-pagination-item`}>
             <IxInput
               disabled={props.disabled}
               size={size.value}
               value={activeIndex.value.toString()}
               onKeydown={jumpToIndex}
             />
-            <span class="ix-pagination-item-slash">/</span>
+            <span class={`${prefixCls}-pagination-item-slash`}>/</span>
             <span>{lastIndex.value}</span>
           </li>
           <Item disabled={isLastIndex.value} type="next" />

--- a/packages/components/pagination/src/Sizes.tsx
+++ b/packages/components/pagination/src/Sizes.tsx
@@ -1,9 +1,12 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxSelect } from '@idux/components/select'
 import { paginationToken } from './token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props, config, locale, activeSize, onPageSizeChange } = inject(paginationToken)!
 
     const size = computed(() => props.size ?? config.size)
@@ -20,7 +23,7 @@ export default defineComponent({
 
     return () => {
       return (
-        <li class="ix-pagination-sizes">
+        <li class={`${prefixCls}-pagination-sizes`}>
           <IxSelect
             disabled={props.disabled}
             options={sizeOptions.value}

--- a/packages/components/pagination/src/Total.tsx
+++ b/packages/components/pagination/src/Total.tsx
@@ -1,8 +1,11 @@
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { paginationToken } from './token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { props, slots, config, locale, activeIndex, activeSize } = inject(paginationToken)!
 
     const totalRender = computed(() => slots.total ?? props.totalRender ?? config.totalRender)
@@ -22,7 +25,7 @@ export default defineComponent({
       const children = _totalRender
         ? _totalRender({ total, range: range.value })
         : `${totalPrefix} ${total} ${totalSuffix}`
-      return <li class="ix-pagination-total">{children}</li>
+      return <li class={`${prefixCls}-pagination-total`}>{children}</li>
     }
   },
 })

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -13,6 +13,7 @@ export default defineComponent({
   name: 'IxPopover',
   props: popoverProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('popover')
     const configProps = ɵUseConfigProps(props, config)
     const visibility = ɵUseVisibility(props)
@@ -20,9 +21,9 @@ export default defineComponent({
     return () => (
       <IxOverlay
         v-model={[visibility.value, 'visible']}
-        v-slots={{ default: slots.default, content: () => renderContent(props, slots) }}
-        class="ix-popover"
-        transitionName="ix-fade"
+        v-slots={{ default: slots.default, content: () => renderContent(prefixCls, props, slots) }}
+        class={`${prefixCls}-popover`}
+        transitionName={`${prefixCls}-fade`}
         {...configProps.value}
         offset={defaultOffset}
       />
@@ -30,18 +31,18 @@ export default defineComponent({
   },
 })
 
-const renderContent = (props: PopoverProps, slots: Slots) => {
+const renderContent = (prefixCls: string, props: PopoverProps, slots: Slots) => {
   if (!(slots.title || props.title || slots.content || props.content)) {
     return null
   }
 
   const child: VNode[] = []
   if (slots.title || props.title) {
-    child.push(<div class="ix-popover-title">{slots.title?.() ?? props.title}</div>)
+    child.push(<div class={`${prefixCls}-popover-title`}>{slots.title?.() ?? props.title}</div>)
   }
 
   if (slots.content || props.content) {
-    child.push(<div class="ix-popover-content">{slots.content?.() ?? props.content}</div>)
+    child.push(<div class={`${prefixCls}-popover-content`}>{slots.content?.() ?? props.content}</div>)
   }
 
   return child

--- a/packages/components/progress/__tests__/__snapshots__/progress.spec.ts.snap
+++ b/packages/components/progress/__tests__/__snapshots__/progress.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Progress gapPosition work 1`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <!--v-if-->
     <path class=\\"ix-progress-circle-trail\\" stroke=\\"#f5f5f5\\" fill-opacity=\\"0\\" stroke-linecap=\\"round\\" stroke-width=\\"6\\" d=\\"M 50,50 m 0,47
        a 47,47 0 1 1 0,-94
@@ -15,7 +15,7 @@ exports[`Progress gapPosition work 1`] = `
 `;
 
 exports[`Progress gapPosition work 2`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <!--v-if-->
     <path class=\\"ix-progress-circle-trail\\" stroke=\\"#f5f5f5\\" fill-opacity=\\"0\\" stroke-linecap=\\"round\\" stroke-width=\\"6\\" d=\\"M 50,50 m -47,0
        a 47,47 0 1 1 94,0
@@ -29,7 +29,7 @@ exports[`Progress gapPosition work 2`] = `
 `;
 
 exports[`Progress gapPosition work 3`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <!--v-if-->
     <path class=\\"ix-progress-circle-trail\\" stroke=\\"#f5f5f5\\" fill-opacity=\\"0\\" stroke-linecap=\\"round\\" stroke-width=\\"6\\" d=\\"M 50,50 m 47,0
        a 47,47 0 1 1 -94,0
@@ -43,7 +43,7 @@ exports[`Progress gapPosition work 3`] = `
 `;
 
 exports[`Progress render circle progress work 1`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <!--v-if-->
     <path class=\\"ix-progress-circle-trail\\" stroke=\\"#f5f5f5\\" fill-opacity=\\"0\\" stroke-linecap=\\"round\\" stroke-width=\\"6\\" d=\\"M 50,50 m 0,-47
        a 47,47 0 1 1 0,94
@@ -57,7 +57,7 @@ exports[`Progress render circle progress work 1`] = `
 `;
 
 exports[`Progress render dashboard progress work 1`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <!--v-if-->
     <path class=\\"ix-progress-circle-trail\\" stroke=\\"#f5f5f5\\" fill-opacity=\\"0\\" stroke-linecap=\\"round\\" stroke-width=\\"6\\" d=\\"M 50,50 m 0,47
        a 47,47 0 1 1 0,-94
@@ -107,7 +107,7 @@ exports[`Progress strokeColor work 1`] = `
 `;
 
 exports[`Progress strokeColor work 2`] = `
-"<div class=\\"ix-progress-circle ix-progress-status-normal ix-progress-circle-gradient ix-progress\\" style=\\"width: 132px; height: 132px; font-size: 25.8px;\\"><svg viewBox=\\"0 0 100 100\\">
+"<div style=\\"width: 132px; height: 132px; font-size: 25.8px;\\" class=\\"ix-progress-circle ix-progress-status-normal ix-progress-circle-gradient ix-progress\\"><svg viewBox=\\"0 0 100 100\\">
     <defs>
       <linearGradient id=\\"ix-progress-gradient-ix-2\\" x1=\\"100%\\" y1=\\"0%\\" x2=\\"0%\\" y2=\\"0%\\">
         <stop offset=\\"0%\\" stop-color=\\"#108ee9\\"></stop>

--- a/packages/components/progress/src/Circle.vue
+++ b/packages/components/progress/src/Circle.vue
@@ -1,27 +1,26 @@
 <template>
-  <div class="ix-progress-circle" :style="circleStyle" :class="circleClasses">
+  <div :style="circleStyle" :class="circleClasses">
     <svg viewBox="0 0 100 100">
       <defs v-if="isGradient">
         <linearGradient :id="linearGradientId" x1="100%" y1="0%" x2="0%" y2="0%">
           <stop v-for="(v, idx) in circleGradient" :key="idx" :offset="v.offset" :stop-color="v.color"></stop>
         </linearGradient>
       </defs>
-      <path class="ix-progress-circle-trail" v-bind="trailPathAttr" :style="trailPathStyle"></path>
+      <path :class="`${prefixCls}-progress-circle-trail`" v-bind="trailPathAttr" :style="trailPathStyle"></path>
       <path
         v-for="(p, idx) in strokePath"
         :key="idx"
         :stroke="p.stroke"
-        class="ix-progress-circle-path"
         :class="p.strokeClasses"
         v-bind="strokePathAttr"
         :style="p.strokePathStyle"
       ></path>
     </svg>
-    <div v-if="!hideInfo" class="ix-progress-text">
+    <div v-if="!hideInfo" :class="`${prefixCls}-progress-text`">
       <slot>
         <template v-if="showFormat">{{ formattedText }}</template>
-        <IxIcon v-else-if="showSuccessIcon" class="ix-progress-success-icon" name="check" />
-        <IxIcon v-else-if="showExceptionIcon" class="ix-progress-exception-icon" name="close" />
+        <IxIcon v-else-if="showSuccessIcon" :class="`${prefixCls}-progress-success-icon`" name="check" />
+        <IxIcon v-else-if="showExceptionIcon" :class="`${prefixCls}-progress-exception-icon`" name="close" />
       </slot>
     </div>
   </div>
@@ -53,13 +52,14 @@ export default defineComponent({
   components: { IxIcon },
   props: convertProgressProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const progressConfig = useGlobalConfig('progress')
     const status = useStatus(props)
     const { formattedText, showSuccessIcon, showExceptionIcon, showFormat } = useInfo(props, progressConfig, status)
     const strokeWidth = computed(() => convertNumber(props.strokeWidth, defaultStrokeWidth))
     const isGradient = computed(() => isObject(props.strokeColor))
     const statusClass = useStatusClasses(status)
-    const linearGradientId = ref(`ix-progress-gradient-${uniqueId()}`)
+    const linearGradientId = ref(`${prefixCls}-progress-gradient-${uniqueId()}`)
     const calcSharedProperties = computed<CalcSharedProperties>(() => {
       const isCircle = props.type === 'circle'
       const radius = 50 - strokeWidth.value / 2
@@ -93,7 +93,11 @@ export default defineComponent({
       'stroke-width': props.percent ? strokeWidth.value : 0,
       d: pathString.value,
     }))
-    const circleClasses = computed(() => [statusClass.value, isGradient.value ? 'ix-progress-circle-gradient' : ''])
+    const circleClasses = computed(() => [
+      [`${prefixCls}-progress-circle`],
+      statusClass.value,
+      isGradient.value ? `${prefixCls}-progress-circle-gradient` : '',
+    ])
     const circleStyle = computed(() => ({
       width: `${props.width}px`,
       height: `${props.width}px`,
@@ -101,6 +105,7 @@ export default defineComponent({
     }))
 
     return {
+      prefixCls,
       calcSharedProperties,
       formattedText,
       showFormat,
@@ -170,6 +175,7 @@ function useTrailPathStyle(calcSharedProperties: ComputedRef<CalcSharedPropertie
 }
 
 function useCirclePath(calcSharedProperties: ComputedRef<CalcSharedProperties>, props: ConvertProgressProps) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const { gapDegree, len, isGradient, linearGradientId } = calcSharedProperties.value
     const strokeProgress = props.success.percent > 0 ? [props.success.percent, props.percent] : [props.percent]
@@ -181,8 +187,9 @@ function useCirclePath(calcSharedProperties: ComputedRef<CalcSharedProperties>, 
         return {
           stroke: isGradient && !hasSuccessPercent ? `url(#${linearGradientId})` : null,
           strokeClasses: [
-            !isGradient && hasSuccessPercent ? 'ix-progress-circle-success' : '',
-            isGradient ? '' : 'ix-progress-circle-bg',
+            [`${prefixCls}-progress-circle-path`],
+            !isGradient && hasSuccessPercent ? `${prefixCls}-progress-circle-success` : '',
+            isGradient ? '' : `${prefixCls}-progress-circle-bg`,
           ],
           strokePathStyle: {
             stroke: !isGradient ? (hasSuccessPercent ? successColor : (props.strokeColor as string)) : null,

--- a/packages/components/progress/src/Line.vue
+++ b/packages/components/progress/src/Line.vue
@@ -1,16 +1,20 @@
 <template>
-  <div class="ix-progress-line" :class="lineClasses">
-    <div class="ix-progress-outer">
-      <div class="ix-progress-inner">
-        <div v-if="success.percent" class="ix-progress-success-bg" :style="successStyle"></div>
-        <div class="ix-progress-bg" :style="bgStyle"></div>
+  <div :class="lineClasses">
+    <div :class="`${prefixCls}-progress-outer`">
+      <div :class="`${prefixCls}-progress-inner`">
+        <div v-if="success.percent" :class="`${prefixCls}-progress-success-bg`" :style="successStyle"></div>
+        <div :class="`${prefixCls}-progress-bg`" :style="bgStyle"></div>
       </div>
     </div>
-    <div v-if="!hideInfo" class="ix-progress-text">
+    <div v-if="!hideInfo" :class="`${prefixCls}-progress-text`">
       <slot>
         <template v-if="showFormat">{{ formattedText }}</template>
-        <IxIcon v-else-if="showSuccessIcon" class="ix-progress-success-icon" name="check-circle-filled" />
-        <IxIcon v-else-if="showExceptionIcon" class="ix-progress-exception-icon" name="close-circle-filled" />
+        <IxIcon v-else-if="showSuccessIcon" :class="`${prefixCls}-progress-success-icon`" name="check-circle-filled" />
+        <IxIcon
+          v-else-if="showExceptionIcon"
+          :class="`${prefixCls}-progress-exception-icon`"
+          name="close-circle-filled"
+        />
       </slot>
     </div>
   </div>
@@ -33,6 +37,7 @@ export default defineComponent({
   components: { IxIcon },
   props: convertProgressProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const progressConfig = useGlobalConfig('progress')
     const isSmallSize = useSmallSize(props, progressConfig)
     const strokeWidth = computed(() =>
@@ -48,10 +53,11 @@ export default defineComponent({
 
     const lineClasses = computed(() => {
       return [
+        `${prefixCls}-progress-line`,
         statusClass.value,
-        props.hideInfo ? '' : 'ix-progress-show-info',
-        props.strokeLinecap === 'round' ? 'ix-progress-round' : '',
-        isSmallSize.value ? 'ix-progress-small' : '',
+        props.hideInfo ? '' : `${prefixCls}-progress-show-info`,
+        props.strokeLinecap === 'round' ? `${prefixCls}-progress-round` : '',
+        isSmallSize.value ? `${prefixCls}-progress-small` : '',
       ]
     })
     const successStyle = computed(() => ({
@@ -66,6 +72,7 @@ export default defineComponent({
     }))
 
     return {
+      prefixCls,
       lineClasses,
       successStyle,
       bgStyle,

--- a/packages/components/progress/src/Progress.vue
+++ b/packages/components/progress/src/Progress.vue
@@ -1,10 +1,11 @@
 <template>
-  <component :is="tag" v-bind="$props" :percent="percent" :success="formattedSuccess" class="ix-progress">
+  <component :is="tag" v-bind="$props" :percent="percent" :success="formattedSuccess" :class="`${prefixCls}-progress`">
     <slot name="format" :percent="percent" :successPercent="successPercent"></slot>
   </component>
 </template>
 <script lang="ts">
 import { defineComponent, computed } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { progressProps } from './types'
 import Line from './Line.vue'
 import Circle from './Circle.vue'
@@ -14,12 +15,14 @@ export default defineComponent({
   name: 'IxProgress',
   props: progressProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const percent = computed(() => convertPercent(props.percent))
     const successPercent = computed(() => convertPercent(props.success?.percent))
     const tag = computed(() => (props.type === 'line' ? Line : Circle))
     const formattedSuccess = computed(() => ({ ...props.success, percent: successPercent.value }))
 
     return {
+      prefixCls,
       tag,
       percent,
       formattedSuccess,

--- a/packages/components/progress/src/useCommonLogic.ts
+++ b/packages/components/progress/src/useCommonLogic.ts
@@ -2,10 +2,11 @@ import { ConvertProgressProps, ProgressStatus, progressStatus } from './types'
 import { computed, ComputedRef } from 'vue'
 import { convertPercent, fullPercent } from './util'
 import { isFunction } from 'lodash-es'
-import { ProgressConfig } from '@idux/components/config'
+import { ProgressConfig, useGlobalConfig } from '@idux/components/config'
 
 export function useStatusClasses(status: ComputedRef<ProgressStatus>): ComputedRef<string> {
-  const prefix = 'ix-progress'
+  const { prefixCls: compPrefixCls } = useGlobalConfig('common')
+  const prefix = `${compPrefixCls}-progress`
   const statusClassMap: Record<ProgressStatus, string> = {
     normal: `${prefix}-status-normal`,
     exception: `${prefix}-status-exception`,

--- a/packages/components/radio/src/Radio.tsx
+++ b/packages/components/radio/src/Radio.tsx
@@ -14,6 +14,8 @@ export default defineComponent({
   name: 'IxRadio',
   props: radioProps,
   setup(props, { attrs, expose, slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const radioGroup = inject(radioGroupToken, null)
     const mergedName = computed(() => (attrs.name as string) ?? radioGroup?.props.name)
     const isButtoned = computed(() => props.buttoned ?? radioGroup?.props.buttoned)
@@ -26,14 +28,14 @@ export default defineComponent({
     return () => {
       const { autofocus, value, label } = props
       const labelNode = slots.default?.() ?? label
-      const labelWrapper = labelNode ? <span class="ix-radio-label">{labelNode}</span> : undefined
+      const labelWrapper = labelNode ? <span class={`${prefixCls}-radio-label`}>{labelNode}</span> : undefined
       return (
         <label class={classes.value} role="radio" aria-checked={isChecked.value} aria-disabled={isDisabled.value}>
-          <span class="ix-radio-input">
+          <span class={`${prefixCls}-radio-input`}>
             <input
               ref={inputRef}
               type="radio"
-              class="ix-radio-input-inner"
+              class={`${prefixCls}-radio-input-inner`}
               aria-hidden
               autofocus={autofocus}
               checked={isChecked.value}
@@ -44,7 +46,7 @@ export default defineComponent({
               onBlur={handleBlur}
               onFocus={handleFocus}
             ></input>
-            {isButtoned.value ? null : <span class="ix-radio-input-box"></span>}
+            {isButtoned.value ? null : <span class={`${prefixCls}-radio-input-box`}></span>}
           </span>
           {labelWrapper}
         </label>
@@ -105,17 +107,18 @@ const useClasses = (
   isDisabled: ComputedRef<boolean>,
 ) => {
   const config = useGlobalConfig('radio')
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const isButton = isButtoned.value
     const mode = props.mode ?? groupProps?.mode ?? 'default'
     const size = props.size ?? groupProps?.size ?? config.size
     return {
-      'ix-radio': true,
-      'ix-radio-button': isButton,
-      'ix-radio-checked': isChecked.value,
-      'ix-radio-disabled': isDisabled.value,
-      [`ix-radio-${mode}`]: isButton,
-      [`ix-radio-${size}`]: isButton,
+      [`${prefixCls}-radio`]: true,
+      [`${prefixCls}-radio-button`]: isButton,
+      [`${prefixCls}-radio-checked`]: isChecked.value,
+      [`${prefixCls}-radio-disabled`]: isDisabled.value,
+      [`${prefixCls}-radio-${mode}`]: isButton,
+      [`${prefixCls}-radio-${size}`]: isButton,
     }
   })
 }

--- a/packages/components/radio/src/RadioGroup.tsx
+++ b/packages/components/radio/src/RadioGroup.tsx
@@ -1,5 +1,6 @@
 import { defineComponent, provide } from 'vue'
 import { useValueAccessor } from '@idux/cdk/forms'
+import { useGlobalConfig } from '@idux/components/config'
 import { useFormItemRegister } from '@idux/components/form'
 import Radio from './Radio'
 import { radioGroupProps } from './types'
@@ -9,6 +10,7 @@ export default defineComponent({
   name: 'IxRadioGroup',
   props: radioGroupProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { accessor } = useValueAccessor()
     useFormItemRegister()
     provide(radioGroupToken, { props, accessor })
@@ -16,7 +18,7 @@ export default defineComponent({
     return () => {
       const { options } = props
       const children = options ? options.map(option => <Radio {...option}></Radio>) : slots.default?.()
-      return <div class="ix-radio-group">{children}</div>
+      return <div class={`${prefixCls}-radio-group`}>{children}</div>
     }
   },
 })

--- a/packages/components/rate/src/Rate.vue
+++ b/packages/components/rate/src/Rate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ix-rate-wrap">
+  <div :class="`${prefixCls}-rate-wrap`">
     <div
       v-for="(item, index) in rateCount"
       :key="index"
@@ -8,19 +8,19 @@
           if (el) starRefs[index] = el
         }
       "
-      class="ix-rate-item"
+      :class="`${prefixCls}-rate-item`"
       :title="getTooltip(index)"
       :style="{ cursor: disabled ? 'auto' : 'pointer' }"
       @mousemove="handleMouseEnter(item, $event)"
       @mouseleave="handleMouseLeave(item)"
       @click="handleClick(item, $event)"
     >
-      <div class="ix-rate-full">
-        <IxIcon :name="rateIcon" class="ix-rate-iconfont-main" :class="getIconClass(item)" />
+      <div :class="`${prefixCls}-rate-full`">
+        <IxIcon :name="rateIcon" :class="getIconClass(item)" />
       </div>
 
-      <div v-if="showDecimalIcon(item)" class="ix-rate-half">
-        <IxIcon :name="rateIcon" class="ix-rate-iconfont-main ix-rate-half-icon" />
+      <div v-if="showDecimalIcon(item)" :class="`${prefixCls}-rate-half`">
+        <IxIcon :name="rateIcon" :class="`${prefixCls}-rate-iconfont-main ${prefixCls}-rate-half-icon`" />
       </div>
     </div>
   </div>
@@ -45,6 +45,7 @@ export default defineComponent({
     const touchHalf = ref(false)
     const starRefs = ref([])
 
+    const { prefixCls } = useGlobalConfig('common')
     const rateGlobalConfig = useGlobalConfig('rate')
     const rateCount = computed(() => convertNumber(props.count ?? rateGlobalConfig.count))
     const rateIcon = computed(() => props.icon ?? rateGlobalConfig.icon)
@@ -62,7 +63,10 @@ export default defineComponent({
     })
 
     function getIconClass(item: number) {
-      return item <= score.value ? 'ix-rate-highlight' : 'ix-rate-normal'
+      return [
+        `${prefixCls}-rate-iconfont-main`,
+        item <= score.value ? `${prefixCls}-rate-highlight` : `${prefixCls}-rate-normal`,
+      ]
     }
 
     function showDecimalIcon(item: number) {
@@ -137,6 +141,7 @@ export default defineComponent({
     }
 
     return {
+      prefixCls,
       rateCount,
       rateIcon,
       getTooltip,

--- a/packages/components/result/src/Result.vue
+++ b/packages/components/result/src/Result.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="ix-result" :class="className">
-    <div class="ix-result-icon">
+  <div :class="className">
+    <div :class="`${prefixCls}-result-icon`">
       <slot name="icon">
         <IxIcon :name="currentIcon"></IxIcon>
       </slot>
     </div>
-    <div v-if="hasTitle || !!title" class="ix-result-title">
+    <div v-if="hasTitle || !!title" :class="`${prefixCls}-result-title`">
       <slot name="title">{{ title }}</slot>
     </div>
-    <div v-if="hasSubtitle || !!subtitle" class="ix-result-subtitle">
+    <div v-if="hasSubtitle || !!subtitle" :class="`${prefixCls}-result-subtitle`">
       <slot name="subtitle">{{ subtitle }}</slot>
     </div>
-    <div v-if="hasExtra" class="ix-result-extra">
+    <div v-if="hasExtra" :class="`${prefixCls}-result-extra`">
       <slot name="extra" />
     </div>
-    <div v-if="hasContent" class="ix-result-content">
+    <div v-if="hasContent" :class="`${prefixCls}-result-content`">
       <slot />
     </div>
   </div>
@@ -42,6 +42,7 @@ export default defineComponent({
   components: { IxIcon },
   props: resultProps,
   setup(props, { slots }: SetupContext) {
+    const { prefixCls } = useGlobalConfig('common')
     const resultConfig = useGlobalConfig('result')
     const className = useClassName(props, resultConfig)
     const hasTitle = useSlot(slots, 'title')
@@ -50,15 +51,16 @@ export default defineComponent({
     const hasContent = useSlot(slots)
     const currentIcon = useIcon(props, resultConfig)
 
-    return { className, hasTitle, hasSubtitle, hasExtra, hasContent, currentIcon }
+    return { prefixCls, className, hasTitle, hasSubtitle, hasExtra, hasContent, currentIcon }
   },
 })
 
 function useClassName(props: ResultProps, config: ResultConfig) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const status = props.status ?? config.status
 
-    return [`ix-result-${status}`]
+    return [`${prefixCls}-result`, `${prefixCls}-result-${status}`]
   })
 }
 

--- a/packages/components/select/src/Select.vue
+++ b/packages/components/select/src/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="triggerRef" v-click-outside="onClickOutside" :class="classes" @click="onClick">
-    <div class="ix-select-selector" @keydown="onKeyDown">
+    <div :class="`${prefixCls}-select-selector`" @keydown="onKeyDown">
       <SelectItem
         v-for="item in selectedItems"
         v-show="showItem"
@@ -28,17 +28,21 @@
         @focus="onFocus"
         @blur="onBlur"
       />
-      <div v-if="showPlaceholder" class="ix-select-placeholder">
+      <div v-if="showPlaceholder" :class="`${prefixCls}-select-placeholder`">
         <slot name="placeholder">{{ placeholder }}</slot>
       </div>
     </div>
-    <div v-if="suffix || $slots.suffix || !multiple" class="ix-select-suffix">
+    <div v-if="suffix || $slots.suffix || !multiple" :class="`${prefixCls}-select-suffix`">
       <slot name="suffix"><IxIcon :name="suffixIcon" /></slot>
     </div>
-    <div v-if="clearable && !disabled$$ && selectedItems.length" class="ix-select-clear" @click.stop="onClear">
+    <div
+      v-if="clearable && !disabled$$ && selectedItems.length"
+      :class="`${prefixCls}-select-clear`"
+      @click.stop="onClear"
+    >
       <IxIcon name="close-circle" />
     </div>
-    <IxPortal target="ix-select-container">
+    <IxPortal :target="`${prefixCls}-select-container`">
       <transition>
         <SelectOptionContainer
           v-show="visibility"
@@ -96,6 +100,7 @@ export default defineComponent({
     'inputChange',
   ],
   setup(props, { emit }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('select')
     const selectedOptions = ref<SelectOptionProps[]>([])
 
@@ -162,6 +167,7 @@ export default defineComponent({
     })
 
     return {
+      prefixCls,
       disabled$$,
       focus,
       blur,

--- a/packages/components/select/src/SelectInput.vue
+++ b/packages/components/select/src/SelectInput.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="ix-select-input" :style="{ width: inputWidth }">
+  <div :class="`${prefixCls}-select-input`" :style="{ width: inputWidth }">
     <input
       ref="inputRef"
-      class="ix-select-input-inner"
+      :class="`${prefixCls}-select-input-inner`"
       :value="value"
       autocomplete="off"
       :autofocus="autofocus"
@@ -14,12 +14,13 @@
       @focus="$emit('focus', $event)"
       @blur="$emit('blur', $event)"
     />
-    <span v-if="showMirror" ref="mirrorRef" class="ix-select-input-mirror" aria-hidden="true"></span>
+    <span v-if="showMirror" ref="mirrorRef" :class="`${prefixCls}-select-input-mirror`" aria-hidden="true"></span>
   </div>
 </template>
 <script lang="ts">
 import { defineComponent, onMounted, ref, watch } from 'vue'
 import { IxPropTypes } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 
 export default defineComponent({
   props: {
@@ -32,6 +33,7 @@ export default defineComponent({
   },
   emits: ['compositionstart', 'compositionend', 'input', 'change', 'focus', 'blur'],
   setup(props, { emit }) {
+    const { prefixCls } = useGlobalConfig('common')
     const inputWidth = ref('')
     const inputRef = ref(null as unknown as HTMLInputElement)
     const mirrorRef = ref(null as unknown as HTMLInputElement)
@@ -96,7 +98,18 @@ export default defineComponent({
       syncMirrorWidth()
     })
 
-    return { inputWidth, inputRef, mirrorRef, onCompositionStart, onCompositionEnd, onInput, focus, blur, clear }
+    return {
+      prefixCls,
+      inputWidth,
+      inputRef,
+      mirrorRef,
+      onCompositionStart,
+      onCompositionEnd,
+      onInput,
+      focus,
+      blur,
+      clear,
+    }
   },
 })
 </script>

--- a/packages/components/select/src/SelectItem.vue
+++ b/packages/components/select/src/SelectItem.vue
@@ -1,15 +1,16 @@
 <template>
-  <div class="ix-select-item" :class="{ 'ix-select-item-disabled': disabled }">
-    <span class="ix-select-item-label">
+  <div :class="{ [`${prefixCls}-select-item`]: true, [`${prefixCls}-select-item-disabled`]: disabled }">
+    <span :class="`${prefixCls}-select-item-label`">
       <slot> {{ label }} </slot>
     </span>
-    <span v-if="removeable && !disabled" class="ix-select-item-remove" @click.stop="$emit('delete')">
+    <span v-if="removeable && !disabled" :class="`${prefixCls}-select-item-remove`" @click.stop="$emit('delete')">
       <IxIcon name="close" />
     </span>
   </div>
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { IxPropTypes } from '@idux/cdk/utils'
 
@@ -21,5 +22,12 @@ export default defineComponent({
     label: IxPropTypes.string,
   },
   emits: ['delete'],
+  setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
+    return {
+      prefixCls,
+    }
+  },
 })
 </script>

--- a/packages/components/select/src/SelectOption.vue
+++ b/packages/components/select/src/SelectOption.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-show="visible" :class="classes" @mouseenter="onMouseEnter" @click.stop="onClick">
-    <span v-if="showCheckbox" class="ix-option-checkbox">
+    <span v-if="showCheckbox" :class="`${prefixCls}-option-checkbox`">
       <IxCheckbox :checked="selected" :disabled="disabled" readonly />
     </span>
-    <span class="ix-option-label">
+    <span :class="`${prefixCls}-option-label`">
       <slot>{{ label }}</slot>
     </span>
   </div>
@@ -13,6 +13,7 @@ import type { SelectOptionProps, SelectFilterFn } from './types'
 
 import { computed, defineComponent, inject, nextTick, onUnmounted, watch } from 'vue'
 import { isFunction } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { selectOptionProps } from './types'
 import { selectToken, visibleChangeToken } from './token'
@@ -26,6 +27,8 @@ export default defineComponent({
   components: { IxCheckbox },
   props: selectOptionProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const {
       selectProps,
       inputValue,
@@ -55,10 +58,10 @@ export default defineComponent({
     const classes = computed(() => {
       const _disabled = props.disabled
       return {
-        'ix-option': true,
-        'ix-option-disabled': _disabled,
-        'ix-option-active': !_disabled && active.value,
-        'ix-option-selected': !_disabled && selected.value,
+        [`${prefixCls}-option`]: true,
+        [`${prefixCls}-option-disabled`]: _disabled,
+        [`${prefixCls}-option-active`]: !_disabled && active.value,
+        [`${prefixCls}-option-selected`]: !_disabled && selected.value,
       }
     })
 
@@ -84,7 +87,7 @@ export default defineComponent({
       }
     })
 
-    return { visible, classes, showCheckbox, selected, onMouseEnter, onClick }
+    return { prefixCls, visible, classes, showCheckbox, selected, onMouseEnter, onClick }
   },
 })
 </script>

--- a/packages/components/select/src/SelectOptionContainer.vue
+++ b/packages/components/select/src/SelectOptionContainer.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="ix-option-container">
+  <div :class="`${prefixCls}-option-container`">
     <template v-for="option in options" :key="option.value">
       <SelectOptionGroup v-if="option.children" :label="option.label" :options="option.children" />
       <SelectOption v-else :disabled="option.disabled" :label="option.label" :value="option.value" />
     </template>
     <slot v-if="!options.length" />
-    <div v-show="isEmpty" class="ix-option-container-empty">
+    <div v-show="isEmpty" :class="`${prefixCls}-option-container-empty`">
       <slot name="empty">
         <IxEmpty :description="empty" />
       </slot>
@@ -16,6 +16,7 @@
 <script lang="ts">
 import { computed, defineComponent, provide, ref } from 'vue'
 import { IxPropTypes } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxEmpty } from '@idux/components/empty'
 import SelectOption from './SelectOption.vue'
 import SelectOptionGroup from './SelectOptionGroup.vue'
@@ -28,6 +29,7 @@ export default defineComponent({
     empty: IxPropTypes.string,
   },
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const showItemCount = ref(0)
     const isEmpty = computed(() => showItemCount.value === 0)
 
@@ -40,7 +42,7 @@ export default defineComponent({
     }
     provide(visibleChangeToken, visibleChange)
 
-    return { isEmpty }
+    return { prefixCls, isEmpty }
   },
 })
 </script>

--- a/packages/components/select/src/SelectOptionGroup.vue
+++ b/packages/components/select/src/SelectOptionGroup.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-show="visible" class="ix-option-group">
-    <span class="ix-option-group-label">
+  <div v-show="visible" :class="`${prefixCls}-option-group`">
+    <span :class="`${prefixCls}-option-group-label`">
       <slot name="label">{{ label }}</slot>
     </span>
   </div>
@@ -9,6 +9,7 @@
 </template>
 <script lang="ts">
 import { computed, defineComponent, inject, nextTick, onUnmounted, provide, ref, watch } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import SelectOption from './SelectOption.vue'
 import { selectOptionGroupProps } from './types'
 import { visibleChangeToken } from './token'
@@ -18,6 +19,7 @@ export default defineComponent({
   components: { SelectOption },
   props: selectOptionGroupProps,
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const showItemCount = ref(0)
     const visible = computed(() => showItemCount.value > 0)
 
@@ -38,7 +40,7 @@ export default defineComponent({
       }
     })
 
-    return { visible }
+    return { prefixCls, visible }
   },
 })
 </script>

--- a/packages/components/select/src/useSelect.ts
+++ b/packages/components/select/src/useSelect.ts
@@ -9,6 +9,7 @@ import { computed, getCurrentInstance, onMounted, onUnmounted, provide, ref, wat
 import { useOverlay } from '@idux/cdk/overlay'
 import { offResize, onResize, convertArray } from '@idux/cdk/utils'
 import { useValueAccessor } from '@idux/cdk/forms'
+import { useGlobalConfig } from '@idux/components/config'
 import { useFormItemRegister } from '@idux/components/form'
 import { selectToken } from './token'
 
@@ -236,6 +237,7 @@ export const useSelectClasses = (
   isActive: Ref<boolean>,
   disabled: ComputedRef<boolean>,
 ): ComputedRef<Record<string, boolean>> => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const multiple = props.multiple
     const borderless = props.borderless ?? config.borderless
@@ -245,17 +247,17 @@ export const useSelectClasses = (
     const suffix = props.suffix ?? config.suffix
     const _disabled = disabled.value
     return {
-      'ix-select': true,
-      'ix-select-single': !multiple,
-      'ix-select-multiple': multiple,
-      'ix-select-opened': visibility.value,
-      'ix-select-active': isActive.value,
-      'ix-select-borderless': borderless,
-      'ix-select-disabled': _disabled,
-      'ix-select-clearable': !_disabled && clearable,
-      'ix-select-searchable': !_disabled && (searchable || multiple),
-      'ix-select-show-suffix': !!suffix || !multiple,
-      [`ix-select-${size}`]: true,
+      [`${prefixCls}-select`]: true,
+      [`${prefixCls}-select-single`]: !multiple,
+      [`${prefixCls}-select-multiple`]: multiple,
+      [`${prefixCls}-select-opened`]: visibility.value,
+      [`${prefixCls}-select-active`]: isActive.value,
+      [`${prefixCls}-select-borderless`]: borderless,
+      [`${prefixCls}-select-disabled`]: _disabled,
+      [`${prefixCls}-select-clearable`]: !_disabled && clearable,
+      [`${prefixCls}-select-searchable`]: !_disabled && (searchable || multiple),
+      [`${prefixCls}-select-show-suffix`]: !!suffix || !multiple,
+      [`${prefixCls}-select-${size}`]: true,
     }
   })
 }

--- a/packages/components/space/src/Space.tsx
+++ b/packages/components/space/src/Space.tsx
@@ -45,12 +45,13 @@ export default defineComponent({
 })
 
 const useClasses = (props: SpaceProps, config: SpaceConfig) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-space': true,
-      'ix-space-wrap': props.wrap ?? config.wrap,
-      [`ix-space-${props.align}`]: true,
-      [`ix-space-${props.direction}`]: true,
+      [`${prefixCls}-space`]: true,
+      [`${prefixCls}-space-wrap`]: props.wrap ?? config.wrap,
+      [`${prefixCls}-space-${props.align}`]: true,
+      [`${prefixCls}-space-${props.direction}`]: true,
     }
   })
 }
@@ -63,13 +64,14 @@ interface SpaceItem {
 }
 
 const useChildren = (children: VNode[], size: SpaceSize | SpaceSize[], direction: SpaceDirection) => {
+  const { prefixCls } = useGlobalConfig('common')
   const lastIndex = children.length - 1
   const sizes = Array.isArray(size) ? size : Array(lastIndex).fill(size)
   if (__DEV__ && lastIndex !== sizes.length) {
     Logger.warn('components/space', 'The number of split elements is inconsistent with the length of the size array')
   }
   return children.map((child, index) => {
-    const currNode: SpaceItem = { node: child, itemClass: ['ix-space-item'] }
+    const currNode: SpaceItem = { node: child, itemClass: [`${prefixCls}-space-item`] }
     const currSize = sizes[index]
 
     if (!currSize) {
@@ -80,8 +82,8 @@ const useChildren = (children: VNode[], size: SpaceSize | SpaceSize[], direction
       const marginDirection = direction === 'vertical' ? 'marginBottom' : 'marginRight'
       currNode.style = { [marginDirection]: `${currSize}px` }
     } else {
-      currNode.itemClass.push(`ix-space-item-${currSize}`)
-      currNode.splitClass = `ix-space-split-${currSize}`
+      currNode.itemClass.push(`${prefixCls}-space-item-${currSize}`)
+      currNode.splitClass = `${prefixCls}-space-split-${currSize}`
     }
 
     return currNode

--- a/packages/components/spin/src/Spin.tsx
+++ b/packages/components/spin/src/Spin.tsx
@@ -28,10 +28,11 @@ export default defineComponent({
     }
   },
   render() {
+    const { prefixCls } = useGlobalConfig('common')
     const { spinning, spinnerClassName, containerClassName, icon$$, tip$$, $slots } = this
 
     return (
-      <div class="ix-spin">
+      <div class={`${prefixCls}-spin`}>
         {renderSpinner(spinning, spinnerClassName, icon$$, $slots.icon, tip$$)}
         {renderContent($slots.default, containerClassName)}
       </div>
@@ -40,17 +41,22 @@ export default defineComponent({
 })
 
 const useClasses = (props: SpinProps, config: SpinConfig, hasDefaultSlot: ComputedRef<boolean>) => {
+  const { prefixCls } = useGlobalConfig('common')
   const spinnerClassName = computed(() => {
     const size = props.size ?? config.size
     const tipAlign = props.tipAlign ?? config.tipAlign
-    return ['ix-spin-spinner', `ix-spin-spinner-tip-${tipAlign}`, size !== 'medium' ? `ix-spin-spinner-${size}` : '']
+    return [
+      `${prefixCls}-spin-spinner`,
+      `${prefixCls}-spin-spinner-tip-${tipAlign}`,
+      size !== 'medium' ? `${prefixCls}-spin-spinner-${size}` : '',
+    ]
   })
 
   const containerClassName = computed(() => {
     if (!hasDefaultSlot.value) {
       return []
     }
-    return ['ix-spin-container', props.spinning ? 'ix-spin-container-blur' : '']
+    return [`${prefixCls}-spin-container`, props.spinning ? `${prefixCls}-spin-container-blur` : '']
   })
 
   return {
@@ -69,11 +75,12 @@ const renderSpinner = (
   if (!spinning) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
   const iconNode = iconSlot ? iconSlot() : <IxIcon name={icon} />
   const tipNode = renderTip(tip)
   return (
     <div class={spinnerClassName}>
-      <div class="ix-spin-spinner-icon">{iconNode}</div>
+      <div class={`${prefixCls}-spin-spinner-icon`}>{iconNode}</div>
       {tipNode}
     </div>
   )
@@ -83,8 +90,9 @@ const renderTip = (tip: string | undefined) => {
   if (!tip) {
     return null
   }
+  const { prefixCls } = useGlobalConfig('common')
 
-  return <div class="ix-spin-spinner-tip">{tip}</div>
+  return <div class={`${prefixCls}-spin-spinner-tip`}>{tip}</div>
 }
 
 const renderContent = (defaultSlot: Slot | undefined, containerClassName: string[]) => {

--- a/packages/components/statistic/src/Statistic.vue
+++ b/packages/components/statistic/src/Statistic.vue
@@ -1,21 +1,23 @@
 <template>
-  <div class="ix-statistic">
-    <div v-if="title || $slots.title" class="ix-statistic-title">
+  <div :class="`${prefixCls}-statistic`">
+    <div v-if="title || $slots.title" :class="`${prefixCls}-statistic-title`">
       <slot name="title">{{ title }}</slot>
     </div>
-    <div class="ix-statistic-content">
-      <span v-if="prefix || $slots.prefix" class="ix-statistic-content-prefix">
+    <div :class="`${prefixCls}-statistic-content`">
+      <span v-if="prefix || $slots.prefix" :class="`${prefixCls}-statistic-content-prefix`">
         <slot name="prefix">{{ prefix }}</slot>
       </span>
-      <span class="ix-statistic-content-value">
+      <span :class="`${prefixCls}-statistic-content-value`">
         <slot>
-          <span class="ix-statistic-content-value-int">{{ formatedValue.int || formatedValue.value }}</span>
-          <span v-if="formatedValue.decimal" class="ix-statistic-content-value-decimal">
+          <span :class="`${prefixCls}-statistic-content-value-int`">{{
+            formatedValue.int || formatedValue.value
+          }}</span>
+          <span v-if="formatedValue.decimal" :class="`${prefixCls}-statistic-content-value-decimal`">
             {{ formatedValue.decimal }}
           </span>
         </slot>
       </span>
-      <span v-if="suffix || $slots.suffix" class="ix-statistic-content-suffix">
+      <span v-if="suffix || $slots.suffix" :class="`${prefixCls}-statistic-content-suffix`">
         <slot name="suffix">{{ suffix }}</slot>
       </span>
     </div>
@@ -33,10 +35,12 @@ export default defineComponent({
   name: 'IxStatistic',
   props: statisticProps,
   setup(props) {
+    const { prefixCls } = useGlobalConfig('common')
     const statisticConfig = useGlobalConfig('statistic')
     const formatedValue = useFomat(props, statisticConfig)
 
     return {
+      prefixCls,
       formatedValue,
     }
   },

--- a/packages/components/stepper/src/Stepper.tsx
+++ b/packages/components/stepper/src/Stepper.tsx
@@ -29,16 +29,17 @@ export default defineComponent({
 })
 
 function useClasses(props: StepperProps, slots: Slots, config: StepperConfig) {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const { direction, size = config.size, placement, progressDot } = props
 
     return {
-      'ix-stepper': true,
-      [`ix-stepper-${direction}`]: true,
-      [`ix-stepper-${size}`]: true,
-      'ix-stepper-vertical-placement': placement === 'vertical',
-      'ix-stepper-vertical': direction === 'vertical',
-      'ix-stepper-dot': progressDot || hasSlot(slots, 'progressDot'),
+      [`${prefixCls}-stepper`]: true,
+      [`${prefixCls}-stepper-${direction}`]: true,
+      [`${prefixCls}-stepper-${size}`]: true,
+      [`${prefixCls}-stepper-vertical-placement`]: placement === 'vertical',
+      [`${prefixCls}-stepper-vertical`]: direction === 'vertical',
+      [`${prefixCls}-stepper-dot`]: progressDot || hasSlot(slots, 'progressDot'),
     }
   })
 }

--- a/packages/components/stepper/src/StepperItem.tsx
+++ b/packages/components/stepper/src/StepperItem.tsx
@@ -4,6 +4,7 @@ import type { StepperProps, StepperItemProps, StepperStatus } from './types'
 import { defineComponent, inject, computed } from 'vue'
 import { isBoolean, isNil } from 'lodash-es'
 import { hasSlot } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { stepperToken } from './token'
 import { stepperItemProps } from './types'
@@ -12,6 +13,8 @@ export default defineComponent({
   name: 'IxStepperItem',
   props: stepperItemProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     // stepsContext must exist
     const { props: parentProps, slots: parentSlots, currActive } = inject(stepperToken)!
     const isActive = computed(() => currActive.value === props.index)
@@ -42,7 +45,7 @@ export default defineComponent({
         headContent = renderHeadProcessDot(props, progressDot, status)
       } else {
         const _icon = renderHeadIcon(props, slots.icon, status)
-        headContent = _icon ?? <span class="ix-stepper-item-head-text">{props.index + 1}</span>
+        headContent = _icon ?? <span class={`${prefixCls}-stepper-item-head-text`}>{props.index + 1}</span>
       }
 
       const title = slots.title?.() ?? props.title
@@ -50,14 +53,14 @@ export default defineComponent({
       const description = slots.description?.() ?? props.description
       return (
         <div class={classes.value} onClick={onClick}>
-          <div class="ix-stepper-item-tail"></div>
-          <div class="ix-stepper-item-head">{headContent}</div>
-          <div class="ix-stepper-item-content">
-            <div class="ix-stepper-item-title">
+          <div class={`${prefixCls}-stepper-item-tail`}></div>
+          <div class={`${prefixCls}-stepper-item-head`}>{headContent}</div>
+          <div class={`${prefixCls}-stepper-item-content`}>
+            <div class={`${prefixCls}-stepper-item-title`}>
               {title}
-              <span class="ix-stepper-item-subtitle">{subTitle}</span>
+              <span class={`${prefixCls}-stepper-item-subtitle`}>{subTitle}</span>
             </div>
-            <div class="ix-stepper-item-description">{description}</div>
+            <div class={`${prefixCls}-stepper-item-description`}>{description}</div>
           </div>
         </div>
       )
@@ -90,14 +93,15 @@ const useClasses = (
   status: ComputedRef<StepperStatus>,
   hasIcon: ComputedRef<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const { disabled, icon } = props
     return {
-      'ix-stepper-item': true,
-      'ix-stepper-item-disabled': disabled,
-      'ix-stepper-item-clickable': !disabled && parentProps.clickable,
-      'ix-stepper-item-custom': icon || hasIcon.value,
-      [`ix-stepper-item-${status.value!}`]: true,
+      [`${prefixCls}-stepper-item`]: true,
+      [`${prefixCls}-stepper-item-disabled`]: disabled,
+      [`${prefixCls}-stepper-item-clickable`]: !disabled && parentProps.clickable,
+      [`${prefixCls}-stepper-item-custom`]: icon || hasIcon.value,
+      [`${prefixCls}-stepper-item-${status.value!}`]: true,
     }
   })
 }
@@ -138,18 +142,25 @@ function useDeg(parentProps: StepperProps, status: ComputedRef<StepperStatus>) {
 }
 
 const renderHeadPercent = (props: StepperItemProps, deg: ComputedRef<Deg>) => {
+  const { prefixCls } = useGlobalConfig('common')
   const { left, right } = deg.value
   return (
     <>
-      <div class="ix-stepper-item-head-percent">
-        <div class="ix-stepper-item-head-percent-right">
-          <div class="ix-stepper-item-head-percent-circle" style={'transform: rotate(' + right + 'deg)'}></div>
+      <div class={`${prefixCls}-stepper-item-head-percent`}>
+        <div class={`${prefixCls}-stepper-item-head-percent-right`}>
+          <div
+            class={`${prefixCls}-stepper-item-head-percent-circle`}
+            style={'transform: rotate(' + right + 'deg)'}
+          ></div>
         </div>
-        <div class="ix-stepper-item-head-percent-left">
-          <div class="ix-stepper-item-head-percent-circle" style={'transform: rotate(' + left + 'deg)'}></div>
+        <div class={`${prefixCls}-stepper-item-head-percent-left`}>
+          <div
+            class={`${prefixCls}-stepper-item-head-percent-circle`}
+            style={'transform: rotate(' + left + 'deg)'}
+          ></div>
         </div>
       </div>
-      <span class="ix-stepper-item-head-text">{props.index + 1}</span>
+      <span class={`${prefixCls}-stepper-item-head-text`}>{props.index + 1}</span>
     </>
   )
 }
@@ -160,7 +171,8 @@ const renderHeadProcessDot = (
   status: ComputedRef<StepperStatus>,
 ) => {
   if (isBoolean(progressDot.value)) {
-    return <span class="ix-stepper-item-head-dot"></span>
+    const { prefixCls } = useGlobalConfig('common')
+    return <span class={`${prefixCls}-stepper-item-head-dot`}></span>
   }
   return progressDot.value({ index: props.index, status: status.value })
 }
@@ -171,6 +183,7 @@ const statusIconMap: Partial<Record<StepperStatus, string>> = {
 }
 
 const renderHeadIcon = (props: StepperItemProps, iconSlot: Slot | undefined, status: ComputedRef<StepperStatus>) => {
+  const { prefixCls } = useGlobalConfig('common')
   let iconNode: VNodeTypes | undefined
 
   if (iconSlot) {
@@ -182,5 +195,5 @@ const renderHeadIcon = (props: StepperItemProps, iconSlot: Slot | undefined, sta
     }
   }
 
-  return iconNode ? <span class="ix-stepper-item-head-icon">{iconNode}</span> : null
+  return iconNode ? <span class={`${prefixCls}-stepper-item-head-icon`}>{iconNode}</span> : null
 }

--- a/packages/components/style/motion/fade.less
+++ b/packages/components/style/motion/fade.less
@@ -1,15 +1,15 @@
 @import '../variable/animation.less';
 
 .fade-motion(@className, @duration: @transition-duration-base) {
-  .ix-@{className}-enter-active,
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-enter-active,
+  .@{idux-prefix}-@{className}-leave-active {
     transition-property: opacity;
     transition-duration: @duration;
     transition-timing-function: linear;
   }
 
-  .ix-@{className}-enter-from,
-  .ix-@{className}-leave-to {
+  .@{idux-prefix}-@{className}-enter-from,
+  .@{idux-prefix}-@{className}-leave-to {
     opacity: 0;
   }
 }

--- a/packages/components/style/motion/move.less
+++ b/packages/components/style/motion/move.less
@@ -1,22 +1,22 @@
 @import '../variable/animation.less';
 
 .move-motion(@className, @translate, @duration: @transition-duration-base) {
-  .ix-@{className}-enter-active,
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-enter-active,
+  .@{idux-prefix}-@{className}-leave-active {
     transition-property: transform, opacity;
     transition-duration: @duration;
   }
 
-  .ix-@{className}-enter-active {
+  .@{idux-prefix}-@{className}-enter-active {
     transition-timing-function: @ease-out-circ;
   }
 
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-leave-active {
     transition-timing-function: @ease-in-circ;
   }
 
-  .ix-@{className}-enter-from,
-  .ix-@{className}-leave-to {
+  .@{idux-prefix}-@{className}-enter-from,
+  .@{idux-prefix}-@{className}-leave-to {
     transform: @translate;
     opacity: 0;
   }

--- a/packages/components/style/motion/slide.less
+++ b/packages/components/style/motion/slide.less
@@ -1,23 +1,23 @@
 @import '../variable/animation.less';
 
 .slide-motion(@className, @origin, @scale, @duration: @transition-duration-base) {
-  .ix-@{className}-enter-active,
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-enter-active,
+  .@{idux-prefix}-@{className}-leave-active {
     transform-origin: @origin;
     transition-property: transform, opacity;
     transition-duration: @duration;
   }
 
-  .ix-@{className}-enter-active {
+  .@{idux-prefix}-@{className}-enter-active {
     transition-timing-function: @ease-out-quint;
   }
 
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-leave-active {
     transition-timing-function: @ease-in-quint;
   }
 
-  .ix-@{className}-enter-from,
-  .ix-@{className}-leave-to {
+  .@{idux-prefix}-@{className}-enter-from,
+  .@{idux-prefix}-@{className}-leave-to {
     transform: @scale;
     opacity: 0;
   }

--- a/packages/components/style/motion/zoom.less
+++ b/packages/components/style/motion/zoom.less
@@ -1,23 +1,23 @@
 @import '../variable/animation.less';
 
 .zoom-motion(@className, @origin: @scale-origin-zoom-center, @scale: @scale-zoom-big, @duration: @transition-duration-base) {
-  .ix-@{className}-enter-active,
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-enter-active,
+  .@{idux-prefix}-@{className}-leave-active {
     transform-origin: @origin;
     transition-property: opacity, transform;
     transition-duration: @duration;
   }
 
-  .ix-@{className}-enter-active {
+  .@{idux-prefix}-@{className}-enter-active {
     transition-timing-function: @ease-out-circ;
   }
 
-  .ix-@{className}-leave-active {
+  .@{idux-prefix}-@{className}-leave-active {
     transition-timing-function: @ease-in-out-circ;
   }
 
-  .ix-@{className}-enter-from,
-  .ix-@{className}-leave-to {
+  .@{idux-prefix}-@{className}-enter-from,
+  .@{idux-prefix}-@{className}-leave-to {
     opacity: 0;
     transform: ~'scale(@{scale})';
   }

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -2,6 +2,7 @@ import { computed, defineComponent, ref, ComputedRef, onMounted } from 'vue'
 import { IxIcon } from '@idux/components/icon'
 import { useValueAccessor } from '@idux/cdk/forms'
 import { callEmit } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { useFormItemRegister } from '@idux/components/form'
 import { SwitchProps, switchProps } from './types'
 
@@ -31,6 +32,7 @@ export default defineComponent({
     }
   },
   render() {
+    const { prefixCls } = useGlobalConfig('common')
     const { loading, checkedChildren, unCheckedChildren, isChecked, classes, handleClick, handleBlur, handleMouseup } =
       this
     const checkedChild = this.$slots.checkedChildren ? this.$slots.checkedChildren() : checkedChildren
@@ -45,11 +47,11 @@ export default defineComponent({
         onBlur={handleBlur}
       >
         {loading && (
-          <div class="ix-switch-loading-icon">
+          <div class={`${prefixCls}-switch-loading-icon`}>
             <IxIcon name="loading" />
           </div>
         )}
-        <div class="ix-switch-inner">{isChecked ? checkedChild : unCheckedChild}</div>
+        <div class={`${prefixCls}-switch-inner`}>{isChecked ? checkedChild : unCheckedChild}</div>
       </button>
     )
   },
@@ -87,13 +89,14 @@ const useClasses = (
   isDisabled: ComputedRef<boolean>,
   isSmallSize: ComputedRef<boolean>,
 ) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     return {
-      'ix-switch': true,
-      'ix-switch-loading': props.loading,
-      'ix-switch-checked': isChecked.value,
-      'ix-switch-disabled': isDisabled.value,
-      'ix-switch-small': isSmallSize.value,
+      [`${prefixCls}-switch`]: true,
+      [`${prefixCls}-switch-loading`]: props.loading,
+      [`${prefixCls}-switch-checked`]: isChecked.value,
+      [`${prefixCls}-switch-disabled`]: isDisabled.value,
+      [`${prefixCls}-switch-small`]: isSmallSize.value,
     }
   })
 }

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -27,6 +27,7 @@ export default defineComponent({
   name: 'IxTable',
   props: tableProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('table')
     const locale = getLocale('table')
     const tags = useTags(props)
@@ -74,7 +75,7 @@ export default defineComponent({
       const children = [header, paginationTop, <MainTable />, paginationBottom, footer]
       const spinProps = covertSpinProps(props.spin)
       const spinWrapper = spinProps ? <IxSpin {...spinProps}>{children}</IxSpin> : children
-      return <div class="ix-table">{spinWrapper}</div>
+      return <div class={`${prefixCls}-table`}>{spinWrapper}</div>
     }
   },
 })

--- a/packages/components/table/src/main/ColGroup.tsx
+++ b/packages/components/table/src/main/ColGroup.tsx
@@ -4,6 +4,7 @@ import type { TableColumnSelectableOption } from '../types'
 
 import { computed, defineComponent, inject } from 'vue'
 import { convertCssPixel } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { TABLE_TOKEN } from '../token'
 
 export default defineComponent({
@@ -42,12 +43,13 @@ function renderCol(
   column: TableColumnMerged,
   width?: number,
 ) {
+  const { prefixCls } = useGlobalConfig('common')
   let className: string | undefined
   if ('type' in column) {
     const type = column.type
-    className = `ix-table-col-${type}`
+    className = `${prefixCls}-table-col-${type}`
     if (type === 'selectable' && mergedSelectableOptions.value) {
-      className += ' ix-table-selectable-with-options'
+      className += ` ${prefixCls}-table-selectable-with-options`
     }
   }
   const mergedWidth = width ?? column.width

--- a/packages/components/table/src/main/FixedHolder.tsx
+++ b/packages/components/table/src/main/FixedHolder.tsx
@@ -2,11 +2,13 @@ import type { Ref, StyleValue } from 'vue'
 
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted } from 'vue'
 import { off, on } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { TABLE_TOKEN } from '../token'
 import ColGroup from './ColGroup'
 
 export default defineComponent({
   setup(_, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const { scrollHeadRef, handleScroll, scrollX, flattedData, isSticky, mergedSticky, columnWidths } =
       inject(TABLE_TOKEN)!
 
@@ -16,8 +18,8 @@ export default defineComponent({
     const hasData = computed(() => flattedData.value.length > 0)
     const classes = computed(() => {
       return {
-        'ix-table-fixed-holder': true,
-        'ix-table-sticky-holder': isSticky.value,
+        [`${prefixCls}-table-fixed-holder`]: true,
+        [`${prefixCls}-table-sticky-holder`]: isSticky.value,
       }
     })
     const style = computed<StyleValue>(() => {

--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -6,6 +6,7 @@ import type { Key } from '../types'
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted, provide, ref, watch, watchEffect } from 'vue'
 import { IxVirtualScroll } from '@idux/cdk/scroll'
 import { convertElement, isVisibleElement, offResize, onResize } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { tableBodyToken, TABLE_TOKEN } from '../token'
 import ColGroup from './ColGroup'
 import Head from './head/Head'
@@ -17,6 +18,7 @@ import StickyScroll from './StickyScroll'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const {
       props,
       config,
@@ -84,7 +86,8 @@ export default defineComponent({
     onBeforeUnmount(() => offResize(mainTableRef.value, handleWrapperResize))
 
     const classes = computed(() => {
-      const prefixCls = 'ix-table'
+      const { prefixCls: compPrefixCls } = useGlobalConfig('common')
+      const prefixCls = [`${compPrefixCls}-table`]
       const { borderless = config.borderless, size = config.size } = props
       return {
         [`${prefixCls}-container`]: true,
@@ -159,7 +162,12 @@ export default defineComponent({
           )
         } else {
           tableBody = (
-            <div ref={scrollBodyRef} class="ix-table-content" style={contentStyle.value} onScroll={handleScroll}>
+            <div
+              ref={scrollBodyRef}
+              class={`${prefixCls}-table-content`}
+              style={contentStyle.value}
+              onScroll={handleScroll}
+            >
               <TableTag style={tableStyle.value}>
                 <ColGroup></ColGroup>
                 <Body></Body>
@@ -176,7 +184,12 @@ export default defineComponent({
         children = [tableHead, tableBody, tableFoot, sticky]
       } else {
         children = (
-          <div ref={scrollBodyRef} class="ix-table-content" style={contentStyle.value} onScroll={handleScroll}>
+          <div
+            ref={scrollBodyRef}
+            class={`${prefixCls}-table-content`}
+            style={contentStyle.value}
+            onScroll={handleScroll}
+          >
             <TableTag style={tableStyle.value}>
               <ColGroup></ColGroup>
               {props.headless ? null : <Head></Head>}

--- a/packages/components/table/src/main/StickyScroll.tsx
+++ b/packages/components/table/src/main/StickyScroll.tsx
@@ -3,10 +3,12 @@ import type { StyleValue } from 'vue'
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue'
 import { getScrollBarSize } from '@idux/cdk/scroll'
 import { convertElement, getOffset, off, on } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { TABLE_TOKEN } from '../token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { scrollBodyRef, handleScroll, mergedSticky, stickyScrollLeft } = inject(TABLE_TOKEN)!
 
     const isShow = ref(false)
@@ -44,8 +46,8 @@ export default defineComponent({
 
     const scrollBarClasses = computed(() => {
       return {
-        'ix-table-sticky-scroll-bar': true,
-        'ix-table-sticky-scroll-bar-active': isActive.value,
+        [`${prefixCls}-table-sticky-scroll-bar`]: true,
+        [`${prefixCls}-table-sticky-scroll-bar-active`]: isActive.value,
       }
     })
 
@@ -143,7 +145,7 @@ export default defineComponent({
       }
 
       return (
-        <div class="ix-table-sticky-scroll" style={style.value}>
+        <div class={`${prefixCls}-table-sticky-scroll`} style={style.value}>
           <div class={scrollBarClasses.value} style={scrollBarStyle.value} onMousedown={handleMouseDown} />
         </div>
       )

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -9,6 +9,7 @@ import type { TableBodyCellProps } from '../../types'
 import { computed, defineComponent, inject } from 'vue'
 import { isFunction, isString } from 'lodash-es'
 import { convertArray, convertCssPixel } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { IxIcon } from '@idux/components/icon'
 import { IxRadio } from '@idux/components/radio'
@@ -23,13 +24,15 @@ type BodyColumn = TableColumnMergedExtra & {
 export default defineComponent({
   props: tableBodyCellProps,
   setup(props) {
+    const { prefixCls: compPrefixCls } = useGlobalConfig('common')
+
     const { slots, activeSortable, fixedColumnKeys, columnOffsets, isSticky, expandable, selectable, bodyColTag } =
       inject(TABLE_TOKEN)!
     const dataValue = useDataValue(props)
 
     const cellProps = computed(() => {
       const { key, fixed, align, ellipsis } = props.column as BodyColumn
-      const prefixCls = 'ix-table'
+      const prefixCls = [`${compPrefixCls}-table`]
       let classes: Record<string, boolean> = {
         [`${prefixCls}-cell-sorted`]: activeSortable.key === key && !!activeSortable.orderBy,
         [`${prefixCls}-align-${align}`]: !!align,

--- a/packages/components/table/src/main/body/BodyRow.tsx
+++ b/packages/components/table/src/main/body/BodyRow.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../../composables/useColumns'
 
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { isFunction, isString } from 'lodash-es'
 import { TABLE_TOKEN } from '../../token'
 import { tableBodyRowProps } from '../../types'
@@ -74,8 +75,9 @@ export default defineComponent({
 
 function useClasses(props: TableBodyRowProps, tableProps: TableProps, isSelected: ComputedRef<boolean>) {
   const rowClassName = computed(() => tableProps.rowClassName?.(props.record, props.rowIndex))
+  const { prefixCls: compPrefixCls } = useGlobalConfig('common')
   return computed(() => {
-    const prefixCls = 'ix-table-row'
+    const prefixCls = [`${compPrefixCls}-table-row`]
     const { level, expanded } = props
     const computeRowClassName = rowClassName.value
     return {

--- a/packages/components/table/src/main/body/MeasureRow.tsx
+++ b/packages/components/table/src/main/body/MeasureRow.tsx
@@ -1,9 +1,11 @@
 import { defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { tableBodyToken, TABLE_TOKEN } from '../../token'
 import MeasureCell from './MeasureCell'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
     const { flattedColumns } = inject(TABLE_TOKEN)!
     const { changeColumnWidth } = inject(tableBodyToken)!
     return () => {
@@ -13,7 +15,7 @@ export default defineComponent({
         return <MeasureCell {...cellProps}></MeasureCell>
       })
       return (
-        <tr class="ix-table-measure-row" style={{ fontSize: 0, height: 0 }} aria-hidden={true}>
+        <tr class={`${prefixCls}-table-measure-row`} style={{ fontSize: 0, height: 0 }} aria-hidden={true}>
           {children}
         </tr>
       )

--- a/packages/components/table/src/main/head/HeadCell.tsx
+++ b/packages/components/table/src/main/head/HeadCell.tsx
@@ -5,6 +5,7 @@ import type { TableColumnTitleFn } from '../../types'
 import { computed, defineComponent, inject } from 'vue'
 import { isFunction, isString } from 'lodash-es'
 import { convertCssPixel } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { TABLE_TOKEN } from '../../token'
 import { tableHeadCellProps } from '../../types'
 import { getColTitle } from '../../utils'
@@ -19,6 +20,7 @@ type HeadColumn = TableColumnMergedExtra & {
 export default defineComponent({
   props: tableHeadCellProps,
   setup(props) {
+    const { prefixCls: compPrefixCls } = useGlobalConfig('common')
     const { slots, fixedColumnKeys, columnOffsetsWithScrollBar, isSticky, activeSortable, handleSort, headColTag } =
       inject(TABLE_TOKEN)!
     const key = computed(() => props.column.key)
@@ -35,7 +37,7 @@ export default defineComponent({
       const { type, align, hasChildren, fixed, key, colStart, colEnd, sortable, titleColSpan, titleRowSpan } =
         props.column as HeadColumn
 
-      const prefixCls = 'ix-table'
+      const prefixCls = [`${compPrefixCls}-table`]
       let classes: Record<string, boolean | undefined> = {
         [`${prefixCls}-cell-${type}`]: !!type,
         [`${prefixCls}-cell-sortable`]: !!sortable,
@@ -85,7 +87,7 @@ export default defineComponent({
         children = renderChildren(title, customTitle, slots)
         _title = getColTitle(ellipsis, children!, title)
         if (ellipsis || sortable) {
-          children = <span class="ix-table-cell-title">{children}</span>
+          children = <span class={`${compPrefixCls}-table-cell-title`}>{children}</span>
           if (sortable) {
             children = (
               <HeadCellSortable activeOrderBy={activeSortOrderBy.value} sortable={sortable}>

--- a/packages/components/table/src/main/head/HeadCellSelectable.tsx
+++ b/packages/components/table/src/main/head/HeadCellSelectable.tsx
@@ -1,6 +1,7 @@
 import type { VNodeTypes } from 'vue'
 
 import { computed, defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { IxDropdown } from '@idux/components/dropdown'
 import { IxIcon } from '@idux/components/icon'
@@ -9,6 +10,8 @@ import { TABLE_TOKEN } from '../../token'
 
 export default defineComponent({
   setup() {
+    const { prefixCls } = useGlobalConfig('common')
+
     const {
       paginatedMap,
       selectable,
@@ -36,7 +39,7 @@ export default defineComponent({
       children.push(<IxCheckbox {...checkboxProps}></IxCheckbox>)
       const options = mergedSelectableOptions.value
       if (options) {
-        const trigger = <IxIcon name="down" class="ix-dropdown-trigger"></IxIcon>
+        const trigger = <IxIcon name="down" class={`${prefixCls}-dropdown-trigger`}></IxIcon>
         const content = (
           <IxMenu>
             {options.map(option => (

--- a/packages/components/table/src/main/head/HeadCellSortable.tsx
+++ b/packages/components/table/src/main/head/HeadCellSortable.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, inject } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import { TableLocale } from '@idux/components/i18n'
 import { TableColumnSortOrder } from '@idux/components/table'
@@ -9,6 +10,8 @@ export default defineComponent({
   // eslint-disable-next-line vue/require-prop-types
   props: ['activeOrderBy', 'sortable'],
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
+
     const { locale } = inject(TABLE_TOKEN)!
 
     return () => {
@@ -16,7 +19,7 @@ export default defineComponent({
       const { orders, nextTooltip } = sortable
       const title = nextTooltip ? getNextTooltipTitle(locale.value, orders!, activeOrderBy) : undefined
       const sortableNode = (
-        <span class="ix-table-sortable">
+        <span class={`${prefixCls}-table-sortable`}>
           {slots.default!()}
           {renderSortTrigger(orders!, activeOrderBy)}
         </span>
@@ -40,14 +43,15 @@ function getNextTooltipTitle(
 }
 
 function renderSortTrigger(orders: TableColumnSortOrder[], activeOrderBy?: TableColumnSortOrder) {
+  const { prefixCls } = useGlobalConfig('common')
   const upNode = orders!.includes('ascend') ? (
-    <IxIcon name="caret-up" class={{ 'ix-table-sortable-trigger-active': activeOrderBy === 'ascend' }} />
+    <IxIcon name="caret-up" class={{ [`${prefixCls}-table-sortable-trigger-active`]: activeOrderBy === 'ascend' }} />
   ) : undefined
   const downNode = orders!.includes('descend') ? (
-    <IxIcon name="caret-down" class={{ 'ix-table-sortable-trigger-active': activeOrderBy === 'descend' }} />
+    <IxIcon name="caret-down" class={{ [`${prefixCls}-table-sortable-trigger-active`]: activeOrderBy === 'descend' }} />
   ) : undefined
   return (
-    <span class="ix-table-sortable-trigger">
+    <span class={`${prefixCls}-table-sortable-trigger`}>
       {upNode}
       {downNode}
     </span>

--- a/packages/components/table/src/other/Footer.tsx
+++ b/packages/components/table/src/other/Footer.tsx
@@ -1,8 +1,10 @@
 import type { Slots, VNode } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 
 export function renderFooter(slots: Slots): VNode | null {
+  const { prefixCls } = useGlobalConfig('common')
   if (!slots.footer) {
     return null
   }
-  return <div class="ix-table-footer">{slots.footer()}</div>
+  return <div class={`${prefixCls}-table-footer`}>{slots.footer()}</div>
 }

--- a/packages/components/table/src/other/Pagination.tsx
+++ b/packages/components/table/src/other/Pagination.tsx
@@ -3,19 +3,22 @@ import type { TablePagination } from '../types'
 import type { MergedData } from '../composables/useDataSource'
 
 import { kebabCase } from 'lodash-es'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxPagination } from '@idux/components/pagination'
 
 export function renderPagination(
   mergedPagination: TablePagination | null,
   filteredData: MergedData[],
 ): [VNode | null, VNode | null] {
+  const { prefixCls } = useGlobalConfig('common')
+
   let top: VNode | null = null
   let bottom: VNode | null = null
 
   if (mergedPagination !== null) {
     const { position } = mergedPagination
     const [vertical, horizontal] = kebabCase(position).split('-')
-    const className = `ix-table-pagination ix-table-pagination-${horizontal}`
+    const className = `${prefixCls}-table-pagination ${prefixCls}-table-pagination-${horizontal}`
 
     const node = <IxPagination class={className} total={filteredData.length} {...mergedPagination} />
 

--- a/packages/components/tag/src/Tag.vue
+++ b/packages/components/tag/src/Tag.vue
@@ -1,10 +1,10 @@
 <template>
   <div :class="classes" :style="tagStyle">
-    <span v-if="icon || $slots.icon" class="ix-tag-icon">
+    <span v-if="icon || $slots.icon" :class="`${prefixCls}-tag-icon`">
       <slot name="icon"><IxIcon :name="icon" /></slot>
     </span>
-    <span class="ix-tag-content"><slot></slot></span>
-    <IxIcon v-if="closeAbleFlag" name="close" class="ix-tag-close-icon" @click="onClose" />
+    <span :class="`${prefixCls}-tag-content`"><slot></slot></span>
+    <IxIcon v-if="closeAbleFlag" name="close" :class="`${prefixCls}-tag-close-icon`" @click="onClose" />
   </div>
 </template>
 <script lang="ts">
@@ -28,6 +28,7 @@ export default defineComponent({
       return isPresetColor(color) || isStatusColor(color)
     })
 
+    const { prefixCls } = useGlobalConfig('common')
     const config = useGlobalConfig('tag')
     const classes = useClasses(props, config, isPresetOrStatusColor.value)
     const onClose = (evt: MouseEvent) => emit('close', evt)
@@ -39,6 +40,7 @@ export default defineComponent({
     })
 
     return {
+      prefixCls,
       classes,
       tagStyle,
       onClose,
@@ -48,19 +50,20 @@ export default defineComponent({
 })
 
 const useClasses = (props: TagProps, config: TagConfig, isPresetOrStatusColor: boolean) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
-    const colorClass = `ix-tag-${props.color}`
+    const colorClass = `${prefixCls}-tag-${props.color}`
     const presetFlag = isPresetOrStatusColor && (!props.checkAble || !config.checkAble)
     const checkAble = props.checkAble ?? config.checkAble
     const isRound = props.isRound ?? config.isRound
 
     return {
-      'ix-tag': true,
-      'ix-tag-round': isRound,
+      [`${prefixCls}-tag`]: true,
+      [`${prefixCls}-tag-round`]: isRound,
       [colorClass]: presetFlag,
-      'ix-tag-has-color': props.color ? !presetFlag : false,
-      'ix-tag-checkable': checkAble,
-      'ix-tag-checkable-checked': checkAble && props.checked,
+      [`${prefixCls}-tag-has-color`]: props.color ? !presetFlag : false,
+      [`${prefixCls}-tag-checkable`]: checkAble,
+      [`${prefixCls}-tag-checkable-checked`]: checkAble && props.checked,
     }
   })
 }

--- a/packages/components/textarea/src/Textarea.tsx
+++ b/packages/components/textarea/src/Textarea.tsx
@@ -55,6 +55,7 @@ export default defineComponent({
     useAutoRows(elementRef as Ref<HTMLTextAreaElement>, autoRows, accessor)
 
     return () => {
+      const { prefixCls } = useGlobalConfig('common')
       const suffix = renderSuffix(isClearable.value, slots.clearIcon, clearIcon.value, clearHidden.value, handlerClear)
       const { class: className, style, ...rest } = attrs
       return (
@@ -66,7 +67,7 @@ export default defineComponent({
           <textarea
             {...rest}
             ref={elementRef}
-            class="ix-textarea-inner"
+            class={`${prefixCls}-textarea-inner`}
             style={textareaStyle.value}
             disabled={isDisabled.value}
             readonly={props.readonly}
@@ -90,13 +91,14 @@ function useClasses(
   disabled: ComputedRef<boolean>,
 ) {
   return computed(() => {
-    const sizeClass = `ix-textarea-${props.size ?? config.size}`
+    const { prefixCls } = useGlobalConfig('common')
+    const sizeClass = `${prefixCls}-textarea-${props.size ?? config.size}`
     return {
-      'ix-textarea': true,
+      [`${prefixCls}-textarea`]: true,
       [sizeClass]: true,
-      'ix-textarea-disabled': disabled.value,
-      'ix-textarea-focused': isFocused.value,
-      'ix-textarea-with-count': props.showCount ?? config.showCount,
+      [`${prefixCls}-textarea-disabled`]: disabled.value,
+      [`${prefixCls}-textarea-focused`]: isFocused.value,
+      [`${prefixCls}-textarea-with-count`]: props.showCount ?? config.showCount,
     }
   })
 }
@@ -130,8 +132,8 @@ function renderSuffix(
   if (!isClearable) {
     return null
   }
-
-  const classes = { 'ix-textarea-suffix': true, 'ix-textarea-suffix-hidden': clearHidden }
+  const { prefixCls } = useGlobalConfig('common')
+  const classes = { [`${prefixCls}-textarea-suffix`]: true, [`${prefixCls}-textarea-suffix-hidden`]: clearHidden }
   const child = clearIconSlot?.({ handlerClear }) ?? <IxIcon name={clearIcon} onClick={handlerClear}></IxIcon>
   return <span class={classes}>{child}</span>
 }

--- a/packages/components/textarea/src/useAutoRows.ts
+++ b/packages/components/textarea/src/useAutoRows.ts
@@ -8,6 +8,7 @@ import { nextTick, onMounted, onUnmounted, watch, watchEffect } from 'vue'
 import { isObject, isNumber, throttle } from 'lodash-es'
 import { isFirefox } from '@idux/cdk/platform'
 import { on, off, rAF } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 
 const isAutoRowsObject = (value: unknown): value is TextareaAutoRows => {
   return isObject(value) && isNumber(value.minRows) && isNumber(value.maxRows)
@@ -18,6 +19,7 @@ export function useAutoRows(
   autoRows: ComputedRef<boolean | TextareaAutoRows>,
   accessor: FormAccessor,
 ): void {
+  const { prefixCls } = useGlobalConfig('common')
   let enabled = false
   let minRows: number | null = null
   let maxRows: number | null = null
@@ -33,7 +35,9 @@ export function useAutoRows(
   const textareaBoxHeight = 10
 
   /** Class that should be applied to the textarea while it's being measured. */
-  const measuringClass = isFirefox ? 'ix-textarea-autosize-measuring-firefox' : 'ix-textarea-autosize-measuring'
+  const measuringClass = isFirefox
+    ? `${prefixCls}-textarea-autosize-measuring-firefox`
+    : `${prefixCls}-textarea-autosize-measuring`
 
   let isDestroyed = false
 

--- a/packages/components/timeline/src/Timeline.vue
+++ b/packages/components/timeline/src/Timeline.vue
@@ -3,17 +3,16 @@ import type { VNode } from 'vue'
 import type { TimelinePosition, TimelineItemPosition, TimelineProps } from './types'
 
 import { defineComponent, h, cloneVNode } from 'vue'
+import { useGlobalConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
 import IxTimelineItem from './TimelineItem.vue'
 import { timelineProps } from './types'
-
-const timelinePrefixCls = 'ix-timeline'
-const itemPrefixCls = 'ix-timeline-item'
 
 export default defineComponent({
   name: 'IxTimeline',
   props: timelineProps,
   render() {
+    const { prefixCls } = useGlobalConfig('common')
     const pendingSlots = this.$slots?.pending?.()
     const pendingDotSlots = this.$slots?.pendingDot?.()
     const defaultSlots = this.$slots?.default?.() || []
@@ -26,7 +25,7 @@ export default defineComponent({
     if (pendingNode) {
       penddingItem = h(
         IxTimelineItem,
-        { class: `${itemPrefixCls}-pending-dot` },
+        { class: `${prefixCls}-timeline-item-pending-dot` },
         { default: () => pendingNode, dot: () => pendingDotNode },
       )
     }
@@ -92,13 +91,14 @@ const getRealPosition = (itemPositionArr: TimelineItemPosition[]): TimelinePosit
 }
 
 const useClasses = (itemPositionArr: TimelineItemPosition[], props: TimelineProps): string => {
+  const { prefixCls } = useGlobalConfig('common')
   const realPosition = getRealPosition(itemPositionArr)
-  const positionCls = `${timelinePrefixCls}-${realPosition}`
+  const positionCls = `${prefixCls}-timeline-${realPosition}`
 
-  let cls = `${timelinePrefixCls} ${positionCls}`
+  let cls = `${prefixCls}-timeline ${positionCls}`
 
   if (props.reverse) {
-    cls += ` ${timelinePrefixCls}-reverse`
+    cls += ` ${prefixCls}-timeline-reverse`
   }
 
   return cls
@@ -117,14 +117,15 @@ const useItemClasses = ({
   itemsLength: number
   props: TimelineProps
 }): string => {
-  let cls = `${itemPrefixCls}-${position}`
+  const { prefixCls } = useGlobalConfig('common')
+  let cls = `${prefixCls}-timeline-item-${position}`
 
   if (hasPendingNode) {
     const isReversePending = props.reverse && index === 0
     const isPending = !props.reverse && index === itemsLength - 2
 
     if (isReversePending || isPending) {
-      cls += ` ${itemPrefixCls}-pending`
+      cls += ` ${prefixCls}-timeline-item-pending`
     }
   }
 

--- a/packages/components/timeline/src/TimelineItem.vue
+++ b/packages/components/timeline/src/TimelineItem.vue
@@ -1,10 +1,10 @@
 <template>
-  <li class="ix-timeline-item">
-    <div class="ix-timeline-item-line"></div>
+  <li :class="`${prefixCls}-timeline-item`">
+    <div :class="`${prefixCls}-timeline-item-line`"></div>
     <div :class="dotClass" :style="dotStyle">
       <slot name="dot">{{ dot }}</slot>
     </div>
-    <div class="ix-timeline-item-content"><slot></slot></div>
+    <div :class="`${prefixCls}-timeline-item-content`"><slot></slot></div>
   </li>
 </template>
 
@@ -15,6 +15,7 @@ import type { TimelineItemProps } from './types'
 import { defineComponent, computed, ComputedRef } from 'vue'
 
 import { hasSlot } from '@idux/cdk/utils'
+import { useGlobalConfig } from '@idux/components/config'
 import { isPresetColor, isStatusColor } from '@idux/components/utils'
 import { timelineItemProps } from './types'
 
@@ -22,12 +23,14 @@ export default defineComponent({
   name: 'IxTimelineItem',
   props: timelineItemProps,
   setup(props, { slots }) {
+    const { prefixCls } = useGlobalConfig('common')
     const isPresetOrStatus = computed(() => isPresetColor(props.color) || isStatusColor(props.color))
 
     const dotStyle = useStyle(props, isPresetOrStatus)
     const dotClass = useClasses(props, slots, isPresetOrStatus)
 
     return {
+      prefixCls,
       dotStyle,
       dotClass,
     }
@@ -35,12 +38,13 @@ export default defineComponent({
 })
 
 const useClasses = (props: TimelineItemProps, slots: Slots, isPresetOrStatus: ComputedRef<boolean>) => {
+  const { prefixCls } = useGlobalConfig('common')
   return computed(() => {
     const hasCustomDot = hasSlot(slots, 'dot') || !!props.dot
     return {
-      'ix-timeline-item-dot': true,
-      'ix-timeline-item-dot-custom': hasCustomDot,
-      [`ix-timeline-item-dot-${props.color}`]: isPresetOrStatus.value,
+      [`${prefixCls}-timeline-item-dot`]: true,
+      [`${prefixCls}-timeline-item-dot-custom`]: hasCustomDot,
+      [`${prefixCls}-timeline-item-dot-${props.color}`]: isPresetOrStatus.value,
     }
   })
 }

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -14,14 +14,16 @@ export default defineComponent({
   props: tooltipProps,
   setup(props, { slots }) {
     const config = useGlobalConfig('tooltip')
+    const { prefixCls } = useGlobalConfig('common')
+
     const configProps = useConfigProps(props, config)
     const visibility = ɵUseVisibility(props)
     return () => (
       <IxOverlay
         v-model={[visibility.value, 'visible']}
         v-slots={{ default: slots.default, content: () => renderTitle(props, slots) }}
-        class="ix-tooltip"
-        transitionName="ix-fade-fast"
+        class={`${prefixCls}-tooltip`}
+        transitionName={`${prefixCls}-fade-fast`}
         {...configProps.value}
         offset={defaultOffset}
       />
@@ -33,5 +35,6 @@ const renderTitle = (props: TooltipProps, slots: Slots) => {
   if (!(slots.title || props.title)) {
     return null
   }
-  return <div class="ix-tooltip-title">{slots.title?.() ?? props.title}</div>
+  const { prefixCls } = useGlobalConfig('common')
+  return <div class={`${prefixCls}-tooltip-title`}>{slots.title?.() ?? props.title}</div>
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
1. 提取所有组件的类名前缀到全局的 config中，供用户配置
譬如：
```
const globalConfig = createGlobalConfig({
  common: {
    prefixCls: 'is'
  }
})
```
## Other information
遇到了一些问题：
1. 由于less是预编译，无法在运行时去确定类名前缀，从而生成相对应的css，如何解决？
貌似只能通过变量覆盖的方式去解决，需要用户手动去引入 less文件后进行覆盖，我在site中试了一下，发现无效，不知道咋回事
2. 对于一些use函数方法，在使用时会报警
[Vue warn]: inject() can only be used inside setup() or functional components.
例如：typography指令，`packages\components\typography\src\typography.ts` 
3. 还要一些组件设置的全局默认target是写死的'ix-xxx-xxx'， 这种是不是可以不设置全局配置，在setup中去设置默认值？

