### PR TITLE
fix(comp: tag): if value of number over 9 and show '9+'

### DIFF
--- a/packages/components/tag/__tests__/tag.spec.ts
+++ b/packages/components/tag/__tests__/tag.spec.ts
@@ -62,4 +62,9 @@ describe('Tag', () => {
     expect(wrapper.classes()).toContain('ix-tag-numeric')
     expect(wrapper.find('.ix-tag-numeric-prefix').text()).toBe('2')
   })
+
+  test('number exceeds 9 work', async () => {
+    const wrapper = TagMount({ props: { number: 10000 } })
+    expect(wrapper.find('.ix-tag-numeric-prefix').text()).toBe('9+')
+  })
 })

--- a/packages/components/tag/src/Tag.tsx
+++ b/packages/components/tag/src/Tag.tsx
@@ -75,7 +75,7 @@ function renderNumericPrefix(prefixCls: string, number: number | undefined, styl
 
   return (
     <span class={`${prefixCls}-numeric-prefix`} style={style}>
-      {number}
+      {number > 9 ? '9+' : number}
     </span>
   )
 }


### PR DESCRIPTION
This problem has not been fixed for a long time, so I raised a PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Component style update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

## Other information

fix #841 