### PR TITLE
fix(comp:list): remove the gutter of ListGridProps and extends RowProps

### DIFF
--- a/packages/components/grid/docs/Index.zh.md
+++ b/packages/components/grid/docs/Index.zh.md
@@ -32,10 +32,10 @@ order: 0
 | `push` | 栅格向右移动格数 | `number` | - | - | - |
 | `span` | 栅格占位格数 | `number` | - | -  | - |
 | `xs` | 响应式栅格，可为栅格数或一个包含其他属性的对象 | `number \| object` | - | -  | - |
-| `sm` | 响应式栅格，同上 | `number/object` | - | -  | - |
-| `md` | 响应式栅格，同上 | `number/object` | - | -  | - |
-| `lg` | 响应式栅格，同上 | `number/object` | - | -  | - |
-| `xl` | 响应式栅格，同上 | `number/object` | - | -  | - |
+| `sm` | 响应式栅格，同上 | `number \| object` | - | -  | - |
+| `md` | 响应式栅格，同上 | `number \| object` | - | -  | - |
+| `lg` | 响应式栅格，同上 | `number \| object` | - | -  | - |
+| `xl` | 响应式栅格，同上 | `number \| object` | - | -  | - |
 
 响应式栅格请参考[断点](/cdk/breakpoint/zh), 如果你修改默认的断点，请同步修改相关的 `less` 变量。
 

--- a/packages/components/list/docs/Index.zh.md
+++ b/packages/components/list/docs/Index.zh.md
@@ -21,13 +21,13 @@ order: 0
 | `loading` | 加载状态 | `boolean \| SpinProps` | false | - | SpinProps请参照 spin 组件 |
 | `size` | 大小 | `'lg' \| 'md' \| 'sm'` | `'md'` | ✅ | - |
 | `grid` | grid 布局 | `ListGridProps` | - | - | 结合了IxRow, IxCol 的部分配置 |
-| `grid.gutter` | grid 元素间隔 | `number` | - | - | IxRow 中的 gutter |
+| `grid.gutter` | grid 元素间隔, 支持配置数字, 对象和数组 | `number \| object \| array` | `0` | - | IxRow 中的 gutter |
 | `grid.column` | gird 布局中每一行元素的个数 | `number` | - | - | 通过Math.floor(24 / column) 计算得到IxCol 中的 span |
-| `grid.ms` | gird 布局在 ms分辨率下的所占格数 | `number` | - | - | 同IxCol的ms |
-| `grid.sm` | gird 布局在 sm分辨率下的所占格数 | `number` | - | - | 同IxCol的sm |
-| `grid.md` | gird 布局在 md分辨率下的所占格数 | `number` | - | - | 同IxCol的md |
-| `grid.ld` | gird 布局在 ld分辨率下的所占格数 | `number` | - | - | 同IxCol的ld |
-| `grid.xl` | gird 布局在 xl分辨率下的所占格数 | `number` | - | - | 同IxCol的xl |
+| `grid.ms` | gird 布局在 ms分辨率下的所占格数 | `number \| object` | - | - | 同IxCol的ms |
+| `grid.sm` | gird 布局在 sm分辨率下的所占格数 | `number \| object` | - | - | 同IxCol的sm |
+| `grid.md` | gird 布局在 md分辨率下的所占格数 | `number \| object` | - | - | 同IxCol的md |
+| `grid.ld` | gird 布局在 ld分辨率下的所占格数 | `number \| object` | - | - | 同IxCol的ld |
+| `grid.xl` | gird 布局在 xl分辨率下的所占格数 | `number \| object` | - | - | 同IxCol的xl |
 
 #### ListSlots
 

--- a/packages/components/list/src/types.ts
+++ b/packages/components/list/src/types.ts
@@ -6,19 +6,14 @@
  */
 
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes } from '@idux/cdk/utils'
-import type { RowProps } from '@idux/components/grid'
+import type { ColProps, RowProps } from '@idux/components/grid'
 import type { SpinProps } from '@idux/components/spin'
 import type { DefineComponent, HTMLAttributes, PropType } from 'vue'
 
 export type ListSize = 'sm' | 'md' | 'lg'
-export interface ListGridProps extends RowProps {
+export type ColPropsType = Partial<Pick<ColProps, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>>
+export interface ListGridProps extends RowProps, ColPropsType {
   column?: number
-  gutter?: number
-  xs?: number
-  sm?: number
-  md?: number
-  lg?: number
-  xl?: number
 }
 
 export const listProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- ListGridProps 原来覆盖了 RowProps 的 gutter，导致只能写数字
- ColProps 复制过来没有进行同步

## What is the new behavior?
- ListGridProps 删除自定义的 gutter，改用继承的属于，同时修改List gutter API文档与 RowProps 保持一致 
- ColProps types也进行了同步

## Other information
