### PR TITLE
fix(comp: tree): the horizontal scroll bar does not appear

### DIFF
--- a/packages/components/config/src/defaultConfig.ts
+++ b/packages/components/config/src/defaultConfig.ts
@@ -338,7 +338,7 @@ export const defaultConfig: GlobalConfig = {
     clearIcon: 'close-circle',
     labelKey: 'label',
     nodeKey: 'key',
-    overlayMatchWidth: false,
+    overlayMatchWidth: true,
     size: 'md',
     suffix: 'down',
   },

--- a/packages/components/tree-select/docs/Index.zh.md
+++ b/packages/components/tree-select/docs/Index.zh.md
@@ -50,7 +50,7 @@ order: 0
 | `treeDisabled` | 树的禁用节点的函数 | 参考 [Tree](/components/tree/zh#API) | - | - | - |
 | `virtual` | 是否开启虚拟滚动 | `boolean` | `false` | - | - |
 | `overlayClassName` | 下拉菜单的 `class`  | `string` | - | - | - |
-| `overlayMatchWidth` | 下拉菜单和选择器同宽  | `boolean` | `false` | ✅ | - |
+| `overlayMatchWidth` | 下拉菜单和选择器同宽  | `boolean` | `true` | ✅ | - |
 | `overlayRender` | 自定义下拉菜单内容的渲染  | `(children:VNode[]) => VNodeTypes` | - | - | - |
 | `placeholder` | 选择框默认文本 | `string` | - | - | - |
 | `readonly` | 只读模式 | `boolean` | - | - | - |

--- a/packages/components/tree/style/index.less
+++ b/packages/components/tree/style/index.less
@@ -95,6 +95,7 @@
   display: flex;
   align-items: center;
   padding: @tree-node-padding-vertical 0;
+  white-space: nowrap;
 
   .@{icon-prefix} {
     font-size: @tree-icon-font-size;
@@ -110,7 +111,7 @@
   }
 
   &-expand {
-    width: @tree-node-content-height;
+    padding: 0 calc(@tree-node-content-height / 4);
     line-height: @tree-node-content-height;
     text-align: center;
     cursor: pointer;
@@ -136,8 +137,8 @@
       position: relative;
       z-index: 1;
       display: inline-block;
-      width: 100%;
       height: 100%;
+      padding: 0 calc(@tree-node-content-height / 2);
 
       &::before {
         position: absolute;


### PR DESCRIPTION
BREAKING CHANGE:
- treeSelect overlayMatchWidth prop is changed to `true` by default

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
当内容过多时，未出现横向滚动条

![image](https://user-images.githubusercontent.com/26105153/165086384-629fa7fa-e049-4e45-81db-e0d765d48862.png)

## What is the new behavior?
修复样式，并且需要给tree的height赋值，才能开启cdkScroll的overflow:auto样式

![image](https://user-images.githubusercontent.com/26105153/165086537-03d9b839-acd3-4076-ba35-dbb8ff060cf9.png)


## Other information
