### PR TITLE
feat(comp:date-picker): timeFormat is now infered from format by default；time of Date value should be kept after range value selected

### DIFF
--- a/packages/components/date-picker/demo/Format.vue
+++ b/packages/components/date-picker/demo/Format.vue
@@ -5,6 +5,7 @@
     <IxDatePicker v-model:value="value" type="month" format="MM/yyyy"></IxDatePicker>
     <IxDatePicker v-model:value="value" type="quarter" format="'Q'Q/yyyy"></IxDatePicker>
     <IxDatePicker v-model:value="value" type="year" format="yy"></IxDatePicker>
+    <IxDatePicker v-model:value="value" type="datetime" format="dd/MM/yyyy hh:mm"></IxDatePicker>
   </IxSpace>
 </template>
 

--- a/packages/components/date-picker/src/composables/useRangePanelState.ts
+++ b/packages/components/date-picker/src/composables/useRangePanelState.ts
@@ -12,7 +12,7 @@ import { type ComputedRef, computed, watch } from 'vue'
 
 import { callEmit, convertArray, useState } from '@idux/cdk/utils'
 
-import { sortRangeValue } from '../utils'
+import { applyDateTime, sortRangeValue } from '../utils'
 
 export interface RangePanelStateContext {
   panelValue: ComputedRef<(Date | undefined)[] | undefined>
@@ -49,8 +49,16 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
       setIsSelecting(true)
       setSelectingDate([value, undefined])
     } else {
+      const propsValue = convertArray(props.value)
+
       setIsSelecting(false)
-      handleChange([selectingDate.value?.[0], value])
+      handleChange(
+        [selectingDate.value?.[0], value].map((dateValue, index) =>
+          propsValue[index]
+            ? applyDateTime(dateConfig, propsValue[index], dateValue!, ['hour', 'minute', 'second'])
+            : dateValue,
+        ),
+      )
     }
   }
 

--- a/packages/components/date-picker/src/composables/useTimePanelProps.ts
+++ b/packages/components/date-picker/src/composables/useTimePanelProps.ts
@@ -14,27 +14,48 @@ import { isArray } from 'lodash-es'
 
 export function useTimePanelProps(
   props: DatePickerProps,
-  timeFormatRef: ComputedRef<string>,
+  hourEnabled: ComputedRef<boolean>,
+  minuteEnabled: ComputedRef<boolean>,
+  secondEnabled: ComputedRef<boolean>,
+  use12Hours: ComputedRef<boolean>,
 ): ComputedRef<ɵTimePanelProps> {
-  return computed(() => getTimePanelProps(props.timePanelOptions ?? {}, timeFormatRef))
+  return computed(() => ({
+    ...getTimePanelProps(props.timePanelOptions ?? {}),
+    hourEnabled: hourEnabled.value,
+    minuteEnabled: minuteEnabled.value,
+    secondEnabled: secondEnabled.value,
+    use12Hours: use12Hours.value,
+  }))
 }
 
 export function useRangeTimePanelProps(
   props: DateRangePickerProps,
-  timeFormatRef: ComputedRef<string>,
+  hourEnabled: ComputedRef<boolean>,
+  minuteEnabled: ComputedRef<boolean>,
+  secondEnabled: ComputedRef<boolean>,
+  use12Hours: ComputedRef<boolean>,
 ): ComputedRef<ɵTimePanelProps[]> {
   const getOptions = (isFrom: boolean) =>
     (isArray(props.timePanelOptions) ? props.timePanelOptions[isFrom ? 0 : 1] : props.timePanelOptions) ?? {}
 
-  const rangeTimePanelProps = computed(() => [
-    getTimePanelProps(getOptions(true), timeFormatRef),
-    getTimePanelProps(getOptions(false), timeFormatRef),
-  ])
+  const rangeTimePanelProps = computed(() => {
+    const enabledStatus = {
+      hourEnabled: hourEnabled.value,
+      minuteEnabled: minuteEnabled.value,
+      secondEnabled: secondEnabled.value,
+      use12Hours: use12Hours.value,
+    }
+
+    return [
+      { ...getTimePanelProps(getOptions(true)), ...enabledStatus },
+      { ...getTimePanelProps(getOptions(false)), ...enabledStatus },
+    ]
+  })
 
   return rangeTimePanelProps
 }
 
