### PR TITLE
fix(comp:anchor): should default active first item

### DIFF
--- a/packages/components/anchor/__tests__/anchor.spec.ts
+++ b/packages/components/anchor/__tests__/anchor.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 
 import { renderWork, scrollTarget, wait } from '@tests'
 
@@ -91,6 +91,14 @@ describe('Anchor', () => {
     await wait(100)
 
     expect(window.scrollTo).toHaveBeenCalled()
+  })
+
+  test('anchor default active first one', async () => {
+    // fix issue #774
+    const wrapper = mount(TestComponent)
+    await nextTick()
+    const links = wrapper.findAll('.ix-anchor-link')
+    expect(links[0].find('a').classes()).toContain('ix-anchor-link-title-active')
   })
 
   test('register and unregister work', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- remove default link
- use first item as reduce start, ensure default first item active works

<img width="503" alt="image" src="https://user-images.githubusercontent.com/31590999/162573157-6790e79f-ee96-42c9-892e-c5fa82f53564.png">


## What is the new behavior?

## Other information

close #774 