### PR TITLE
fix(comp:carousel): stop onTransitionend from bubbling

### DIFF
--- a/packages/components/carousel/src/Carousel.tsx
+++ b/packages/components/carousel/src/Carousel.tsx
@@ -119,6 +119,9 @@ export default defineComponent({
     }
 
     const onTransitionend = () => {
+      if (runningIndex.value === -1) {
+        return
+      }
       const sliderTrackElement = sliderTrackRef.value!
       sliderTrackElement.style.transition = ''
       sliderRefs.value.forEach(slider => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
子元素的 `transitionend` 事件会影响到 `carousel` 的定位

## What is the new behavior?

## Other information
