### PR TITLE
fix(comp:carousel): modify onChange params order

### DIFF
--- a/packages/components/carousel/docs/Index.zh.md
+++ b/packages/components/carousel/docs/Index.zh.md
@@ -18,7 +18,7 @@ order: 0
 | `dotPlacement` | 面板指示点的位置 | `'top' \| 'start' \| 'bottom' \| 'end' \| 'none'` | `'bottom'` | ✅ | 为`'none'`时不显示面板指示点 |
 | `showArrow` | 是否显示`prev`、`next`按钮 | `boolean` | `false` | ✅ | - |
 | `trigger` | 面板指示点的触发方式 | `'click' \| 'hover'` | `'click'` | ✅ | - |
-| `onChange` | 面板切换时会触发的回调函数 | `(prevIndex: number, nextIndex: number) => void` | - | - | - |
+| `onChange` | 面板切换时会触发的回调函数 | `(nextIndex: number, prevIndex: number) => void` | - | - | - |
 
 #### CarouselSlots
 

--- a/packages/components/carousel/src/composables/useWalk.ts
+++ b/packages/components/carousel/src/composables/useWalk.ts
@@ -25,7 +25,7 @@ export const useWalk = (length: ComputedRef<number>, props: CarouselProps): Walk
 
   watch(activeIndex, (newVal: number, oldVal: number) => {
     if (newVal >= 1 && newVal <= length.value) {
-      callEmit(props.onChange, oldVal, newVal)
+      callEmit(props.onChange, newVal, oldVal)
     }
   })
 


### PR DESCRIPTION
FIX #862 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

onChange入参顺序是prevIndex，nextIndex

## What is the new behavior?

onChange入参顺序是nextIndex，prevIndex

## Other information
