### PR TITLE
fix(comp:tree): defaultExpandAll is invalid in controlled mode

### DIFF
--- a/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
@@ -1066,3 +1066,84 @@ exports[`Tree searchValue work 3`] = `
   </div>
 </div>"
 `;
+
+exports[`Tree searchValue work 4`] = `
+"<div class=\\"ix-tree ix-tree-active\\" role=\\"tree\\">
+  <!----><input style=\\"width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;\\" tabindex=\\"0\\" aria-label=\\"for screen reader\\">
+  <div class=\\"cdk-virtual-scroll\\" style=\\"position: relative;\\">
+    <div class=\\"cdk-virtual-scroll-holder\\">
+      <div class=\\"cdk-virtual-scroll-filler\\">
+        <div class=\\"cdk-virtual-scroll-content\\" style=\\"display: flex; flex-direction: column;\\">
+          <div class=\\"ix-tree-node ix-tree-node-expanded\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"></span><span class=\\"ix-tree-node-expand\\"><i class=\\"ix-icon ix-icon-right\\" role=\\"img\\" aria-label=\\"right\\"><svg viewBox=\\"64 64 896 896\\" width=\\"1em\\" height=\\"1em\\" focusable=\\"false\\" fill=\\"currentColor\\" aria-hidden=\\"true\\" data-icon=\\"right\\" style=\\"transform: rotate(90deg)\\"><path d=\\"m728.896 521.024-388.48 388.544a12.8 12.8 0 0 1-18.176 0l-27.136-27.136a12.8 12.8 0 0 1 0-18.112L638.4 521.024a12.8 12.8 0 0 0 0-18.048L295.04 159.68a12.8 12.8 0 0 1 0-18.112l27.136-27.136a12.8 12.8 0 0 1 18.112 0l388.48 388.48a12.8 12.8 0 0 1 0 18.112z\\"></path></svg></i></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node ix-tree-node-expanded\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand\\"><i class=\\"ix-icon ix-icon-right\\" role=\\"img\\" aria-label=\\"right\\"><svg viewBox=\\"64 64 896 896\\" width=\\"1em\\" height=\\"1em\\" focusable=\\"false\\" fill=\\"currentColor\\" aria-hidden=\\"true\\" data-icon=\\"right\\" style=\\"transform: rotate(90deg)\\"><path d=\\"m728.896 521.024-388.48 388.544a12.8 12.8 0 0 1-18.176 0l-27.136-27.136a12.8 12.8 0 0 1 0-18.112L638.4 521.024a12.8 12.8 0 0 0 0-18.048L295.04 159.68a12.8 12.8 0 0 1 0-18.112l27.136-27.136a12.8 12.8 0 0 1 18.112 0l388.48 388.48a12.8 12.8 0 0 1 0 18.112z\\"></path></svg></i></span><label class=\\"ix-checkbox ix-checkbox-checked ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-0</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-0-0</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-0-1</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-0-2</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node ix-tree-node-active ix-tree-node-disabled ix-tree-node-selected ix-tree-node-expanded\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand\\"><i class=\\"ix-icon ix-icon-right\\" role=\\"img\\" aria-label=\\"right\\"><svg viewBox=\\"64 64 896 896\\" width=\\"1em\\" height=\\"1em\\" focusable=\\"false\\" fill=\\"currentColor\\" aria-hidden=\\"true\\" data-icon=\\"right\\" style=\\"transform: rotate(90deg)\\"><path d=\\"m728.896 521.024-388.48 388.544a12.8 12.8 0 0 1-18.176 0l-27.136-27.136a12.8 12.8 0 0 1 0-18.112L638.4 521.024a12.8 12.8 0 0 0 0-18.048L295.04 159.68a12.8 12.8 0 0 1 0-18.112l27.136-27.136a12.8 12.8 0 0 1 18.112 0l388.48 388.48a12.8 12.8 0 0 1 0 18.112z\\"></path></svg></i></span><label class=\\"ix-checkbox ix-checkbox-checked ix-checkbox-disabled ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"true\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-1</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-1-0</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-1-1</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"><span class=\\"ix-tree-node-indent-unit\\"></span><span class=\\"ix-tree-node-indent-unit\\"></span></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 0-1-2</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"></span><span class=\\"ix-tree-node-expand\\"><i class=\\"ix-icon ix-icon-right\\" role=\\"img\\" aria-label=\\"right\\"><svg viewBox=\\"64 64 896 896\\" width=\\"1em\\" height=\\"1em\\" focusable=\\"false\\" fill=\\"currentColor\\" aria-hidden=\\"true\\" data-icon=\\"right\\" style=\\"transform: rotate(0deg)\\"><path d=\\"m728.896 521.024-388.48 388.544a12.8 12.8 0 0 1-18.176 0l-27.136-27.136a12.8 12.8 0 0 1 0-18.112L638.4 521.024a12.8 12.8 0 0 0 0-18.048L295.04 159.68a12.8 12.8 0 0 1 0-18.112l27.136-27.136a12.8 12.8 0 0 1 18.112 0l388.48 388.48a12.8 12.8 0 0 1 0 18.112z\\"></path></svg></i></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 1</span>
+            <!----></span>
+          </div>
+          <div class=\\"ix-tree-node\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"></span><span class=\\"ix-tree-node-expand ix-tree-node-expand-noop\\"><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!---->
+            </label><span class=\\"ix-tree-node-content\\"><!----><span class=\\"ix-tree-node-content-label\\">Node 2</span>
+            <!----></span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!---->
+  </div>
+</div>"
+`;

