### PR TITLE
fix(comp:table): fix table column width measure problem when data load is delayed

### DIFF
--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -120,7 +120,7 @@ export default defineComponent({
       const width = scrollWidth.value
       const height = scrollHeight.value
       const overflowX = width ? 'auto' : undefined
-      const overflowY = props.virtual ? 'hidden' : height ? 'scroll' : width ? 'hidden' : undefined
+      const overflowY = props.virtual ? 'hidden' : height ? 'auto' : width ? 'hidden' : undefined
       const fullHeight = props.scroll?.fullHeight
       return { overflowX, overflowY, [fullHeight ? 'height' : 'maxHeight']: height }
     })

--- a/packages/components/table/src/main/body/Body.tsx
+++ b/packages/components/table/src/main/body/Body.tsx
@@ -28,7 +28,9 @@ export default defineComponent({
       bodyTag,
     } = inject(TABLE_TOKEN)!
 
-    const showMeasure = computed(() => scrollWidth.value || scrollHeight.value || isSticky.value)
+    const showMeasure = computed(
+      () => flattedData.value.length > 0 && (scrollWidth.value || scrollHeight.value || isSticky.value),
+    )
 
     return () => {
       const children: VNodeChild[] = []


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
1. 虚拟滚动场景下，延迟加载数据之后列宽计算不准确，整体表格宽度比预期多出一个滚动条宽度
2. 在提供高度时默认 overflow-y: scroll

## What is the new behavior?
1. 在有数据时再渲染measureRow，使得远程数据加载场景下的列宽计算没有问题
2. 修改overflow-y为auto

## Other information
