### PR TITLE
fix(comp:tree): node cannot be checked when its key is 0(Number type)

### DIFF
--- a/packages/components/modal/style/index.less
+++ b/packages/components/modal/style/index.less
@@ -128,10 +128,6 @@
     min-height: @modal-footer-min-height;
     padding: @modal-footer-padding;
 
-    .@{button-prefix} {
-      vertical-align: bottom;
-    }
-    
     .@{button-prefix} + .@{button-prefix} {
       margin-left: @modal-footer-button-margin-left;
     }

--- a/packages/components/tree/src/composables/useCheckable.ts
+++ b/packages/components/tree/src/composables/useCheckable.ts
@@ -11,6 +11,8 @@ import type { ComputedRef, WritableComputedRef } from 'vue'
 
 import { computed } from 'vue'
 
+import { isNil } from 'lodash-es'
+
 import { VKey, callEmit, useControlledProp } from '@idux/cdk/utils'
 
 import { callChange, getChildrenKeys, getParentKeys } from '../utils'
@@ -58,13 +60,13 @@ export function useCheckable(props: TreeProps, mergedNodeMap: ComputedRef<Map<VK
     const nodeMap = mergedNodeMap.value
     _checkedKeys.forEach(key => {
       const { parentKey } = nodeMap.get(key) || {}
-      if (parentKey) {
+      if (!isNil(parentKey)) {
         let parent = nodeMap.get(parentKey)
         if (parent && !_checkedKeys.includes(parent.key)) {
           if (!disabledKeys.includes(parentKey)) {
             indeterminateKeySet.add(parentKey)
           }
-          while (parent?.parentKey) {
+          while (parent && !isNil(parent.parentKey)) {
             if (!disabledKeys.includes(parent.parentKey)) {
               indeterminateKeySet.add(parent.parentKey)
             }
@@ -131,7 +133,7 @@ function setParentChecked(
   disabledKeys: VKey[],
 ) {
   let parentSelected = true
-  while (parentSelected && currNode?.parentKey) {
+  while (parentSelected && currNode && !isNil(currNode.parentKey)) {
     const parent = dataMap.get(currNode.parentKey)
     if (parent && !disabledKeys.includes(currNode.parentKey)) {
       parentSelected = parent.children!.every(item => disabledKeys.includes(item.key) || tempKeys.includes(item.key))
@@ -189,7 +191,7 @@ function findAllCheckedKeys(dataMap: Map<VKey, MergedNode>, checkedKys: VKey[], 
     const parentKey = currNode?.parentKey
     const childrenKeys = getChildrenKeys(currNode, disabledKeys)
     res = res.concat(childrenKeys)
-    if (parentKey && lastParentKey !== parentKey) {
+    if (!isNil(parentKey) && lastParentKey !== parentKey) {
       setParentChecked(dataMap, currNode, res, disabledKeys)
       lastParentKey = parentKey
     }

--- a/packages/components/tree/src/utils/index.ts
+++ b/packages/components/tree/src/utils/index.ts
@@ -10,6 +10,8 @@ import type { TreeNode } from '../types'
 import type { VKey } from '@idux/cdk/utils'
 import type { ComputedRef } from 'vue'
 
+import { isNil } from 'lodash-es'
+
 import { callEmit } from '@idux/cdk/utils'
 
 export function callChange(
@@ -48,7 +50,7 @@ export function getParentKeys(
   disabledKeys?: VKey[],
 ): VKey[] {
   const keys: VKey[] = []
-  while (currNode?.parentKey) {
+  while (currNode && !isNil(currNode.parentKey)) {
     const { parentKey } = currNode
     if (!disabledKeys?.includes(currNode.parentKey)) {
       keys.push(parentKey)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
级联时，子选项选中，其父节点（key为0）无法被选中

```
<template>
  <IxTree
    v-model:checkedKeys="checkedKeys"
    v-model:expandedKeys="expandedKeys"
    v-model:selectedKeys="selectedKeys"
    cascade
    checkable
    checkStrategy="parent"
    :dataSource="treeData"
    @check="onCheck"
    @expand="onExpand"
    @select="onSelect"
  >
  </IxTree>
</template>

<script setup lang="ts">
import type { TreeNode } from '@idux/components/tree'

import { ref } from 'vue'

const treeData: TreeNode[] = [
  {
    label: 'Node 0',
    key: 0,
    children: [
      {
        label: 'Node 0-0',
        key: '0-0',
        children: [
          {
            label: 'Node 0-0-0',
            key: '0-0-0',
          },
          {
            label: 'Node 0-0-1',
            key: '0-0-1',
          },
        ],
      },
      {
        label: 'Node 0-1',
        key: '0-1',
        children: [
          {
            label: 'Node 0-1-0',
            key: '0-1-0',
          },
          {
            label: 'Node 0-1-1',
            key: '0-1-1',
          },
        ],
      },
    ],
  },
]

const checkedKeys = ref(['0'])
const expandedKeys = ref(['0', '0-0', '0-1'])
const selectedKeys = ref(['0-1'])

const onCheck = (checked: boolean, node: TreeNode) => console.log('checked', checked, node)
const onExpand = (expanded: boolean, node: TreeNode) => console.log('expanded', expanded, node)
const onSelect = (selected: boolean, node: TreeNode) => console.log('selected', selected, node)
</script>
```
## What is the new behavior?

能正常被选中

## Other information
