### PR TITLE
fix(site): 修复npm run start子进程无法关闭的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A UI Component Library for Vue 3.x",
   "license": "MIT",
   "scripts": {
-    "start": "gulp start --gulpfile ./scripts/gulp/gulpfile.ts",
+    "start": "gulp start --cwd ./packages/site --gulpfile ./scripts/gulp/gulpfile.ts",
     "build": "gulp build --gulpfile ./scripts/gulp/gulpfile.ts",
     "icons": "gulp icons --gulpfile ./scripts/gulp/gulpfile.ts",
     "gen": "ts-node scripts/gen/generate.ts",

--- a/scripts/gulp/site/index.ts
+++ b/scripts/gulp/site/index.ts
@@ -8,7 +8,7 @@ const init: TaskFunction = done => {
   done()
 }
 
-const start: TaskFunction = done => execNodeTask('lerna', ['run', 'start', '--scope', '@idux/site', '--stream'])(done)
+const start: TaskFunction = done => execNodeTask('vite', [])(done)
 
 const build: TaskFunction = done => execNodeTask('lerna', ['run', 'build', '--scope', '@idux/site'])(done)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
npm run start启动site，在终端中ctrl + c 无法关闭，site依旧运行
## What is the new behavior?
恢复正常
## Other information
