### PR TITLE
fix(comp:alert): cannot change pagination.pageindex through button

### DIFF
--- a/packages/components/alert/__tests__/alert.spec.ts
+++ b/packages/components/alert/__tests__/alert.spec.ts
@@ -107,5 +107,18 @@ describe('Alert', () => {
 
     await wrapper.findAll('button')[0].trigger('click')
     expect(wrapper.find('.ix-alert-content').text()).toBe('message1')
+
+    const onChange = vi.fn()
+
+    await wrapper.setProps({
+      pagination: {
+        pageIndex: 2,
+        onChange,
+      },
+    })
+    expect(wrapper.find('.ix-alert-content').text()).toBe('message2')
+
+    await wrapper.findAll('button')[0].trigger('click')
+    expect(onChange).toBeCalledWith(1)
   })
 })

--- a/packages/components/alert/src/Alert.tsx
+++ b/packages/components/alert/src/Alert.tsx
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { Transition, computed, defineComponent, normalizeClass, watchEffect } from 'vue'
+import { Transition, computed, defineComponent, normalizeClass, watch } from 'vue'
 
 import { isNil, isObject } from 'lodash-es'
 
@@ -40,11 +40,22 @@ export default defineComponent({
       setPageIndex(index)
     }
 
-    watchEffect(() => {
+    watch(
+      () => props.pagination,
+      pagination => {
+        if (isObject(pagination) && !isNil(pagination.pageIndex)) {
+          setPageIndex(pagination.pageIndex)
+        }
+      },
+      {
+        deep: true,
+        immediate: true,
+      },
+    )
+
+    watch(pageIndex, index => {
       const { pagination } = props
-      if (isObject(pagination) && !isNil(pagination.pageIndex)) {
-        setPageIndex(pagination.pageIndex)
-      }
+      isObject(pagination) && callEmit(pagination.onChange, index)
     })
 
     const classes = computed(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
<template>
  <IxAlert :pagination="pagination">
    <div v-for="(item, index) in titles" :key="index">
      {{ item }}
    </div>
  </IxAlert>
</template>

<script lang="ts" setup>
import { reactive } from 'vue'

const titles = ['上次看到这句话的时候还是上次。', '上次看到这么无语的话，还是在上次。', '上次看到这么的发言还是上次。']

const pagination = reactive({
  pageIndex: 1,
  onChange: (index: number) => {
    pagination.pageIndex = index
  },
})
</script>
```

![image](https://user-images.githubusercontent.com/26105153/187819710-bab2a8ae-87fd-4da5-a703-ff59655390c6.png)

当设置了`pagination.pageIndex`，无法通过分页按钮切换，并且无法触发`onChange`
## What is the new behavior?

修复正常

## Other information
