### PR TITLE
fix(comp: affix): style is not recalculated when resizing

### DIFF
--- a/packages/components/affix/src/Affix.tsx
+++ b/packages/components/affix/src/Affix.tsx
@@ -45,7 +45,7 @@ export default defineComponent({
 
     const throttleMeasure = throttleRAF(measure)
 
-    function measure() {
+    function measure(event?: unknown) {
       if (!affixRef.value || !targetRef.value) {
         return
       }
@@ -53,6 +53,16 @@ export default defineComponent({
       isStickyRef.value = isSticky(affixRect, offset.value)
       contentStyle.value = calcPosition(affixRect, offset.value, targetRef.value)
       if (isStickyRef.value && contentRef.value) {
+        if (event && (event as Event).type === 'resize') {
+          clearStyle()
+
+          nextTick(() => {
+            measure()
+          })
+
+          return
+        }
+
         const { width, height } = getTargetSize(contentRef.value)
         contentStyle.value = {
           ...contentStyle.value,
@@ -67,6 +77,11 @@ export default defineComponent({
           affixStyle.value.position = 'relative'
         }
       }
+    }
+
+    function clearStyle() {
+      affixStyle.value = {}
+      contentStyle.value = {}
     }
 
     onMounted(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. 当isStickyRef.value为false时，没有清除为true时动态赋值的style
![GIF 2022-1-22 20-00-44](https://user-images.githubusercontent.com/26105153/150637743-317b6de5-79c5-4fec-872e-8257f2128cfe.gif)

2. 当内容区宽高自适应，且target触发resize时，没有重新计算内容区的宽高，导致布局出现问题

## What is the new behavior?

## Other information
