### PR TITLE
feat(cdk:forms): setValue of AbstractControl supports triggering blur

### DIFF
--- a/packages/cdk/forms/__tests__/formArray.spec.ts
+++ b/packages/cdk/forms/__tests__/formArray.spec.ts
@@ -83,7 +83,7 @@ describe('formArray.ts', () => {
       expect(array.length.value).toEqual(1)
       expect(array.getValue()).toEqual([basicValue])
 
-      const group = array.at(0)
+      const group = array.at(0)!
       array.removeAt(0)
       expect(array.length.value).toEqual(0)
       expect(array.getValue()).toEqual([])

--- a/packages/cdk/forms/__tests__/formControl.spec.ts
+++ b/packages/cdk/forms/__tests__/formControl.spec.ts
@@ -41,6 +41,11 @@ describe('formControl.ts', () => {
 
       expect(control.getValue()).toEqual('')
       expect(control.dirty.value).toEqual(true)
+
+      control.setValue('test', { blur: true })
+
+      expect(control.getValue()).toEqual('test')
+      expect(control.blurred.value).toEqual(true)
     })
 
     test('markAsBlurred and markAsUnblurred work', () => {

--- a/packages/cdk/forms/__tests__/formGroup.spec.ts
+++ b/packages/cdk/forms/__tests__/formGroup.spec.ts
@@ -20,7 +20,7 @@ describe('formGroup.ts', () => {
     let group: FormGroup<BasicGroup>
 
     beforeEach(() => {
-      group = new FormGroup<BasicGroup>({
+      group = new FormGroup({
         control: new FormControl(''),
         array: new FormArray([new FormControl(''), new FormControl('')]),
         group: new FormGroup({

--- a/packages/cdk/forms/__tests__/useForms.spec.ts
+++ b/packages/cdk/forms/__tests__/useForms.spec.ts
@@ -1,6 +1,6 @@
 import { flushPromises } from '@vue/test-utils'
 
-import { useFormArray, useFormGroup } from '../src/useForms'
+import { useFormArray, useFormControl, useFormGroup } from '../src/useForms'
 import { Validators } from '../src/validators'
 
 interface BasicGroup {
@@ -20,7 +20,7 @@ describe('useForms.ts', () => {
       control1: ['', Validators.required],
       control2: [undefined, { trigger: 'blur', validators: Validators.required }],
       array: useFormArray([[''], [1]]),
-      group: useFormGroup({ control: [''] }),
+      group: useFormGroup({ control: useFormControl<string | number>('') }),
     })
 
     expect(group.getValue()).toEqual(basicValue)

--- a/packages/cdk/forms/__tests__/utils.spec.ts
+++ b/packages/cdk/forms/__tests__/utils.spec.ts
@@ -6,6 +6,12 @@ import { FormGroup } from '../src/controls'
 import { useFormGroup } from '../src/useForms'
 import { FORMS_CONTROL_TOKEN, useAccessorAndControl, useControl } from '../src/utils'
 
+interface BasicGroup {
+  name: string
+  age: string
+  email: string
+}
+
 const InputComponent = {
   template: `<input :value="accessor.value" :disabled="accessor.disabled" @input="onInput" @blur="onBlur" />`,
   props: ['value', 'control', 'disabled'],
@@ -27,7 +33,7 @@ const FormComponent = {
   },
 }
 
-const MountForm = (group: FormGroup) => {
+const MountForm = (group: FormGroup<BasicGroup>) => {
   return mount({
     components: { FormComponent, InputComponent },
     template: `
@@ -44,7 +50,7 @@ const MountForm = (group: FormGroup) => {
 }
 
 describe('utils.ts', () => {
-  let group: FormGroup
+  let group: FormGroup<BasicGroup>
 
   test('basic work', async () => {
     const { required, min, max, email } = Validators
@@ -82,7 +88,7 @@ describe('utils.ts', () => {
     group = useFormGroup({
       age: ['18', [required, min(1), max(99)]],
       email: ['', [email]],
-    })
+    }) as unknown as FormGroup<BasicGroup>
     const wrapper = MountForm(group)
     const nameInput = wrapper.find('#name') as DOMWrapper<HTMLInputElement>
 

--- a/packages/cdk/forms/docs/Index.zh.md
+++ b/packages/cdk/forms/docs/Index.zh.md
@@ -117,8 +117,9 @@ export function useFormControl<T>(
 
 ### useAccessorAndControl
 
-> 构建 `accessor`, 来接管表单控件 `props` 的 `control` 和 `value`, `disabled` 状态的优先级关系。
-> 当 `control` 存在时，`value` 和 `disabled` 无效，以 `control` 的状态为准。
+用于处理表单控件 `props` 的 `control` 和 `value`, `disabled` 的优先级关系，`control` 存在时， `value` 和 `disabled` 失效。
+
+创建一个响应式对象 `FormAccessor`，它接管了组件 `value` 和 `disabled` 控制，用法也同 `props` 一致。
 
 ```ts
 export function useAccessorAndControl<T = any>(options?: FormAccessorOptions): {
@@ -126,7 +127,7 @@ export function useAccessorAndControl<T = any>(options?: FormAccessorOptions): {
     control: ShallowRef<AbstractControl<T> | undefined>;
 }
 
-export function useAccessor<T = any>(control: ShallowRef<AbstractControl<T> | undefined>, valueKey?: string, disabledKey?: string): FormAccessor<T>
+export function useAccessor<T = any>(control: MaybeRef<AbstractControl<T> | undefined>, valueKey?: string, disabledKey?: string): FormAccessor<T>
 
 export function useControl<T = any>(controlKey?: string): ShallowRef<AbstractControl<T> | undefined>
 

--- a/packages/cdk/forms/src/utils.ts
+++ b/packages/cdk/forms/src/utils.ts
@@ -20,13 +20,14 @@ import {
   shallowReactive,
   shallowRef,
   toRaw,
+  unref,
   watch,
   watchEffect,
 } from 'vue'
 
 import { isNil } from 'lodash-es'
 
-import { Logger, NoopFunction, callEmit } from '@idux/cdk/utils'
+import { Logger, type MaybeRef, NoopFunction, callEmit } from '@idux/cdk/utils'
 
 import { type AbstractControl, type ControlPathType } from './controls'
 import { isAbstractControl } from './typeof'
@@ -81,7 +82,7 @@ export interface FormAccessor<T = any> {
 }
 
 export function useAccessor<T = any>(
-  control: ShallowRef<AbstractControl<T> | undefined>,
+  control: MaybeRef<AbstractControl<T> | undefined>,
   valueKey = 'value',
   disabledKey = 'disabled',
 ): FormAccessor<T> {
@@ -102,7 +103,7 @@ export function useAccessor<T = any>(
   onScopeDispose(cleanWatch)
 
   watch(
-    control,
+    () => unref(control),
     currControl => {
       cleanWatch()
 

--- a/packages/components/input/src/useInput.ts
+++ b/packages/components/input/src/useInput.ts
@@ -39,9 +39,6 @@ export function useInput(
   props: CommonProps,
   config: InputConfig | TextareaConfig,
 ): InputContext<HTMLInputElement | HTMLTextAreaElement> {
-  // const control = useValueControl()
-  // const accessor = useValueAccessor({ control })
-  // useFormItemRegister(control)
   const { accessor, control } = useAccessorAndControl()
   useFormItemRegister(control)
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
```ts
  /**
   * Sets a new value for the control.
   *
   * @param value The new value.
   * @param options
   * * `dirty`: Marks it dirty, default is false.
   * * `blur`: Marks it blurred, default is false.
   */
  abstract setValue(value: T | Partial<T>, options?: { dirty?: boolean; blur?: boolean }): void
```
## Other information
