### PR TITLE
refactor(comp:time-picker): refactor style

### DIFF
--- a/packages/components/_private/time-panel/src/composables/useOptions.ts
+++ b/packages/components/_private/time-panel/src/composables/useOptions.ts
@@ -71,13 +71,23 @@ export function useOptions(
     }
   }
 
+  const getHourValue = () => {
+    const value = ampm.value === 'pm' ? get(selectedValue.value, 'hour') % 12 : get(selectedValue.value, 'hour')
+
+    if (ampm.value) {
+      return value === 0 ? 12 : value
+    }
+
+    return value
+  }
+
   function getSelectedValue(type: TimePanelColumnType) {
     switch (type) {
       case 'AM/PM':
         return ampm.value
       case 'hour':
       default:
-        return get(selectedValue.value, 'hour')
+        return getHourValue()
       case 'minute':
         return get(selectedValue.value, 'minute')
       case 'second':

--- a/packages/components/_private/time-panel/src/utils.ts
+++ b/packages/components/_private/time-panel/src/utils.ts
@@ -8,7 +8,7 @@
 import type { TimePanelColumnType } from './types'
 import type { DateConfig } from '@idux/components/config'
 
-export function normalizeAmPm(hour: number, is12Hours = false): string {
+export function normalizeAmPm(hour: number, is12Hours = false): 'am' | 'pm' | '' {
   if (!is12Hours) {
     return ''
   }

--- a/packages/components/_private/time-panel/style/index.less
+++ b/packages/components/_private/time-panel/style/index.less
@@ -4,7 +4,8 @@
   justify-content: space-between;
   width: 100%;
   height: @time-panel-height;
-  padding: @time-panel-padding;
+  padding: @time-panel-padding-vertical @time-panel-padding-horizontal;
+  font-size: @time-panel-font-size;
 
   ::-webkit-scrollbar {
     width: @time-panel-scrollbar-width;
@@ -27,7 +28,7 @@
     position: absolute;
     display: block;
     top: 50%;
-    width: calc(100% - @time-panel-padding * 2);
+    width: calc(100% - @time-panel-padding-horizontal * 2);
     margin-top: -(@time-panel-cell-height / 2);
     height: @time-panel-cell-height;
     border-top: @time-panel-window-border-width @time-panel-window-border-style @time-panel-window-border-color;
@@ -37,7 +38,6 @@
 
   &-column {
     position: relative;
-    width: @time-panel-cell-width;
     height: 100%;
     margin: 0;
     list-style-type: none;
@@ -51,13 +51,10 @@
       height: calc(50% - (@time-panel-cell-height / 2));
     }
 
-    &:last-child {
-      border-right: none;
-    }
 
     &:hover {
       overflow-y: scroll;
-      padding-left: @time-panel-scrollbar-width;
+      margin-right: -@time-panel-scrollbar-width;
     }
   }
 

--- a/packages/components/_private/time-panel/style/themes/default.variable.less
+++ b/packages/components/_private/time-panel/style/themes/default.variable.less
@@ -1,13 +1,14 @@
 @time-panel-disabled-color: @form-disabled-color;
 
 @time-panel-height: 224px;
-@time-panel-padding: @spacing-md;
+@time-panel-padding-horizontal: @spacing-lg;
+@time-panel-padding-vertical: @spacing-sm;
+@time-panel-font-size: @font-size-md;
 
 @time-panel-window-border-width: @form-border-width;
 @time-panel-window-border-style: @form-border-style;
 @time-panel-window-border-color: @form-border-color;
 
-@time-panel-cell-width: 40px;
 @time-panel-cell-height: 32px;
 @time-panel-cell-color: @color-graphite-d10;
 @time-panel-cell-active-background-color: transparent;

--- a/packages/components/time-picker/src/composables/useProps.ts
+++ b/packages/components/time-picker/src/composables/useProps.ts
@@ -16,7 +16,7 @@ import type { PopperPlacement, PopperTrigger } from '@idux/cdk/popper'
 import type { PortalTargetType } from '@idux/cdk/portal'
 import type { ɵBaseTimePanelProps } from '@idux/components/_private/time-panel'
 import type { TimePickerConfig, TimeRangePickerConfig } from '@idux/components/config'
-import type { FormContext, FormSize } from '@idux/components/form'
+import type { FormSize } from '@idux/components/form'
 import type { ComputedRef } from 'vue'
 
 import { computed } from 'vue'
@@ -35,14 +35,13 @@ export interface CommonInputProps {
 export function useCommonInputProps(
   props: TimePickerProps | TimeRangePickerProps,
   config: TimePickerConfig | TimeRangePickerConfig,
-  formContext?: FormContext | null,
 ): ComputedRef<CommonInputProps> {
   return computed(() => {
     return {
       borderless: props.borderless ?? config.borderless,
       clearable: props.clearable ?? config.clearable,
       clearIcon: props.clearIcon ?? config.clearIcon,
-      size: props.size ?? formContext?.size.value ?? config.size,
+      size: 'sm',
     }
   })
 }

--- a/packages/components/time-picker/src/overlay/RangeOverlay.tsx
+++ b/packages/components/time-picker/src/overlay/RangeOverlay.tsx
@@ -30,7 +30,6 @@ export default defineComponent({
       format,
       inputEnableStatus,
       overlayOpened,
-      formContext,
       bufferValue,
       commonBindings: { isDisabled, handleChange },
       renderSeparator,
@@ -38,7 +37,7 @@ export default defineComponent({
     } = inject(timeRangePickerContext)!
     const [fromPickerControl, toPickerControl] = inject(timeRangePickerControl)!
 
-    const inputProps = useCommonInputProps(props, config, formContext)
+    const inputProps = useCommonInputProps(props, config)
     const panelProps = useCommonPanelProps(props, config)
 
     const handleConfirm = () => {
@@ -90,7 +89,7 @@ export default defineComponent({
 
     const renderFooter = () =>
       slots.footer?.({ onConfirm: handleConfirm }) ?? (
-        <IxButton mode="primary" size="sm" onClick={handleConfirm}>
+        <IxButton mode="primary" size="xs" onClick={handleConfirm}>
           {locale.timeRangePicker.okText}
         </IxButton>
       )

--- a/packages/components/time-picker/style/index.less
+++ b/packages/components/time-picker/style/index.less
@@ -104,6 +104,8 @@
     border: none;
     outline: none;
     appearance: none;
+    color: inherit;
+    font-size: inherit;
     .placeholder(@time-picker-placeholder-color);
   }
 }
@@ -115,6 +117,7 @@
   padding: @time-picker-overlay-padding;
   background-color: @time-picker-overlay-background-color;
   box-shadow: @time-picker-overlay-box-shadow;
+  font-size: @time-picker-overlay-font-size;
 
   & &-input {
     margin-bottom: @time-picker-input-margin;

--- a/packages/components/time-picker/style/range.less
+++ b/packages/components/time-picker/style/range.less
@@ -19,6 +19,7 @@
   
   background-color: @time-picker-overlay-background-color;
   box-shadow: @time-picker-overlay-box-shadow;
+  font-size: @time-picker-overlay-font-size;
 
   &-content {
     display: flex;
@@ -28,7 +29,7 @@
   &-gap {
     padding: @time-range-picker-overlay-gap-padding;
     text-align: center;
-    color: @time-picker-placeholder-color;
+    color: @time-picker-color;
   }
 
   &-footer {

--- a/packages/components/time-picker/style/themes/default.variable.less
+++ b/packages/components/time-picker/style/themes/default.variable.less
@@ -23,6 +23,7 @@
 @time-picker-overlay-width: 200px;
 @time-picker-overlay-padding: @spacing-sm;
 @time-picker-overlay-box-shadow: @shadow-bottom-md;
+@time-picker-overlay-font-size: @font-size-md;
 @time-picker-overlay-background-color: @form-background-color;
 @time-picker-footer-padding: @spacing-sm 0;
 @time-picker-footer-margin: 0 @spacing-lg;
@@ -33,7 +34,7 @@
 @time-range-picker-overlay-gap-padding: 5px 8px;
 @time-range-picker-panel-border-width: @time-picker-border-width;
 @time-range-picker-panel-border-style: @time-picker-border-style;
-@time-range-picker-panel-border-color: @color-graphite-l30;
+@time-range-picker-panel-border-color: @time-picker-border-color;
 @time-range-picker-panel-border-radius: @time-picker-border-radius;
 
 @time-picker-input-margin: @spacing-sm;


### PR DESCRIPTION
fix input size within overlay to 'sm'
remove padding of time-panel column

fix(comp:time-picker): fix get hour value when 'pm' is sepcified

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
1. 在'pm'下时间选择的hour取值不正确
2. 时间选择面板column的分布不美观
3. 时间选择面板的纵向横向padding不支持分开配置

## What is the new behavior?

## Other information
