### PR TITLE
fix(comp:form): repair the form-item-input-content centering（#1019）

### DIFF
--- a/packages/components/form/style/index.less
+++ b/packages/components/form/style/index.less
@@ -91,6 +91,8 @@
       align-items: center;
 
       &-content {
+        display: flex;
+        align-items: center;
         flex: auto;
         max-width: 100%;
       }

--- a/packages/components/slider/style/index.less
+++ b/packages/components/slider/style/index.less
@@ -8,6 +8,7 @@
 .@{slider-prefix} {
   position: relative;
   box-sizing: border-box;
+  flex: 1;
   height: 12px;
   margin: 10px 6px;
   padding: 4px 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
The default form controls are all 32 px, and the switch is 28, so swtich is not vertically centered, and so are checkbox, radio, rate, and slider

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://user-images.githubusercontent.com/96854855/180638166-51dfed61-033d-4a8a-a09f-b91eb680a628.png)
![image](https://user-images.githubusercontent.com/96854855/180639598-85954232-6bde-4b0b-9479-4c1b41c4759e.png)


## What is the new behavior?
![image](https://user-images.githubusercontent.com/96854855/180639567-ce77fb97-9a98-4439-bf3c-40b1f7ac8cc9.png)
![image](https://user-images.githubusercontent.com/96854855/180639572-e2bdfe71-5a60-4f74-bd47-8dfd56747034.png)
![image](https://user-images.githubusercontent.com/96854855/180639583-9aa280f6-2dda-4e93-9ab3-814e2b8c6c00.png)


## Other information

the slider lose it width

![image](https://user-images.githubusercontent.com/96854855/180639614-6d492e08-8ada-4b55-8179-b206558b4449.png)

add flex: 1; to solve

![image](https://user-images.githubusercontent.com/96854855/180639622-a230953c-7c47-4d46-9e08-1f5c6024da20.png)


