### PR TITLE
feat(comp:select): add 'overlay' to searchable

### DIFF
--- a/packages/components/select/demo/CustomLabel.vue
+++ b/packages/components/select/demo/CustomLabel.vue
@@ -1,7 +1,7 @@
 <template>
   <IxSelect v-model:value="value" :options="options" multiple :maxLabelCount="3" :multipleLimit="5" @change="onChange">
-    <template #label="option"><IxIcon :name="option.value" />{{ option.label }}</template>
-    <template #maxLabel="moreOptions">and {{ moreOptions.length }} more selected</template>
+    <template #selectedLabel="option"><IxIcon :name="option.value" />{{ option.label }}</template>
+    <template #overflowedLabel="moreOptions">and {{ moreOptions.length }} more selected</template>
   </IxSelect>
 </template>
 <script setup lang="ts">

--- a/packages/components/select/demo/Searchable.vue
+++ b/packages/components/select/demo/Searchable.vue
@@ -1,10 +1,29 @@
 <template>
-  <IxSelect v-model:value="value" :options="options" searchable placeholder="Searchable" @change="onChange"> </IxSelect>
+  <IxSpace direction="vertical">
+    <IxSpace> searchable:<IxRadioGroup v-model:value="searchableValue" :options="searchableOptions" /></IxSpace>
+    <IxSelect
+      v-model:value="value"
+      :options="options"
+      :searchable="searchableValue"
+      placeholder="Searchable"
+      @change="onChange"
+    >
+    </IxSelect>
+  </IxSpace>
 </template>
 <script setup lang="ts">
+import type { RadioOption } from '@idux/components/radio'
+import type { SelectData } from '@idux/components/select'
+
 import { ref } from 'vue'
 
