### PR TITLE
refactor(comp:menu): use customXxx instead of slots

### DIFF
--- a/packages/components/menu/demo/Horizontal.vue
+++ b/packages/components/menu/demo/Horizontal.vue
@@ -7,7 +7,7 @@ import { h } from 'vue'
 import { MenuData } from '@idux/components/menu'
 
 const dataSource: MenuData[] = [
-  { key: 'item1', icon: 'home', slots: { label: () => h('a', 'Item 1') } },
+  { key: 'item1', icon: 'home', customLabel: () => h('a', 'Item 1') },
   { key: 'item2', icon: 'mail', label: 'Item 2' },
   { key: 'item3', icon: 'appstore', label: 'Item 3', disabled: true },
   { type: 'divider', key: 'divider1' },

--- a/packages/components/menu/demo/Inline.vue
+++ b/packages/components/menu/demo/Inline.vue
@@ -7,7 +7,7 @@ import { h } from 'vue'
 import { MenuData } from '@idux/components/menu'
 
 const dataSource: MenuData[] = [
-  { key: 'item1', icon: 'home', slots: { label: () => h('a', 'Item 1') } },
+  { key: 'item1', icon: 'home', customLabel: () => h('a', 'Item 1') },
   { key: 'item2', icon: 'mail', label: 'Item 2' },
   { key: 'item3', icon: 'appstore', label: 'Item 3', disabled: true },
   { type: 'divider', key: 'divider1' },

--- a/packages/components/menu/demo/Router.vue
+++ b/packages/components/menu/demo/Router.vue
@@ -5,7 +5,7 @@
     :selectedKeys="selectedKeys"
     style="width: 256px"
   >
-    <template #label="item">
+    <template #itemLabel="item">
       <router-link :to="item.key">
         <span>{{ item.label }}</span>
       </router-link>
@@ -28,15 +28,15 @@ const lang = ref(currLang)
 const dataSource = computed<MenuData[]>(() => {
   const currLang = lang.value
   const zh = currLang === 'zh'
-  const itemSlots = { label: 'label' }
+
   return [
     {
       key: 'docs',
       type: 'sub',
       label: zh ? '文档' : 'Docs',
       children: [
-        { key: `/docs/introduce/${currLang}`, label: zh ? '介绍' : 'Introduce', slots: itemSlots },
-        { key: `/docs/i18n/${currLang}`, label: zh ? '国际化' : 'I18n', slots: itemSlots },
+        { key: `/docs/introduce/${currLang}`, label: zh ? '介绍' : 'Introduce' },
+        { key: `/docs/i18n/${currLang}`, label: zh ? '国际化' : 'I18n' },
       ],
     },
     {
@@ -44,9 +44,9 @@ const dataSource = computed<MenuData[]>(() => {
       type: 'sub',
       label: zh ? '基础组件' : 'Components',
       children: [
-        { key: `/components/button/${currLang}`, label: zh ? '按钮' : 'Button', slots: itemSlots },
-        { key: `/components/icon/${currLang}`, label: zh ? '图标' : 'Icon', slots: itemSlots },
-        { key: `/components/menu/${currLang}`, label: zh ? '菜单' : 'Menu', slots: itemSlots },
+        { key: `/components/button/${currLang}`, label: zh ? '按钮' : 'Button' },
+        { key: `/components/icon/${currLang}`, label: zh ? '图标' : 'Icon' },
+        { key: `/components/menu/${currLang}`, label: zh ? '菜单' : 'Menu' },
       ],
     },
     {
@@ -54,8 +54,8 @@ const dataSource = computed<MenuData[]>(() => {
       type: 'sub',
       label: zh ? '开发套件' : 'CDK',
       children: [
-        { key: `/cdk/a11y/${lang.value}`, label: zh ? '无障碍性' : 'A11y', slots: itemSlots },
-        { key: `/cdk/breakpoint/${lang.value}`, label: zh ? '断点' : 'Breakpoint', slots: itemSlots },
+        { key: `/cdk/a11y/${lang.value}`, label: zh ? '无障碍性' : 'A11y' },
+        { key: `/cdk/breakpoint/${lang.value}`, label: zh ? '断点' : 'Breakpoint' },
       ],
     },
   ]

--- a/packages/components/menu/demo/Slots.md
+++ b/packages/components/menu/demo/Slots.md
@@ -1,14 +1,14 @@
 ---
 title:
-  zh: 数据源配合插槽使用
-  en: DataSource with slots  
+  zh: 自定义插槽
+  en: Custom slots  
 order: 7
 ---
 
 ## zh
 
-可以使用 `dataSource` 的 `slots` 来灵活的自定义显示菜单内容
+提供了多种方式自定义显示菜单内容
 
 ## en
 
-You can customize the menu content using `slots` of `dataSource`.
+Provides many ways to customize display menu content.

--- a/packages/components/menu/demo/Slots.vue
+++ b/packages/components/menu/demo/Slots.vue
@@ -1,10 +1,13 @@
 <template>
   <IxMenu :dataSource="dataSource" style="width: 256px">
-    <template #label="item">
-      <span style="color: red">{{ item.label }} with slot</span>
+    <template #itemLabel="{ label }">
+      <span style="color: red">{{ label }} with slot</span>
     </template>
-    <template #subIcon="item">
-      <IxIcon :name="item.expanded ? 'menu-fold' : 'menu-unfold'" style="color: red"></IxIcon>
+    <template #subIcon="{ expanded }">
+      <IxIcon :name="expanded ? 'menu-fold' : 'menu-unfold'"></IxIcon>
+    </template>
+    <template #subLabel="{ label }">
+      <span>{{ label }} with slot</span>
     </template>
   </IxMenu>
 </template>
@@ -16,25 +19,28 @@ import { IxIcon } from '@idux/components/icon'
 import { MenuData } from '@idux/components/menu'
 
 const dataSource: MenuData[] = [
-  { key: 'item1', icon: 'home', label: 'Item 1', slots: { label: 'label' } },
+  { key: 'item1', icon: 'home', label: 'Item 1' },
   {
     key: 'item2',
     label: 'Item 2',
-    slots: { label: item => h('a', item.label), icon: () => h(IxIcon, { name: 'mail' }) },
+    customIcon: () => h(IxIcon, { name: 'mail' }),
+    customLabel: item => h('a', `${item.label} with customLabel`),
   },
   { type: 'divider', key: 'divider1' },
+
   {
     type: 'sub',
     key: 'sub1',
     label: 'Menu Sub 1',
-    slots: { label: 'label', icon: 'subIcon' },
+    customIcon: () => h(IxIcon, { name: 'setting' }),
+    customLabel: item => h('a', `${item.label} with customLabel`),
     children: [
       {
         type: 'itemGroup',
         key: 'itemGroup1',
         label: 'Item Group 1',
         children: [
-          { key: 'item4', label: 'Item 4', slots: { label: 'label' } },
+          { key: 'item4', label: 'Item 4' },
           { key: 'item5', label: 'Item 5' },
         ],
       },
@@ -44,7 +50,7 @@ const dataSource: MenuData[] = [
         key: 'sub2',
         label: 'Menu Sub 2',
         children: [
-          { key: 'item6', label: 'Item 6', slots: { label: 'label' } },
+          { key: 'item6', label: 'Item 6' },
           { key: 'item7', label: 'Item 7' },
         ],
       },
@@ -63,10 +69,9 @@ const dataSource: MenuData[] = [
     type: 'sub',
     key: 'sub4',
     label: 'Menu Sub 4',
-    slots: { label: 'label', icon: 'subIcon' },
     children: [
       { key: 'item10', label: 'Item 10' },
-      { key: 'item11', label: 'Item 911' },
+      { key: 'item11', label: 'Item 11' },
     ],
   },
 ]

--- a/packages/components/menu/demo/StateSwitching.vue
+++ b/packages/components/menu/demo/StateSwitching.vue
@@ -52,7 +52,7 @@ const selectedKeys = ref([])
 const expandedKeys = ref([])
 
 const dataSource: MenuData[] = [
-  { key: 'item1', icon: 'home', slots: { label: () => h('a', 'Item 1') } },
+  { key: 'item1', icon: 'home', customLabel: () => h('a', 'Item 1') },
   { key: 'item2', icon: 'mail', label: 'Item 2' },
   { key: 'item3', icon: 'appstore', label: 'Item 3', disabled: true },
   { type: 'divider', key: 'divider1' },

--- a/packages/components/menu/demo/Vertical.vue
+++ b/packages/components/menu/demo/Vertical.vue
@@ -8,7 +8,7 @@ import { h } from 'vue'
 import { MenuData } from '@idux/components/menu'
 
 const dataSource: MenuData[] = [
-  { key: 'item1', icon: 'home', slots: { label: () => h('a', 'Item 1') } },
+  { key: 'item1', icon: 'home', customLabel: () => h('a', 'Item 1') },
   { key: 'item2', icon: 'mail', label: 'Item 2' },
   { key: 'item3', icon: 'appstore', label: 'Item 3', disabled: true },
   { type: 'divider', key: 'divider1' },

--- a/packages/components/menu/docs/Index.zh.md
+++ b/packages/components/menu/docs/Index.zh.md
@@ -43,7 +43,7 @@ export interface MenuClickOptions {
 
 | 名称 | 说明 | 类型  | 默认值 | 全局配置 | 备注 |
 | --- | --- | --- | --- | --- | --- |
-| `type` | 菜单类型 | `'item' \| 'itemGroup' \| 'sub' \| 'divider'` | `'item'` | - | - |
+| `type` | 菜单类型 | `'item' \| 'itemGroup' \| 'sub' \| 'divider'` | - | - | - |
 | `key` | 唯一标识 | `VKey` | - | - | 必传 |
 | `additional` | 菜单的额外配置 | `object` | - | - | 可以传入 `class`, `style` 等原生 DOM 属性 |
 
@@ -57,17 +57,8 @@ export interface MenuClickOptions {
 | `disabled` | 是否禁用 | `boolean` | - | - | - |
 | `icon` | 菜单图标| `string  \| VNode` | - | - |
 | `label` | 菜单文本 | `string`  | - | - |
-| `slots` | 自定义菜单内容 | `MenuItemSlots`  | - | - |
-
-```ts
-export interface MenuItemSlots {
-  /**
-   * 如果类型为 `string`, 会根据该字符串去 `IxMenu` 的插槽中获取
-   */
-  icon?: string | ((data: MenuItemProps & { selected: boolean }) => VNodeChild)
-  label?: string | ((data: MenuItemProps & { selected: boolean }) => VNodeChild)
-}
-```
+| `customIcon` | 自定义图标 | `string \| ((data: MenuItemProps & { selected: boolean }) => VNodeChild)` | `itemIcon` | - | 类型为 `string` 时，对应插槽名 |
+| `customLabel` | 自定义文本 | `string \| ((data: MenuItemProps & { selected: boolean }) => VNodeChild)` | `itemLabel` | - | 类型为 `string` 时，对应插槽名 |
 
 #### MenuItemGroupProps
 
@@ -79,14 +70,8 @@ export interface MenuItemSlots {
 | `children` | 子菜单数据 | `MenuData[]` | - | - | - |
 | `icon` | 菜单图标| `string \| VNode \| #icon` | - | - |
 | `label` | 菜单文本 | `string \| #label`  | - | - |
-| `slots` | 自定义菜单内容 | `MenuItemGroupSlots`  | - | - |
-
-```ts
-export interface MenuItemGroupSlots {
-  icon?: string | ((data: MenuItemGroupProps) => VNodeChild)
-  label?: string | ((data: MenuItemGroupProps) => VNodeChild)
-}
-```
+| `customIcon` | 自定义图标 | `string \| ((data: MenuItemGroupProps) => VNodeChild)` | `itemGroupIcon` | - | 类型为 `string` 时，对应插槽名 |
+| `customLabel` | 自定义文本 | `string \| ((data: MenuItemGroupProps) => VNodeChild)` | `itemGroupLabel` | - | 类型为 `string` 时，对应插槽名 |
 
 #### MenuSubProps
 
@@ -101,15 +86,9 @@ export interface MenuItemGroupSlots {
 | `label` | 菜单文本 | `string`  | - | - |
 | `offset` | 浮层偏移量 | `[number, number]` | `[0, 8]` | ✅ | `inline` 模式时无效 |
 | `suffix` | 后缀图标 | `string` | `right` | ✅ | - |
-| `slots` | 自定义菜单内容 | `MenuSubSlots`  | - | - |
-
-```ts
-export interface MenuSubSlots {
-  icon?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
-  label?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
-  suffix?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
-}
-```
+| `customIcon` | 自定义图标 | `string \| ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)` | `subIcon` | - | 类型为 `string` 时，对应插槽名 |
+| `customLabel` | 自定义文本 | `string \| ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)` | `subLabel` | - | 类型为 `string` 时，对应插槽名 |
+| `customSuffix` | 自定义后缀图标 | `string \| ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)` | `subSuffix` | - | 类型为 `string` 时，对应插槽名 |
 
 #### MenuDividerProps
 

--- a/packages/components/menu/src/children/MenuItem.tsx
+++ b/packages/components/menu/src/children/MenuItem.tsx
@@ -9,6 +9,7 @@ import { computed, defineComponent, inject, normalizeClass } from 'vue'
 
 import { isString } from 'lodash-es'
 
+import { Logger } from '@idux/cdk/utils'
 import { useKey } from '@idux/components/utils'
 
 import { usePaddingLeft } from '../composables/usePaddingLeft'
@@ -59,17 +60,21 @@ export default defineComponent({
     }
 
     return () => {
-      const { additional, disabled, icon, label, slots = {} } = props.data
-      const iconSlot = isString(slots.icon) ? menuSlots[slots.icon] : slots.icon
-      // <IxMenuItem key="key">label</IxMenuItem>
-      let labelSlot = slots.label ?? slots.default
-      if (isString(labelSlot)) {
-        labelSlot = menuSlots[labelSlot]
+      const { additional, disabled, icon, label, slots = {}, customIcon, customLabel } = props.data
+      if (__DEV__ && (slots.icon || slots.label)) {
+        Logger.warn(
+          'components/menu',
+          '`slots` of `MenuItem` is deprecated,  please use `customIcon` and `customLabel` instead',
+        )
       }
+      const iconRender = customIcon ?? slots.icon ?? 'itemIcon'
+      const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
+      const labelRender = customLabel ?? slots.label ?? 'itemLabel'
+      const labelSlot = isString(labelRender) ? menuSlots[labelRender] : labelRender
 
       const slotProps = iconSlot || labelSlot ? { ...props.data, selected: isSelected.value } : undefined
       const iconNode = coverIcon(iconSlot, slotProps!, icon)
-      const labelNode = labelSlot ? labelSlot(slotProps) : label
+      const labelNode = labelSlot ? labelSlot(slotProps!) : label
 
       const prefixCls = `${mergedPrefixCls.value}-item`
       return (

--- a/packages/components/menu/src/children/MenuItemGroup.tsx
+++ b/packages/components/menu/src/children/MenuItemGroup.tsx
@@ -9,6 +9,7 @@ import { computed, defineComponent, inject, provide } from 'vue'
 
 import { isString } from 'lodash-es'
 
+import { Logger } from '@idux/cdk/utils'
 import { useKey } from '@idux/components/utils'
 
 import { usePaddingLeft } from '../composables/usePaddingLeft'
@@ -40,10 +41,17 @@ export default defineComponent({
     }
 
     return () => {
-      const { additional, icon, label, children, slots = {} } = props.data
-
-      const iconSlot = isString(slots.icon) ? menuSlots[slots.icon] : slots.icon
-      const labelSlot = isString(slots.label) ? menuSlots[slots.label] : slots.label
+      const { additional, icon, label, children, slots = {}, customIcon, customLabel } = props.data
+      if (__DEV__ && (slots.icon || slots.label)) {
+        Logger.warn(
+          'components/menu',
+          '`slots` of `MenuItemGroup` is deprecated,  please use `customIcon` and `customLabel` instead',
+        )
+      }
+      const iconRender = customIcon ?? slots.icon ?? 'itemGroupIcon'
+      const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
+      const labelRender = customLabel ?? slots.label ?? 'itemGroupLabel'
+      const labelSlot = isString(labelRender) ? menuSlots[labelRender] : labelRender
 
       const slotProps = props.data
       const iconNode = coverIcon(iconSlot, slotProps, icon)

--- a/packages/components/menu/src/children/menu-sub/MenuSub.tsx
+++ b/packages/components/menu/src/children/menu-sub/MenuSub.tsx
@@ -43,7 +43,6 @@ export default defineComponent({
     // menuContext must exist
     const {
       props: menuProps,
-      slots: menuSlots,
       config,
       mergedPrefixCls,
       indent,
@@ -65,7 +64,7 @@ export default defineComponent({
     const { isExpanded, changeExpanded, handleMouseEvent } = useExpanded(props, key, expandedKeys, handleExpand, mode)
 
     const handleItemClick = () => {
-      if (!props.data.disabled && mode.value !== 'inline' && !menuSlots.multiple) {
+      if (!props.data.disabled && mode.value !== 'inline' && !menuProps.multiple) {
         handleExpand(key, false)
       }
     }

--- a/packages/components/menu/src/children/menu-sub/Title.tsx
+++ b/packages/components/menu/src/children/menu-sub/Title.tsx
@@ -9,6 +9,8 @@ import { computed, defineComponent, inject } from 'vue'
 
 import { isString } from 'lodash-es'
 
+import { Logger } from '@idux/cdk/utils'
+
 import { menuSubToken, menuToken } from '../../token'
 import { coverIcon } from '../Utils'
 
@@ -46,16 +48,24 @@ export default defineComponent({
     })
 
     return () => {
-      const { icon, label, slots = {} } = props.data
-      const iconSlot = isString(slots.icon) ? menuSlots[slots.icon] : slots.icon
-      const labelSlot = isString(slots.label) ? menuSlots[slots.label] : slots.label
-      const suffixSlot = isString(slots.suffix) ? menuSlots[slots.suffix] : slots.suffix
+      const { icon, label, slots = {}, customIcon, customLabel, customSuffix } = props.data
+      if (__DEV__ && (slots.icon || slots.label || slots.suffix)) {
+        Logger.warn(
+          'components/menu',
+          '`slots` of `MenuSub` is deprecated,  please use `customIcon`, `customLabel` and `customSuffix` instead',
+        )
+      }
+      const iconRender = customIcon ?? slots.icon ?? 'subIcon'
+      const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
+      const labelRender = customLabel ?? slots.label ?? 'subLabel'
+      const labelSlot = isString(labelRender) ? menuSlots[labelRender] : labelRender
+      const suffixRender = customSuffix ?? slots.suffix ?? 'subSuffix'
+      const suffixSlot = isString(suffixRender) ? menuSlots[suffixRender] : suffixRender
 
       const slotProps =
         iconSlot || labelSlot || suffixSlot
           ? { ...props.data, expanded: isExpanded.value, selected: isSelected.value }
           : undefined
-
       const iconNode = coverIcon(iconSlot, slotProps!, icon)
       const labelNode = labelSlot ? labelSlot(slotProps!) : label
       const suffixNode = coverIcon(suffixSlot, slotProps!, suffix.value, rotate.value)

--- a/packages/components/menu/src/composables/useDataSource.ts
+++ b/packages/components/menu/src/composables/useDataSource.ts
@@ -37,38 +37,44 @@ function convertDataSource(nodes: VNode[] | undefined): MenuData[] {
     let data: MenuData
     if (type[itemKey]) {
       const { key, disabled, icon, label, ...additional } = props
+      // <IxMenuItem key="key">label</IxMenuItem>
+      const { icon: customIcon, label: customLabel, default: customLabel2 } = slots
       data = {
         key,
         disabled: disabled || disabled === '',
         icon,
         label,
         additional,
-        slots,
+        customIcon,
+        customLabel: customLabel ?? customLabel2,
       }
     } else if (type[itemGroupKey]) {
       const { key, children, icon, label, ...additional } = props
-      const _children = children ?? convertDataSource(slots.default?.())
+      const { icon: customIcon, label: customLabel } = slots
       data = {
         type: 'itemGroup',
         key,
-        children: _children,
+        children: children ?? convertDataSource(slots.default?.()),
         icon,
         label,
         additional,
-        slots,
+        customIcon,
+        customLabel,
       }
     } else if (type[subKey]) {
       const { key, children, disabled, icon, label, suffix, ...additional } = props
-      const _children = children ?? convertDataSource(slots.default?.())
+      const { icon: customIcon, label: customLabel, suffix: customSuffix } = slots
       data = {
         type: 'sub',
         key,
-        children: _children,
+        children: children ?? convertDataSource(slots.default?.()),
         disabled: disabled || disabled === '',
         icon,
         label,
         additional,
-        slots,
+        customIcon,
+        customLabel,
+        customSuffix,
       }
     } else {
       const { key, ...additional } = props

--- a/packages/components/menu/src/types.ts
+++ b/packages/components/menu/src/types.ts
@@ -65,7 +65,12 @@ export interface MenuItemProps extends MenuCommonProps {
   disabled?: boolean
   icon?: string | VNode
   label?: string
+  /**
+   * @deprecated please use `customIcon` and `customLabel` instead'
+   */
   slots?: MenuItemSlots
+  customIcon?: string | ((data: MenuItemProps & { selected: boolean }) => VNodeChild)
+  customLabel?: string | ((data: MenuItemProps & { selected: boolean }) => VNodeChild)
 }
 export type MenuItemPublicProps = Omit<MenuItemProps, 'type' | 'additional' | 'slots'>
 export type MenuItemComponent = FunctionalComponent<
@@ -83,7 +88,12 @@ export interface MenuItemGroupProps extends MenuCommonProps {
   children?: MenuData[]
   icon?: string | VNode
   label?: string
+  /**
+   * @deprecated please use `customIcon` and `customLabel` instead'
+   */
   slots?: MenuItemGroupSlots
+  customIcon?: string | ((data: MenuItemGroupProps) => VNodeChild)
+  customLabel?: string | ((data: MenuItemGroupProps) => VNodeChild)
 }
 export type MenuItemGroupPublicProps = Omit<MenuItemGroupProps, 'type' | 'additional' | 'slots'>
 export type MenuItemGroupComponent = FunctionalComponent<
@@ -96,6 +106,7 @@ export interface MenuSubSlots {
   label?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
   suffix?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
 }
+
 export interface MenuSubProps extends MenuCommonProps {
   type: 'sub'
   children?: MenuData[]
@@ -104,7 +115,13 @@ export interface MenuSubProps extends MenuCommonProps {
   label?: string
   offset?: [number, number]
   suffix?: string
+  /**
+   * @deprecated please use `customIcon`, `customLabel` and `customSuffix` instead'
+   */
   slots?: MenuSubSlots
+  customIcon?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
+  customLabel?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
+  customSuffix?: string | ((data: MenuSubProps & { expanded: boolean; selected: boolean }) => VNodeChild)
 }
 
 export type MenuSubPublicProps = Omit<MenuSubProps, 'type' | 'additional' | 'slots'>

--- a/packages/components/table/docs/Index.zh.md
+++ b/packages/components/table/docs/Index.zh.md
@@ -104,7 +104,7 @@ export type TableColumn<T = any, V = any> =
 
 | 名称 | 说明 | 类型  | 默认值 | 全局配置 | 备注 |
 | --- | --- | --- | --- | --- | --- |
-| `type` | 列类型 | `'selectable'` | - | - | `type` 设置为 `selectable`,即为选择列 |
+| `type` | 列类型 | `'selectable'` | - | - | 必填 |
 | `disabled` |  设置是否允许行选择 | `(record: T, rowIndex: number) => boolean` | - | - | - |
 | `multiple` | 是否支持多选 | `boolean` | `true` | - | - |
 | `menus` | 自定义列头下拉菜单 | `('all' \| 'invert' \| 'none' \| 'pageInvert' \| MenuData)[]` | - | - | - |

--- a/packages/site/src/components/layout/LayoutSider.vue
+++ b/packages/site/src/components/layout/LayoutSider.vue
@@ -1,6 +1,6 @@
 <template>
   <IxMenu :dataSource="menus" mode="inline" :indent="breakpoints.xs ? 24 : 48" :selectedKeys="selectedKeys">
-    <template #label="item">
+    <template #itemLabel="item">
       <router-link :to="item.key">
         <span>{{ item.title }}</span>
         <span v-if="item.subtitle" class="sub-title">{{ item.subtitle }}</span>
@@ -32,12 +32,12 @@ const menus = computed(() => {
           label: name,
           children: children.map(item => {
             const { path, title, subtitle } = item
-            return { key: path, title, subtitle, slots: { label: 'label' } }
+            return { key: path, title, subtitle }
           }),
         }
       }
       const { path, title, subtitle } = item
-      return { key: path, title, subtitle, slots: { label: 'label' } }
+      return { key: path, title, subtitle }
     })
 })
 </script>


### PR DESCRIPTION
BREAKING CHANGE: `slots` of `MenuData` is deprecated,  please use `customIcon`, `customLabel` and
`customSuffix` instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Other information
