### PR TITLE
fix(comp:modal): fix loading stop before hide

### DIFF
--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -115,14 +115,14 @@ function useScrollStrategy(props: ModalProps, mask: ComputedRef<boolean>, merged
 
 function useTrigger(props: ModalProps, setVisible: (value: boolean) => void) {
   const open = () => setVisible(true)
+  const hide = (result: boolean | unknown) => {
+    result !== false && setVisible(false)
+  }
 
   const close = async (evt?: Event | unknown) => {
     const result = await callEmit(props.onBeforeClose, evt)
-    if (result === false) {
-      return
-    }
-    setVisible(false)
-    callEmit(props.onClose, evt)
+    hide(result)
+    result !== false && callEmit(props.onClose, evt)
   }
 
   const cancelLoading = ref(false)
@@ -131,12 +131,11 @@ function useTrigger(props: ModalProps, setVisible: (value: boolean) => void) {
     if (isPromise(result)) {
       cancelLoading.value = true
       result = await result
+      hide(result)
       cancelLoading.value = false
-    }
-    if (result === false) {
       return
     }
-    setVisible(false)
+    hide(result)
   }
 
   const okLoading = ref(false)
@@ -145,12 +144,11 @@ function useTrigger(props: ModalProps, setVisible: (value: boolean) => void) {
     if (isPromise(result)) {
       okLoading.value = true
       result = await result
+      hide(result)
       okLoading.value = false
-    }
-    if (result === false) {
       return
     }
-    setVisible(false)
+    hide(result)
   }
 
   return { cancelLoading, okLoading, open, close, cancel, ok }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
确认按钮事件回调是一个 Promise,点击确认按钮后,按钮结束按钮加载状态再隐藏Modal, 在隐藏之前用户双击可能又触发了确认按钮的事件

## What is the new behavior?
先隐藏 Modal 再将结束按钮加载状态 或者等 Modal 隐藏的动画结束后再结束按钮加载状态

## Other information