-import { SelectData } from '@idux/components/select'
+const searchableValue = ref(true)
+
+const searchableOptions: RadioOption[] = [
+  { label: 'true', value: true },
+  { label: 'overlay', value: 'overlay' },
+  { label: 'false', value: false },
+]
 
 const options: SelectData[] = [
   { key: 1, label: 'Tom', value: 'tom' },

--- a/packages/components/select/docs/Index.zh.md
+++ b/packages/components/select/docs/Index.zh.md
@@ -34,7 +34,7 @@ order: 0
 | `overlayRender` | 自定义下拉菜单内容的渲染  | `(children:VNode[]) => VNodeTypes` | - | - | - |
 | `placeholder` | 选择框默认文本 | `string \| #placeholder` | - | - | - |
 | `readonly` | 只读模式 | `boolean` | - | - | - |
-| `searchable` | 是否可搜索 | `boolean` | `false` | - | - |
+| `searchable` | 是否可搜索 | `boolean \| 'overlay'` | `false` | - | 当为 `true` 时搜索功能集成在选择器上，当为 `overlay` 时，搜索功能集成在悬浮层上 |
 | `searchFilter` | 根据搜索的文本进行筛选 | `boolean \| SelectFilterFn` | `true` | - | 为 `true` 时使用默认的搜索规则, 如果使用远程搜索，应该设置为 `false` |
 | `size` | 设置选择器大小 | `'sm' \| 'md' \| 'lg'` | `md` | ✅ | - |
 | `suffix` | 设置后缀图标 | `string \| #suffix` | `down` | ✅ | - |
@@ -83,8 +83,8 @@ export type SelectFilterFn = (searchValue: string, data: SelectData) => boolean
 | 名称 | 说明 | 参数类型 | 备注 |
 |  -- | -- | -- | -- |
 |  `default` | 选项内容 | - | - |
-|  `label` | 自定义选中的标签 | `data: SelectOption` |  |
-|  `maxLabel` | 自定义超出最多显示多少个标签的内容 | `data: SelectOption[]` | 参数为超出的数组 |
+|  `selectedLabel` | 自定义选中的标签 | `data: SelectOption` |  |
+|  `overflowedLabel` | 自定义超出最多显示多少个标签的内容 | `data: SelectOption[]` | 参数为超出的数组 |
 |  `optionLabel` | 自定义选项的文本 | `data: SelectOption` | - |
 |  `optionGroupLabel` | 自定义选项组的文本 | `data: SelectOptionGroup` | - |
 

--- a/packages/components/select/src/content/Content.tsx
+++ b/packages/components/select/src/content/Content.tsx
@@ -12,6 +12,7 @@ import { defineComponent, inject, onMounted } from 'vue'
 import { CdkVirtualScroll, VirtualItemRenderFn } from '@idux/cdk/scroll'
 import { callEmit } from '@idux/cdk/utils'
 import { ɵEmpty } from '@idux/components/_private/empty'
+import { ɵInput } from '@idux/components/_private/input'
 
 import { selectToken } from '../token'
 import ListBox from './ListBox'
@@ -20,7 +21,17 @@ import OptionGroup from './OptionGroup'
 
 export default defineComponent({
   setup() {
-    const { props, slots, flattedOptions, virtualScrollRef, scrollToActivated } = inject(selectToken)!
+    const {
+      props,
+      slots,
+      mergedPrefixCls,
+      flattedOptions,
+      virtualScrollRef,
+      scrollToActivated,
+      inputValue,
+      handleInput,
+      handleClear,
+    } = inject(selectToken)!
 
     onMounted(() => scrollToActivated())
 
@@ -62,6 +73,21 @@ export default defineComponent({
         )
       } else {
         children.push(<ɵEmpty v-slots={slots} empty={props.empty} />)
+      }
+
+      if (props.searchable === 'overlay') {
+        children.unshift(
+          <div class={`${mergedPrefixCls.value}-overlay-search-wrapper`}>
+            <ɵInput
+              clearable
+              size="sm"
+              suffix="search"
+              value={inputValue.value}
+              onInput={handleInput}
+              onClear={handleClear}
+            />
+          </div>,
+        )
       }
 
       return overlayRender ? overlayRender(children) : <div>{children}</div>

--- a/packages/components/select/src/content/ListBox.tsx
+++ b/packages/components/select/src/content/ListBox.tsx
@@ -10,26 +10,28 @@
 import type { MergedOption } from '../composables/useOptions'
 import type { FunctionalComponent } from 'vue'
 
-import { inject } from 'vue'
+import { type Slots, inject } from 'vue'
 
 import { selectToken } from '../token'
+import { renderOptionLabel } from '../utils/renderOptionLabel'
 
 const defaultStyle = { height: 0, width: 0, overflow: 'hidden' }
 
 const ListBox: FunctionalComponent = () => {
-  const { props, selectedValue, mergedOptions, activeIndex, activeOption } = inject(selectToken)!
+  const { props, slots, selectedValue, mergedOptions, activeIndex, activeOption } = inject(selectToken)!
   const currSelectedValue = selectedValue.value
   const { compareWith } = props
   return (
     <div role="listbox" style={defaultStyle}>
-      {renderOption(mergedOptions.value[activeIndex.value - 1], currSelectedValue, compareWith)}
-      {renderOption(activeOption.value, currSelectedValue, compareWith)}
-      {renderOption(mergedOptions.value[activeIndex.value + 1], currSelectedValue, compareWith)}
+      {renderOption(slots, mergedOptions.value[activeIndex.value - 1], currSelectedValue, compareWith)}
+      {renderOption(slots, activeOption.value, currSelectedValue, compareWith)}
+      {renderOption(slots, mergedOptions.value[activeIndex.value + 1], currSelectedValue, compareWith)}
     </div>
   )
 }
 
 const renderOption = (
+  slots: Slots,
   option: MergedOption | undefined,
   selectedValue: any,
   compareWith: (o1: any, o2: any) => boolean,
@@ -41,7 +43,7 @@ const renderOption = (
   const selected = compareWith(selectedValue, value)
   return (
     <div key={key} role="option" aria-label={label} aria-selected={selected}>
-      {rawOption.slots?.default?.(rawOption) ?? label}
+      {renderOptionLabel(slots, rawOption, label)}
     </div>
   )
 }

--- a/packages/components/select/src/content/Option.tsx
+++ b/packages/components/select/src/content/Option.tsx
@@ -7,12 +7,11 @@
 
 import { computed, defineComponent, inject } from 'vue'
 
-import { isString } from 'lodash-es'
-
 import { IxCheckbox } from '@idux/components/checkbox'
 
 import { selectToken } from '../token'
 import { optionProps } from '../types'
+import { renderOptionLabel } from '../utils/renderOptionLabel'
 
 export default defineComponent({
   props: optionProps,
@@ -61,8 +60,7 @@ export default defineComponent({
       const { multiple } = selectProps
       const selected = isSelected.value
       const prefixCls = `${mergedPrefixCls.value}-option`
-      const labelRender = rawOption.customLabel ?? 'optionLabel'
-      const labelSlot = isString(labelRender) ? slots[labelRender] : labelRender
+
       return (
         <div
           class={classes.value}
@@ -73,7 +71,7 @@ export default defineComponent({
           aria-selected={selected}
         >
           {multiple && <IxCheckbox checked={isSelected.value} disabled={disabled} />}
-          <span class={`${prefixCls}-label`}>{labelSlot ? labelSlot(rawOption) : label}</span>
+          <span class={`${prefixCls}-label`}>{renderOptionLabel(slots, rawOption, label)}</span>
         </div>
       )
     }

--- a/packages/components/select/src/trigger/Input.tsx
+++ b/packages/components/select/src/trigger/Input.tsx
@@ -28,7 +28,7 @@ export default defineComponent({
 
     const innerStyle = computed(() => {
       const { allowInput, searchable } = props
-      const isOpacity = allowInput || searchable
+      const isOpacity = allowInput || searchable === true
       return { opacity: isOpacity ? undefined : 0 }
     })
 

--- a/packages/components/select/src/trigger/Trigger.tsx
+++ b/packages/components/select/src/trigger/Trigger.tsx
@@ -50,7 +50,7 @@ export default defineComponent({
       if (suffix) {
         return suffix
       }
-      return props.searchable && isFocused.value ? 'search' : config.suffix
+      return props.searchable === true && isFocused.value ? 'search' : config.suffix
     })
 
     const classes = computed(() => {

--- a/packages/components/select/src/types.ts
+++ b/packages/components/select/src/types.ts
@@ -41,7 +41,7 @@ export const selectProps = {
   overlayRender: IxPropTypes.func<(children: VNode[]) => VNodeTypes>(),
   placeholder: IxPropTypes.string,
   readonly: IxPropTypes.bool.def(false),
-  searchable: IxPropTypes.bool.def(false),
+  searchable: IxPropTypes.oneOfType([Boolean, IxPropTypes.oneOf(['overlay'])]).def(false),
   searchFilter: IxPropTypes.oneOfType([Boolean, IxPropTypes.func<SelectFilterFn>()]).def(true),
   size: IxPropTypes.oneOf<FormSize>(['sm', 'md', 'lg']),
   suffix: IxPropTypes.string,

--- a/packages/components/select/src/utils/renderOptionLabel.ts
+++ b/packages/components/select/src/utils/renderOptionLabel.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { SelectOptionProps } from '../types'
+import type { Slots, VNodeChild } from 'vue'
+
+import { isString } from 'lodash-es'
+
+export function renderOptionLabel(slots: Slots, rawOption: SelectOptionProps, label?: string): VNodeChild {
+  const labelRender = rawOption.customLabel ?? 'optionLabel'
+  const labelSlot = isString(labelRender) ? slots[labelRender] : labelRender
+
+  return labelSlot?.(rawOption) ?? label
+}

--- a/packages/components/select/style/index.less
+++ b/packages/components/select/style/index.less
@@ -115,6 +115,10 @@
     .@{select-option-prefix}-group:not(:first-child) {
       border-top: @select-option-group-border;
     }
+
+    &-search-wrapper {
+      padding: @select-overlay-input-padding;
+    }
   }
 }
 

--- a/packages/components/select/style/themes/default.variable.less
+++ b/packages/components/select/style/themes/default.variable.less
@@ -50,6 +50,8 @@
 @select-option-container-border-radius: @border-radius-sm;
 @select-option-container-box-shadow: @shadow-bottom-md;
 
+@select-overlay-input-padding: 0 @spacing-md @spacing-sm;
+
 @select-icon-font-size: @font-size-sm;
 @select-icon-margin-right: @spacing-xs;
 @select-icon-color: @select-placeholder-color;


### PR DESCRIPTION
input is now rendered within overlay when searchable is 'overlay'

fix(comp:selectable): fix selected options render when using IxSelectOption

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. searchable 不支持 ’overlay‘
2. 使用 IxSelectOption渲染的option在选中时不显示

## What is the new behavior?
1. searchable支持 'overlay', 与 tree-select 保持一致
2. 使用 IxSelectOption渲染的option在选中时可以正常显示
## Other information
抽离label渲染的工具函数 renderOptionLabel