### PR TITLE
fix(comp:tree):  keeps original expanded state after search clear now

### DIFF
--- a/packages/components/textarea/__tests__/__snapshots__/textarea.spec.ts.snap
+++ b/packages/components/textarea/__tests__/__snapshots__/textarea.spec.ts.snap
@@ -6,6 +6,6 @@ exports[`Textarea > resize and autoRows work 1`] = `"<span class=\\"ix-textarea 
 
 exports[`Textarea > resize and autoRows work 2`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; height: 0px; overflow: hidden;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 3`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; height: 0px; overflow: hidden; max-height: -12px;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 3`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; height: 0px; overflow: hidden; max-height: -4px;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 4`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; height: 0px; overflow: hidden; max-height: -12px;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 4`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; height: 0px; overflow: hidden; max-height: -4px;\\"></textarea><!----></span>"`;

--- a/packages/components/tree/src/composables/useExpandable.ts
+++ b/packages/components/tree/src/composables/useExpandable.ts
@@ -39,15 +39,15 @@ export function useExpandable(
   const [loadedKeys, setLoadedKeys] = useControlledProp(props, 'loadedKeys', () => [])
   const loadingKeys = ref<VKey[]>([])
 
-  watch(searchedKeys, currKeys => {
-    const { searchValue } = props
-    setExpandWithSearch(!searchValue ? [] : currKeys)
-  })
+  const setExpandWithSearch = (searchedKeys?: VKey[]) => {
+    if (!searchedKeys || searchedKeys.length <= 0) {
+      return
+    }
 
-  const setExpandWithSearch = (searchedKeys: VKey[]) => {
     const { onExpandedChange } = props
     const nodeMap = mergedNodeMap.value
-    const keySet = new Set<VKey>()
+
+    const keySet = new Set<VKey>(expandedKeys.value)
     searchedKeys.forEach(key => {
       getParentKeys(nodeMap, nodeMap.get(key)).forEach(parentKey => keySet.add(parentKey))
     })
@@ -55,6 +55,7 @@ export function useExpandable(
     setExpandedKeys(newKeys)
     callChange(mergedNodeMap, newKeys, onExpandedChange)
   }
+  watch(searchedKeys, setExpandWithSearch)
 
   const handleExpand = async (key: VKey, rawNode: TreeNode) => {
     const { loadChildren } = props


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树组件的搜索清空后，全部节点自动收起


## What is the new behavior?
树组件的搜索清空后，保留最初的展开展开状态

## Other information
