### PR TITLE
fix(cdk:click-outside):  not working when click target has @click.stop

### DIFF
--- a/packages/cdk/click-outside/src/useClickOutside.ts
+++ b/packages/cdk/click-outside/src/useClickOutside.ts
@@ -27,15 +27,20 @@ interface DocumentHandlerOptions {
 
 const documentHandlerMap = new Map<HTMLElement, DocumentHandlerOptions>()
 
-on(document, 'click', event => {
-  documentHandlerMap.forEach(({ exclude, handler }) => {
-    const target = event.target as Node
-    if (exclude.some(item => item === target || item.contains(target))) {
-      return
-    }
-    handler(event)
-  })
-})
+on(
+  document,
+  'click',
+  event => {
+    documentHandlerMap.forEach(({ exclude, handler }) => {
+      const target = event.target as Node
+      if (exclude.some(item => item === target || item.contains(target))) {
+        return
+      }
+      handler(event)
+    })
+  },
+  { capture: true },
+)
 
 function createHandler(el: HTMLElement, binding: ClickOutsideBinding): void {
   const exclude: HTMLElement[] = [el]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
click outside not working when click target has @click.stop

## What is the new behavior?
works fine even if there is @click.stop

## Other information
-