### PR TITLE
fix(comp:tree-select): do not deselect when reclicked

### DIFF
--- a/packages/components/tree-select/src/content/Content.tsx
+++ b/packages/components/tree-select/src/content/Content.tsx
@@ -196,6 +196,7 @@ export default defineComponent({
           virtual={virtual}
           selectable={multiple ? 'multiple' : true}
           selectedKeys={selectedValue.value}
+          selectedClearable={false}
           searchValue={searchFn !== false ? inputValue.value : undefined}
           searchFn={isFunction(searchFn) ? searchFn : undefined}
           showLine={showLine}

--- a/packages/components/tree/__tests__/tree.spec.ts
+++ b/packages/components/tree/__tests__/tree.spec.ts
@@ -462,6 +462,28 @@ describe('Tree', () => {
     expect(allNodes[1].classes()).toContain('ix-tree-node-selected')
   })
 
+  test('selectedClearable work', async () => {
+    const onUpdateSelectedKeys = vi.fn()
+    const wrapper = TreeMount({
+      props: {
+        dataSource: simpleDataSource,
+        selectable: true,
+        selectedKeys: ['0'],
+        checkable: false,
+        'onUpdate:selectedKeys': onUpdateSelectedKeys,
+        selectedClearable: true,
+      },
+    })
+
+    const allNodes = wrapper.findAll('.ix-tree-node')
+    await allNodes[0].find('.ix-tree-node-content').trigger('click')
+    expect(onUpdateSelectedKeys).toBeCalledWith([])
+
+    await wrapper.setProps({ selectedClearable: false, selectedKeys: ['0'] })
+    await allNodes[0].find('.ix-tree-node-content').trigger('click')
+    expect(onUpdateSelectedKeys).toBeCalledWith(['0'])
+  })
+
   test('blocked work', async () => {
     const wrapper = TreeMount({
       props: { blocked: true },

--- a/packages/components/tree/src/composables/useSelectable.ts
+++ b/packages/components/tree/src/composables/useSelectable.ts
@@ -52,7 +52,7 @@ export function useSelectable(props: TreeProps, mergedNodeMap: ComputedRef<Map<V
     if (isMultiple.value) {
       selected ? tempKeys.splice(index, 1) : tempKeys.push(key)
     } else {
-      tempKeys = selected ? [] : [key]
+      tempKeys = selected && props.selectedClearable ? [] : [key]
     }
 
     handleChange(selected, currNode.rawNode, tempKeys)
@@ -60,7 +60,8 @@ export function useSelectable(props: TreeProps, mergedNodeMap: ComputedRef<Map<V
 
   const handleChange = (selected: boolean, rawNode: TreeNode, newKeys: VKey[]) => {
     const { onSelect, onSelectedChange } = props
-    callEmit(onSelect, !selected, rawNode)
+    const realSelected = newKeys.includes(rawNode.key ?? '') ? true : !selected
+    callEmit(onSelect, realSelected, rawNode)
     setSelectedKeys(newKeys)
     callChange(mergedNodeMap, newKeys, onSelectedChange)
   }

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -72,6 +72,10 @@ export const treeProps = {
     type: [Boolean, String] as PropType<boolean | 'multiple'>,
     default: true,
   },
+  selectedClearable: {
+    type: Boolean,
+    default: true,
+  },
   showLine: {
     type: Boolean,
     default: undefined,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
reclick tree-select option will cancel the selected state

## What is the new behavior?
reclick tree-select option will not cancel the selected state

## Other information
