### PR TITLE
fix(pro:search): onItemRemove should emit searchValue

### DIFF
--- a/packages/pro/search/src/composables/useSearchStates.ts
+++ b/packages/pro/search/src/composables/useSearchStates.ts
@@ -246,12 +246,12 @@ export function useSearchStates(
     }
 
     const stateIndex = searchStates.value.findIndex(state => state.key === key)
-    const searchValue = searchValues.value?.find(value => value.key === key)
 
     if (stateIndex < 0) {
       return
     }
 
+    const searchValue = _convertStateToValue(searchStates.value[stateIndex])
     searchStates.value.splice(stateIndex, 1)
     callEmit(props.onItemRemove, searchValue!)
     updateSearchValue()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
复合搜索 onItemRemove 事件参数 searchValue 是 undefined


## What is the new behavior?
复合搜索 onItemRemove 事件参数 searchValue 修复为删除的 value

## Other information
