### PR TITLE
fix(comp: overlay): first vnode is comment node

### DIFF
--- a/packages/cdk/utils/__tests__/vNode.spec.ts
+++ b/packages/cdk/utils/__tests__/vNode.spec.ts
@@ -23,6 +23,16 @@ describe('vNode.ts', () => {
     expect(getFirstValidNode(arrayValue as VNodeChild)).toBeUndefined()
     expect(getFirstValidNode(vNode as VNodeChild)).toBeUndefined()
 
+    vNode.type = Comment
+    const textvNode: FakeVNode = {
+      type: Text,
+    }
+    const startCommentNodeArrayValue: FakeVNode[] = [vNode, textvNode]
+    expect(getFirstValidNode(startCommentNodeArrayValue as VNodeChild, 0)).toEqual(textvNode)
+    expect(getFirstValidNode(vNode as VNodeChild, 0)).toBeUndefined()
+    expect(getFirstValidNode(startCommentNodeArrayValue as VNodeChild, 1)).toEqual(textvNode)
+    expect(getFirstValidNode(vNode as VNodeChild, 1)).toBeUndefined()
+
     vNode.type = Fragment
     expect(getFirstValidNode(arrayValue as VNodeChild, 0)).toBeUndefined()
     expect(getFirstValidNode(vNode as VNodeChild, 0)).toBeUndefined()

--- a/packages/cdk/utils/src/vNode.ts
+++ b/packages/cdk/utils/src/vNode.ts
@@ -37,13 +37,14 @@ function getChildren(node: VNode, depth: number): VNode | undefined {
  * @param maxDepth depth to be searched, default is 3
  */
 export function getFirstValidNode(nodes: VNodeChild, maxDepth = 3): VNode | undefined {
-  if (isNil(nodes) || (Array.isArray(nodes) && !nodes.length)) {
+  const targetNodes = Array.isArray(nodes) ? nodes.filter(item => !isComment(item)) : nodes
+  if (isNil(targetNodes) || (Array.isArray(targetNodes) && !targetNodes.length)) {
     return
   }
-  if (Array.isArray(nodes) && nodes.length > 0) {
-    return getChildren(nodes[0] as VNode, maxDepth)
+  if (Array.isArray(targetNodes) && targetNodes.length > 0) {
+    return getChildren(targetNodes[0] as VNode, maxDepth)
   }
-  return getChildren(nodes as VNode, maxDepth)
+  return getChildren(targetNodes as VNode, maxDepth)
 }
 
 /**


### PR DESCRIPTION
fix: https://github.com/IDuxFE/idux/issues/1098
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
overlay 插槽中首个节点是注释节点时 组件不能正常渲染

## What is the new behavior?
overlay 插槽中首个节点是注释节点时 组件可以正常渲染

## Other information