--- a/packages/components/tree/__tests__/tree.spec.ts
+++ b/packages/components/tree/__tests__/tree.spec.ts
@@ -827,7 +827,6 @@ describe('Tree', () => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-
     await wrapper.setProps({ searchValue: '0-0' })
 
     expect(wrapper.html()).toMatchSnapshot()
@@ -835,6 +834,10 @@ describe('Tree', () => {
     // not match
     await wrapper.setProps({ searchValue: '0-0-0-0' })
 
+    expect(wrapper.html()).toMatchSnapshot()
+
+    // setValue = ''
+    await wrapper.setProps({ searchValue: '' })
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/packages/components/tree/demo/Virtual.vue
+++ b/packages/components/tree/demo/Virtual.vue
@@ -1,5 +1,5 @@
 <template>
-  <IxTree :dataSource="treeData" :expandedKeys="expandedKeys" :height="200" virtual></IxTree>
+  <IxTree :dataSource="treeData" defaultExpandAll :height="200" virtual></IxTree>
 </template>
 
 <script setup lang="ts">

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -49,8 +49,15 @@ export default defineComponent({
     const config = useGlobalConfig('tree')
     const getNodeKey = useGetNodeKey(props, config)
     const { mergedNodes, mergedNodeMap } = useMergeNodes(props, getNodeKey)
-    const searchedKeys = useSearchable(props, mergedNodeMap)
-    const expandableContext = useExpandable(props, config, getNodeKey, mergedNodeMap, searchedKeys)
+    const { searchedKeys, lastEffectiveSearchedKeys } = useSearchable(props, mergedNodeMap)
+    const expandableContext = useExpandable(
+      props,
+      config,
+      getNodeKey,
+      mergedNodeMap,
+      searchedKeys,
+      lastEffectiveSearchedKeys,
+    )
     const flattedNodes = useFlattedNodes(mergedNodes, expandableContext)
     const checkableContext = useCheckable(props, mergedNodeMap)
     const dragDropContext = useDragDrop(props, expandableContext)

--- a/packages/components/tree/src/composables/useExpandable.ts
+++ b/packages/components/tree/src/composables/useExpandable.ts
@@ -32,6 +32,7 @@ export function useExpandable(
   mergedNodeMap: ComputedRef<Map<VKey, MergedNode>>,
   searchedKeys: ComputedRef<VKey[]>,
 ): ExpandableContext {
+  const { onExpand, onExpandedChange } = props
   const expandIcon = computed(() => props.expandIcon ?? config.expandIcon)
   const [expandedKeys, setExpandedKeys] = useControlledProp(props, 'expandedKeys', () => [])
   const [loadedKeys, setLoadedKeys] = useControlledProp(props, 'loadedKeys', () => [])
@@ -41,7 +42,9 @@ export function useExpandable(
     if (searchedKeys.value.length) {
       setExpandWithSearch(searchedKeys.value)
     } else if (expandedKeys.value.length === 0 && props.defaultExpandAll) {
-      setExpandedKeys(getAllParentKeys(mergedNodeMap.value))
+      const allParentKeys = getAllParentKeys(mergedNodeMap.value)
+      setExpandedKeys(allParentKeys)
+      callChange(mergedNodeMap, allParentKeys, onExpandedChange)
     }
   })
 
@@ -56,6 +59,7 @@ export function useExpandable(
       getParentKeys(nodeMap, nodeMap.get(key)).forEach(parentKey => keySet.add(parentKey))
     })
     setExpandedKeys([...keySet])
+    callChange(mergedNodeMap, [...keySet], onExpandedChange)
   }
 
   const handleExpand = async (key: VKey, rawNode: TreeNode) => {
@@ -95,7 +99,6 @@ export function useExpandable(
   }
 
   const handleChange = (expanded: boolean, rawNode: TreeNode, newKeys: VKey[]) => {
-    const { onExpand, onExpandedChange } = props
     callEmit(onExpand, !expanded, rawNode)
     setExpandedKeys(newKeys)
     callChange(mergedNodeMap, newKeys, onExpandedChange)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

由于defaultExpandAll 没有抛出expandedChange事件，导致在受控模式下无效
```
  <IxTree
    :expandedKeys="expandedKeys"
    :dataSource="treeData"
    defaultExpandAll
    @expandedChange="onExpandedChange"
  >
  </IxTree>

...
const expandedKeys = ref([])
const onExpandedChange = (keys: VKey[], nodes: TreeNode[]) => {
  console.log('onExpandedChange', keys, nodes)
  expandedKeys.value = keys
}
```

## What is the new behavior?


## Other information
1. 同样的问题存在于受控模式下，进行搜索时也没有抛出onExpandedChange 事件 ，一并修复
2. 为了增加用户体验，优化了一下搜索和展开之间的联动，当搜索值为空字符串时（对应用户操作为删除搜索框的输入值），树会默认展开上一次有效搜索时的展开效果
![GIF 2021-12-8 17-34-22](https://user-images.githubusercontent.com/26105153/145184553-14a460d5-8a89-485c-87e1-f2765bd935db.gif)


