### PR TITLE
fix(comp:card): hoisted vnode cannot be hot updated in dev mode

### DIFF
--- a/packages/components/card/demo/Basic.vue
+++ b/packages/components/card/demo/Basic.vue
@@ -1,21 +1,21 @@
 <template>
   <IxRow>
     <IxCol xs="24" sm="8">
-      <IxCard :header="{ title: 'Card title', extra: 'setting' }" size="lg">
+      <IxCard :header="{ title: 'Card title', suffix: 'setting' }" size="lg">
         <p>Card content</p>
         <p>Card content</p>
         <p>Card content</p>
       </IxCard>
     </IxCol>
     <IxCol xs="24" sm="8">
-      <IxCard :header="{ title: 'Card title', extra: 'setting' }">
+      <IxCard :header="{ title: 'Card title', suffix: 'setting' }">
         <p>Card content</p>
         <p>Card content</p>
         <p>Card content</p>
       </IxCard>
     </IxCol>
     <IxCol xs="24" sm="8">
-      <IxCard :header="{ title: 'Small card', extra: 'setting' }" size="sm">
+      <IxCard :header="{ title: 'Small card', suffix: 'setting' }" size="sm">
         <p>Card content</p>
         <p>Card content</p>
         <p>Card content</p>

--- a/packages/components/card/demo/Loading.vue
+++ b/packages/components/card/demo/Loading.vue
@@ -1,24 +1,25 @@
 <template>
-  <IxSwitch v-model:checked="loading"></IxSwitch>
-  <br />
-  <IxRow>
-    <IxCol xs="24" sm="8">
-      <IxCard :loading="loading" :header="{ title: 'Card title', suffix: 'setting' }">
-        <p>Card content</p>
-        <p>Card content</p>
-        <p>Card content</p>
-      </IxCard>
-    </IxCol>
-    <IxCol xs="24" sm="8">
-      <IxCard :loading="loading" :footer="footer">
-        <IxHeader :avatar="{ src: '/images/avatar/2.png' }" title="Card title">
-          <template #description>
-            <p>This is the description</p>
-          </template>
-        </IxHeader>
-      </IxCard>
-    </IxCol>
-  </IxRow>
+  <IxSpace vertical block>
+    <IxSwitch v-model:checked="loading"></IxSwitch>
+    <IxRow>
+      <IxCol xs="24" sm="8">
+        <IxCard :loading="loading" :header="{ title: 'Card title', suffix: 'setting' }">
+          <p>Card content</p>
+          <p>Card content</p>
+          <p>Card content</p>
+        </IxCard>
+      </IxCol>
+      <IxCol xs="24" sm="8">
+        <IxCard :loading="loading" :footer="footer">
+          <IxHeader :avatar="{ src: '/images/avatar/2.png' }" title="Card title">
+            <template #description>
+              <p>This is the description</p>
+            </template>
+          </IxHeader>
+        </IxCard>
+      </IxCol>
+    </IxRow>
+  </IxSpace>
 </template>
 
 <script lang="ts">

--- a/packages/components/card/demo/Selectable.vue
+++ b/packages/components/card/demo/Selectable.vue
@@ -4,7 +4,7 @@
       <div>Selected: {{ selected1 }}</div>
       <IxCard
         v-model:selected="selected1"
-        :header="{ title: 'Selectable', extra: 'setting' }"
+        :header="{ title: 'Selectable', suffix: 'setting' }"
         size="lg"
         selectable
         @selectedChange="logSelected"
@@ -18,7 +18,7 @@
       <div>Selected: {{ selected2 }}</div>
       <IxCard
         v-model:selected="selected1"
-        :header="{ title: 'Disabled and selected', extra: 'setting' }"
+        :header="{ title: 'Disabled and selected', suffix: 'setting' }"
         selectable
         disabled
       >
@@ -31,7 +31,7 @@
       <div>Selected: {{ selected3 }}</div>
       <IxCard
         v-model:selected="selected1"
-        :header="{ title: 'Disable and unselected', extra: 'setting' }"
+        :header="{ title: 'Disable and unselected', suffix: 'setting' }"
         selectable
         disabled
       >
@@ -49,7 +49,7 @@ const selected1 = ref(true)
 const selected2 = ref(true)
 const selected3 = ref(false)
 
-const logSelected = selected => {
+const logSelected = (selected: boolean) => {
   console.log(`selected is ${selected}`)
 }
 </script>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
dev 模式下，手动修改Card组件中默认插槽中的字符串，页面不更新
```
<IxCard >
    <p>Card content</p>
 </IxCard>
```


## What is the new behavior?
热更新正常


## Other information
下面通过这个例子具体解释一下实验发现
```
<IxCard >
    <p>静态文本</p>
    <p>{{text}}</p>
 </IxCard>

const text = ref('动态文本')
```

操作1：手动修改静态文本，发现页面文本不更新
操作2：手动修改动态文本，发现页面文本更新

首先结论，slots本身不为响应式数据，所以无法这样使用
```
const children = computed(() => slots.default?.() || [])
```
热更新时即Card重新render时，无法触发computed的effect函数，所以children无法重新执行slots.default去获取最新的vnodes

![image](https://user-images.githubusercontent.com/26105153/177364860-fcef33ff-13d2-42d1-910f-70f76251f127.png)
此时computed的dirty为false，表示没有检测到数据被修改，还是用上一次缓存的值`this._value`

但是为什么操作2可以成功呢？

以下为猜测：
![image](https://user-images.githubusercontent.com/26105153/177334530-729e44b0-729d-4844-bc48-3bd94fc7d121.png)

此图为模板编译后的render函数，vue3对于静态节点，在diff的时候不会比较更新，会直接拿初始化时的节点，而动态节点每次则会比较更新； 所以在生成Card组件children的vnode的时候，静态节点并没有被更新，只有动态节点被更新了，加上`this._value`返回的又是数组对象，由于首次执行时的数据引用关系，虽然没有执行effect函数，主动获取最新的slots.default，但是内部已经被更新，所以页面更新成功。


