### PR TITLE
fix(comp:table): bordered not work with spin

### DIFF
--- a/packages/components/table/style/border.less
+++ b/packages/components/table/style/border.less
@@ -1,6 +1,7 @@
 @table-border: @table-border-width @table-border-style @table-border-color;
 
-.@{table-prefix}:not(.@{table-prefix}-borderless) {
+.@{table-prefix}:not(.@{table-prefix}-borderless),
+.@{table-prefix}:not(.@{table-prefix}-borderless) > .@{spin-prefix} > .@{spin-prefix}-container {
   > .@{header-prefix} {
     border: @table-border;
     border-bottom: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```html
  <IxTable :columns="columns" :dataSource="data" spin :borderless="false">
```

同时设置 spin=true, borderless=false 时，不显示边框。

## What is the new behavior?


## Other information
