### PR TITLE
fix(comp:select): fix selector item text overflowed style

### DIFF
--- a/packages/components/_private/selector/style/multiple.less
+++ b/packages/components/_private/selector/style/multiple.less
@@ -8,6 +8,10 @@
     &-content {
       padding: @select-padding-vertical @select-multiple-padding;
       font-size: @select-font-size;
+
+      .@{overflow-prefix}-item {
+        max-width: calc(100% - @select-icon-font-size);
+      }
     }
 
     &-item {
@@ -31,7 +35,6 @@
     &-overflow {
       line-height: @select-item-line-height;
     }
-
   }
 
   &.@{selector-prefix}-searchable .@{selector-prefix}-overflow,

--- a/packages/components/_private/selector/style/single.less
+++ b/packages/components/_private/selector/style/single.less
@@ -8,6 +8,7 @@
 
     &-item {
       left: @select-padding-horizontal;
+      width: calc(100% - @select-padding-horizontal - @select-icon-font-size);
     }
 
     &-item,


### PR DESCRIPTION
singled select item should show ellipsis when text overflowd
single multipled select item shouldn't shove following elements into a new line

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 单选 selector item 文字溢出
2. 多选 selector item 文字溢出会导致出现空行撑开整体高度


## What is the new behavior?
1. 单选 selector item 文字溢出显示省略号
2. 多选 selector item 限制最大宽度使其不会导致换行

## Other information
