### PR TITLE
refactor(comp: tree): optimize rendering speed for big data

### DIFF
--- a/packages/components/tree/demo/Virtual.vue
+++ b/packages/components/tree/demo/Virtual.vue
@@ -1,12 +1,14 @@
 <template>
-  <IxTree :dataSource="treeData" :height="200" virtual></IxTree>
+  <IxTree v-model:expandedKeys="expandedKeys" :dataSource="treeData" :height="200" virtual></IxTree>
 </template>
 
 <script setup lang="ts">
 import type { VKey } from '@idux/cdk/utils'
 import type { TreeNode } from '@idux/components/tree'
 
-const expandedKeys: VKey[] = []
+import { ref } from 'vue'
+
+const expandedKeys = ref<VKey[]>([])
 
 function genData(path = '0', level = 3) {
   const data = []
@@ -19,7 +21,7 @@ function genData(path = '0', level = 3) {
     }
 
     if (level > 0) {
-      expandedKeys.push(key)
+      expandedKeys.value.push(key)
       node.children = genData(key, level - 1)
     }
 

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -5,6 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
+import type { MergedNode } from './composables/useDataSource'
 import type { VirtualItemRenderFn, VirtualScrollInstance, VirtualScrollToOptions } from '@idux/cdk/scroll'
 import type { StyleValue, VNodeTypes } from 'vue'
 
@@ -18,7 +19,7 @@ import { ɵEmpty } from '@idux/components/_private/empty'
 import { useGlobalConfig } from '@idux/components/config'
 
 import { useCheckable } from './composables/useCheckable'
-import { FlattedNode, useFlattedNodes, useMergeNodes } from './composables/useDataSource'
+import { useFlattedNodes, useMergeNodes } from './composables/useDataSource'
 import { useDragDrop } from './composables/useDragDrop'
 import { useEvents } from './composables/useEvents'
 import { useExpandable } from './composables/useExpandable'
@@ -126,10 +127,10 @@ export default defineComponent({
     const scrollTo = (option?: number | VirtualScrollToOptions) => {
       virtualScrollRef?.value?.scrollTo(option)
     }
-    const { setExpandAll } = expandableContext
-    expose({ focus, blur, scrollTo, setExpandAll })
 
-    const handleScrolledChange = (startIndex: number, endIndex: number, visibleNodes: FlattedNode[]) => {
+    expose({ focus, blur, scrollTo })
+
+    const handleScrolledChange = (startIndex: number, endIndex: number, visibleNodes: MergedNode[]) => {
       callEmit(
         props.onScrolledChange,
         startIndex,
@@ -143,9 +144,7 @@ export default defineComponent({
 
       let children: VNodeTypes
       if (nodes.length > 0) {
-        const itemRender: VirtualItemRenderFn<FlattedNode> = ({ item }) => (
-          <TreeNode key={item.key} node={item}></TreeNode>
-        )
+        const itemRender: VirtualItemRenderFn<MergedNode> = ({ item }) => <TreeNode node={item} {...item}></TreeNode>
         const { height, virtual, onScroll, onScrolledBottom } = props
         children = (
           <CdkVirtualScroll

--- a/packages/components/tree/src/node/Checkbox.tsx
+++ b/packages/components/tree/src/node/Checkbox.tsx
@@ -27,7 +27,7 @@ export default defineComponent({
       <IxCheckbox
         class={`${mergedPrefixCls.value}-node-checkbox`}
         checked={isChecked.value}
-        disabled={props.node.checkDisabled}
+        disabled={props.checkDisabled}
         indeterminate={isIndeterminate.value}
         onChange={onChange}
       />

--- a/packages/components/tree/src/node/TreeNode.tsx
+++ b/packages/components/tree/src/node/TreeNode.tsx
@@ -7,6 +7,8 @@
 
 import { computed, defineComponent, inject } from 'vue'
 
+import { useKey } from '@idux/components/utils'
+
 import { treeToken } from '../token'
 import { treeNodeProps } from '../types'
 import { getParentKeys } from '../utils'
@@ -37,19 +39,17 @@ export default defineComponent({
       handleDrop,
     } = inject(treeToken)!
 
-    const key = computed(() => props.node.key)
+    const key = useKey()
 
-    const isActive = computed(() => activeKey.value === key.value)
-    const isLast = computed(() => treeProps.showLine && props.node.isLast)
-    const hasTopLine = computed(
-      () => treeProps.showLine && !props.node.isLeaf && props.node.level !== 0 && props.node.isFirst,
-    )
-    const selected = computed(() => selectedKeys.value.includes(key.value))
-    const disabled = computed(() => props.node.selectDisabled || !treeProps.selectable)
+    const isActive = computed(() => activeKey.value === key)
+    const isLast = computed(() => treeProps.showLine && props.isLast)
+    const hasTopLine = computed(() => treeProps.showLine && !props.isLeaf && props.level !== 0 && props.isFirst)
+    const selected = computed(() => selectedKeys.value.includes(key))
+    const disabled = computed(() => props.selectDisabled || !treeProps.selectable)
 
-    const dragging = computed(() => dragKey.value === key.value)
-    const dropping = computed(() => dropKey.value === key.value)
-    const dropParent = computed(() => dropParentKey.value === key.value)
+    const dragging = computed(() => dragKey.value === key)
+    const dropping = computed(() => dropKey.value === key)
+    const dropParent = computed(() => dropParentKey.value === key)
     const dropBefore = computed(() => dropping.value && dropType.value === 'before')
     const dropInside = computed(() => dropping.value && dropType.value === 'inside')
     const dropAfter = computed(() => dropping.value && dropType.value === 'after')
@@ -62,7 +62,7 @@ export default defineComponent({
         [`${prefixCls}-last`]: isLast.value,
         [`${prefixCls}-disabled`]: disabled.value,
         [`${prefixCls}-selected`]: selected.value,
-        [`${prefixCls}-expanded`]: props.node.expanded,
+        [`${prefixCls}-expanded`]: props.expanded,
         [`${prefixCls}-dragging`]: dragging.value,
         [`${prefixCls}-dropping`]: dropping.value,
         [`${prefixCls}-drop-parent`]: dropParent.value,
@@ -111,9 +111,8 @@ export default defineComponent({
 
     return () => {
       const nodeMap = mergedNodeMap.value
-      const node = props.node
 
-      const { isLeaf, key, label, level, rawNode, expanded, dragDisabled, dropDisabled } = node
+      const { isLeaf, label, level, rawNode, expanded, checkDisabled, dragDisabled, dropDisabled, node } = props
       const { showLine, checkable, draggable } = treeProps
       const mergedDraggable = draggable && !dragDisabled
       const currNode = nodeMap.get(key)
@@ -147,7 +146,7 @@ export default defineComponent({
           ) : (
             <Expand expanded={expanded} hasTopLine={hasTopLine.value} isLeaf={isLeaf} nodeKey={key} rawNode={rawNode} />
           )}
-          {checkable && <Checkbox node={node} />}
+          {checkable && <Checkbox checkDisabled={checkDisabled} node={node} />}
           <Content disabled={disabled.value} nodeKey={key} label={label} rawNode={rawNode} selected={selected.value} />
         </div>
       )

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { FlattedNode } from './composables/useDataSource'
+import type { MergedNode } from './composables/useDataSource'
 import type { VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { IxInnerPropTypes, IxPublicPropTypes, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
@@ -133,17 +133,31 @@ export interface TreeDragDropOptions {
 // private
 export const motionTreeNodeProps = {
   expanded: IxPropTypes.bool,
-  expandedNodes: IxPropTypes.array<FlattedNode>(),
-  node: IxPropTypes.object<FlattedNode>(),
+  expandedNodes: IxPropTypes.array<MergedNode>(),
+  node: IxPropTypes.object<MergedNode>(),
   prefixCls: IxPropTypes.string.isRequired,
 }
 
 export const treeNodeProps = {
-  node: IxPropTypes.object<FlattedNode>().isRequired,
+  node: IxPropTypes.object<MergedNode>().isRequired,
+  isLeaf: IxPropTypes.bool.isRequired,
+  isFirst: IxPropTypes.bool.isRequired,
+  isLast: IxPropTypes.bool.isRequired,
+  label: IxPropTypes.string.isRequired,
+  level: IxPropTypes.number.isRequired,
+  rawNode: IxPropTypes.object<TreeNode>().isRequired,
+  expanded: IxPropTypes.bool.isRequired,
+  children: IxPropTypes.array<MergedNode>(),
+  parentKey: IxPropTypes.oneOfType([String, Number, Symbol]),
+  checkDisabled: IxPropTypes.bool,
+  dragDisabled: IxPropTypes.bool,
+  dropDisabled: IxPropTypes.bool,
+  selectDisabled: IxPropTypes.bool,
 }
 
 export const treeNodeCheckboxProps = {
-  node: IxPropTypes.object<FlattedNode>().isRequired,
+  node: IxPropTypes.object<MergedNode>().isRequired,
+  checkDisabled: IxPropTypes.bool,
 }
 
 export const treeNodeExpandProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
测试：当拥有一万个数据节点，展开所有节点的情况下，哪怕开启了虚拟滚动，也会很卡，如tree的虚拟滚动Demo所示

## What is the new behavior?
优化项：
 - 使用非递归的方式勾选所有的树的flattedNode数据结构，降低空间复杂度
 - 使用Map寻找expandedNode的方式代替使用includes，降低时间复杂度
 - 每次构造的数据沿时用mergeNode，而不是{...mergeNode}，使得Tree在展开节点重新渲染时只渲染新展开更新的节点，不会所有节点都更新

测试结果： 10万条数据在相同条件下，渲染速度由10S减少到1S
## Other information

TODO： 二次构造数据时不用再重新循环所有数据构造flattedNode节点，即diff patch代替全量patch


