### PR TITLE
refactor(comp:select): set the select option to center the text

### DIFF
--- a/packages/components/select/style/index.less
+++ b/packages/components/select/style/index.less
@@ -141,7 +141,6 @@
   }
 
   &-label {
-    margin-left: @select-option-margin-left;
     .ellipsis();
   }
 

--- a/packages/components/select/style/mixin.less
+++ b/packages/components/select/style/mixin.less
@@ -7,6 +7,7 @@
   color: @text-color;
   transition: @select-option-transition;
   cursor: pointer;
+  text-align: center;
 }
 
 .select-icon() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Component style update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
select-option文字没有设置居中，显示不美观
![图片](https://user-images.githubusercontent.com/22878303/147617991-a5a84f8b-b057-4c3b-9205-f478b4fa2d10.png)


## What is the new behavior?
将select-option文字内容设置为居中显示
删除margin-left：12px，将其父级设置text-align: center。

## Other information
