### PR TITLE
fix(comp:select): fix select height error with size 'sm'

### DIFF
--- a/packages/components/_private/selector/style/multiple.less
+++ b/packages/components/_private/selector/style/multiple.less
@@ -100,10 +100,6 @@
 
   &.@{selector-prefix}-sm {
     .select-size(@select-height-sm, @select-font-size-sm);
-
-    .@{selector-prefix}-input {
-      margin: 0;
-    }
   }
 
   &.@{selector-prefix}-md {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
sm尺寸下多选在已选为空的时候高度异常


## What is the new behavior?
去掉sm下 margin: 0, 使高度正常

## Other information