-function getTimePanelProps(timePanelOptions: TimePanelOptions, timeFormatRef: ComputedRef<string>): ɵTimePanelProps {
+function getTimePanelProps(timePanelOptions: TimePanelOptions): ɵTimePanelProps {
   const { disabledHours, disabledMinutes, disabledSeconds, hideDisabledOptions, hourStep, minuteStep, secondStep } =
     timePanelOptions
 
@@ -46,9 +67,5 @@ function getTimePanelProps(timePanelOptions: TimePanelOptions, timeFormatRef: Co
     hourStep,
     minuteStep,
     secondStep,
-    hourEnabled: /[hH]/.test(timeFormatRef.value),
-    minuteEnabled: /m/.test(timeFormatRef.value),
-    secondEnabled: /s/.test(timeFormatRef.value),
-    use12Hours: /[aA]/.test(timeFormatRef.value),
   }
 }

--- a/packages/components/date-picker/src/content/Content.tsx
+++ b/packages/components/date-picker/src/content/Content.tsx
@@ -23,6 +23,10 @@ export default defineComponent({
       mergedPrefixCls,
       dateFormatRef,
       timeFormatRef,
+      hourEnabled,
+      minuteEnabled,
+      secondEnabled,
+      use12Hours,
       slots,
       inputEnableStatus,
       inputRef,
@@ -79,7 +83,7 @@ export default defineComponent({
       }
     }
 
-    const _handleDateInputClear = (evt: Event) => {
+    const _handleDateInputClear = (evt: MouseEvent) => {
       if (!inputEnableStatus.value.enableOverlayTimeInput) {
         handleClear(evt)
       }
@@ -88,7 +92,7 @@ export default defineComponent({
     }
 
     const inputProps = useInputProps(context)
-    const timePanelProps = useTimePanelProps(props, timeFormatRef)
+    const timePanelProps = useTimePanelProps(props, hourEnabled, minuteEnabled, secondEnabled, use12Hours)
 
     const renderInputs = (prefixCls: string) => {
       if (!inputEnableStatus.value.enableOverlayDateInput) {

--- a/packages/components/date-picker/src/content/RangeContent.tsx
+++ b/packages/components/date-picker/src/content/RangeContent.tsx
@@ -24,6 +24,10 @@ export default defineComponent({
       slots,
       dateFormatRef,
       timeFormatRef,
+      hourEnabled,
+      minuteEnabled,
+      secondEnabled,
+      use12Hours,
       rangeControlContext: { buffer, visiblePanel, fromControl, toControl, handlePanelChange },
       mergedPrefixCls,
       inputEnableStatus,
@@ -56,7 +60,7 @@ export default defineComponent({
     }
 
     const inputProps = useInputProps(context)
-    const timePanelProps = useRangeTimePanelProps(props, timeFormatRef)
+    const timePanelProps = useRangeTimePanelProps(props, hourEnabled, minuteEnabled, secondEnabled, use12Hours)
 
     const renderInputsSide = (prefixCls: string, isFrom: boolean) => {
       const { enableOverlayTimeInput } = inputEnableStatus.value


### PR DESCRIPTION
feat(comp:date-picker): timeFormat is now infered from format by default
fix(comp:date-picker): time of Date value should be kept after range value selected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. timeFormat不会根据format推断
2. 日期范围选择之后选择的时间会变成 00:00


## What is the new behavior?
1. timeFormat在不提供的时候默认根据format推断
2. 日期范围选择之后保留原有的时间

## Other information
