### PR TITLE
fix(comp:select): fix searchable select input focus error

### DIFF
--- a/packages/components/_private/selector/src/Selector.tsx
+++ b/packages/components/_private/selector/src/Selector.tsx
@@ -79,17 +79,40 @@ export default defineComponent({
         [`${prefixCls}-readonly`]: props.readonly,
         [`${prefixCls}-single`]: !multiple,
         [`${prefixCls}-searchable`]: mergedSearchable.value,
-        [`${prefixCls}-allow-input`]: allowInput || mergedSearchable.value,
+        [`${prefixCls}-allow-input`]: allowInput,
         [`${prefixCls}-${mergedSize.value}`]: true,
       })
     })
 
     const handleClick = () => {
-      const { disabled, opened, readonly } = props
-      if (disabled || readonly || (opened && mergedSearchable.value)) {
+      const { allowInput, disabled, opened, readonly, onOpenedChange } = props
+      if (disabled || readonly || (opened && (mergedSearchable.value || allowInput))) {
         return
       }
-      callEmit(props.onOpenedChange, !opened)
+
+      callEmit(onOpenedChange, !opened)
+    }
+    const handleContentMouseDown = (evt: MouseEvent) => {
+      if (evt.target instanceof HTMLInputElement) {
+        return
+      }
+
+      const { disabled, readonly } = props
+      if (disabled || readonly || isFocused.value) {
+        evt.preventDefault()
+      }
+    }
+    const handleSuffixMouseDown = (evt: MouseEvent) => {
+      evt.preventDefault()
+    }
+    const handleSuffixClick = (evt: MouseEvent) => {
+      const { disabled, readonly, opened, onOpenedChange } = props
+      if (disabled || readonly) {
+        return
+      }
+
+      evt.stopPropagation()
+      callEmit(onOpenedChange, !opened)
     }
 
     const handleClear = (evt: MouseEvent) => {
@@ -193,7 +216,12 @@ export default defineComponent({
       const suffixNode = slots.suffix ? slots.suffix(suffixProps) : <IxIcon {...suffixProps} />
       suffixNode &&
         children.push(
-          <div key="__suffix" class={`${prefixCls}-suffix`}>
+          <div
+            key="__suffix"
+            class={`${prefixCls}-suffix`}
+            onClick={handleSuffixClick}
+            onMousedown={handleSuffixMouseDown}
+          >
             {suffixNode}
           </div>,
         )
@@ -213,7 +241,9 @@ export default defineComponent({
               {value.join(', ')}
             </span>
           )}
-          <div class={`${prefixCls}-content`}>{children}</div>
+          <div class={`${prefixCls}-content`} onMousedown={handleContentMouseDown}>
+            {children}
+          </div>
         </div>
       )
     }

--- a/packages/components/_private/selector/style/index.less
+++ b/packages/components/_private/selector/style/index.less
@@ -59,8 +59,6 @@
 
   &-suffix {
     .selector-icon();
-
-    pointer-events: none;
   }
 
   &-clear {
@@ -69,6 +67,7 @@
     z-index: 1;
     opacity: 0;
     background-color: @select-icon-background-color;
+    cursor: pointer;
 
     &:hover {
       color: @select-icon-hover-color;
@@ -102,7 +101,8 @@
     .borderless();
   }
 
-  &-searchable &-content {
+  &-searchable &-content
+  &-allow-input &-content {
     cursor: text;
 
     .@{selector-prefix}-input-inner {

--- a/packages/components/_private/selector/style/multiple.less
+++ b/packages/components/_private/selector/style/multiple.less
@@ -34,6 +34,7 @@
 
   }
 
+  &.@{selector-prefix}-searchable .@{selector-prefix}-overflow,
   &.@{selector-prefix}-allow-input .@{selector-prefix}-overflow {
     padding-right: @select-icon-font-size + @select-multiple-padding;
   }

--- a/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
+++ b/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
@@ -101,7 +101,7 @@ exports[`TreeSelect > single work > searchFn work 3`] = `
 `;
 
 exports[`TreeSelect > single work > searchable work 1`] = `
-"<div class=\\"ix-tree-select ix-selector ix-selector-opened ix-selector-single ix-selector-searchable ix-selector-allow-input ix-selector-md\\">
+"<div class=\\"ix-tree-select ix-selector ix-selector-opened ix-selector-single ix-selector-searchable ix-selector-md\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>


### PR DESCRIPTION
focus on input should not be lost after clicking on the serchable select

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
多选select在同时有allowInput以及searchable的时候，出现点击selector时input失焦的问题


## What is the new behavior?
在allowInput或者searchable时，点击selector本身不失焦，点击后缀关闭浮层

## Other information
