### PR TITLE
fix(comp:select): fix select height error when empty

### DIFF
--- a/packages/components/_private/selector/style/single.less
+++ b/packages/components/_private/selector/style/single.less
@@ -6,15 +6,14 @@
       font-size: @selector-font-size;
     }
 
+    &-item {
+      left: @select-padding-horizontal;
+    }
+
     &-item,
     &-placeholder,
     &-input-inner {
       line-height: @selector-height - 2 * @select-border-width;
-    }
-
-    &-input {
-      right: @select-padding-horizontal + @selector-font-size;
-      left: @select-padding-horizontal;
     }
   }
 }
@@ -23,14 +22,17 @@
   .@{selector-prefix} {
     &-content {
       width: 100%;
+      display: flex;
     }
 
     &-input {
-      position: absolute;
+      flex: auto;
+      width: 0;
+      margin-right: (@select-icon-font-size / 2) + @select-icon-margin-right;
     }
 
     &-item {
-      position: relative;
+      position: absolute;
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
单选select在已选为空的时候，包含它的容器高度多出了2px


## What is the new behavior?
修复以上问题

## Other information
