### PR TITLE
fix(comp:header): prefix or suffix is empty str, expect no render vnode

### DIFF
--- a/packages/components/header/__tests__/header.spec.ts
+++ b/packages/components/header/__tests__/header.spec.ts
@@ -61,6 +61,13 @@ describe('Header', () => {
     expect(onPrefixClick).toBeCalledTimes(2)
   })
 
+  test('prefix is empty string work', async () => {
+    const wrapper = HeaderMount({
+      props: { prefix: '' },
+    })
+    expect(wrapper.find('.ix-header-prefix').exists()).toBe(false)
+  })
+
   test('prefix slot work', async () => {
     const wrapper = HeaderMount({
       props: { prefix: 'up' },
@@ -91,6 +98,13 @@ describe('Header', () => {
     await wrapper.find('.ix-header-suffix').trigger('click')
 
     expect(onSuffixClick).toBeCalledTimes(2)
+  })
+
+  test('suffix is empty string work', async () => {
+    const wrapper = HeaderMount({
+      props: { suffix: '' },
+    })
+    expect(wrapper.find('.ix-header-suffix').exists()).toBe(false)
   })
 
   test('suffix slot work', async () => {

--- a/packages/components/utils/src/convertVNode.ts
+++ b/packages/components/utils/src/convertVNode.ts
@@ -47,7 +47,7 @@ export function convertIconVNode(
     return iconSlot(params)
   }
 
-  return isString(iconName) ? createVNode(IxIcon, { name: iconName }, null) : iconName
+  return isString(iconName) && iconName !== '' ? createVNode(IxIcon, { name: iconName }, null) : iconName
 }
 
 export function convertStringVNode(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If prefix or suffix is empty string, still render corresponding vnode with empty content.


## What is the new behavior?
If prefix or suffix is empty string, expect no render corresponding vnode

## Other information
