### PR TITLE
fix(comp:ixmenu): fix error when initialize settings expandKeys

### DIFF
--- a/packages/components/menu/__tests__/menu.spec.ts
+++ b/packages/components/menu/__tests__/menu.spec.ts
@@ -84,7 +84,9 @@ describe('Menu', () => {
 
   test('v-model:expandedKeys work', async () => {
     const onUpdateExpandedKeys = jest.fn()
-    const wrapper = MenuMount({ props: { expandedKeys: ['sub1'], 'onUpdate:expandedKeys': onUpdateExpandedKeys } })
+    const wrapper = MenuMount({
+      props: { expandedKeys: ['sub1'], 'onUpdate:expandedKeys': onUpdateExpandedKeys, mode: 'inline' },
+    })
 
     const subs = wrapper.findAllComponents(MenuSub)
     expect(subs.length).toBe(4)
@@ -101,7 +103,7 @@ describe('Menu', () => {
     expect(subs[3].classes()).toContain('ix-menu-sub-expanded')
 
     await wrapper.setProps({ expandedKeys: [] })
-    await subs[0].find('.ix-menu-sub-title').trigger('mouseenter')
+    await subs[0].find('.ix-menu-sub-title').trigger('click')
     await wait(105)
 
     expect(onUpdateExpandedKeys).toBeCalledWith(['sub1'])

--- a/packages/components/menu/src/children/menu-sub/MenuSub.tsx
+++ b/packages/components/menu/src/children/menu-sub/MenuSub.tsx
@@ -166,10 +166,16 @@ function useExpanded(
   handleExpand: (key: VKey, expanded: boolean) => void,
   mode: ComputedRef<'vertical' | 'horizontal' | 'inline'>,
 ) {
-  const isExpanded = computed(() => expandedKeys.value.includes(key))
+  const isHover = ref(false)
+  const isExpanded = computed(() => {
+    // https://github.com/IDuxFE/idux/issues/636
+    if (mode.value === 'inline') {
+      return expandedKeys.value.includes(key)
+    }
+    return isHover.value && expandedKeys.value.includes(key)
+  })
   const changeExpanded = (expanded: boolean) => handleExpand(key, expanded)
   const childExpanded = computed(() => getState(props.children, expandedKeys.value))
-  const isHover = ref(false)
   const handleMouseEvent = debounce((value: boolean) => (isHover.value = value), 100)
   watch([mode, childExpanded, isHover], ([currMode, currChildExpanded, currIsHover]) => {
     if (currMode !== 'inline') {


### PR DESCRIPTION
fix #636

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/IDuxFE/idux/issues/636
## What is the new behavior?

When vertical and horizontal, the initial setting expandedKeys does not expand IxMenuSub
## Other information
