### PR TITLE
fix(comp:select): onSearch not work with searchable='overlay'

### DIFF
--- a/packages/cdk/utils/src/vNode.ts
+++ b/packages/cdk/utils/src/vNode.ts
@@ -20,7 +20,7 @@ export const isFragment = (node: VNodeChild): boolean => (node as VNode).type ==
 export const isTemplate = (node: VNodeChild): boolean => (node as VNode).type === TEMPLATE
 export const isText = (node: VNodeChild): boolean => (node as VNode).type === Text
 
-function getChildren(node: VNode, depth: number): VNode | undefined {
+function getValidNode(node: VNode, depth: number): VNode | undefined {
   if (isComment(node)) {
     return
   }
@@ -37,14 +37,7 @@ function getChildren(node: VNode, depth: number): VNode | undefined {
  * @param maxDepth depth to be searched, default is 3
  */
 export function getFirstValidNode(nodes: VNodeChild, maxDepth = 3): VNode | undefined {
-  const targetNodes = Array.isArray(nodes) ? nodes.filter(item => !isComment(item)) : nodes
-  if (isNil(targetNodes) || (Array.isArray(targetNodes) && !targetNodes.length)) {
-    return
-  }
-  if (Array.isArray(targetNodes) && targetNodes.length > 0) {
-    return getChildren(targetNodes[0] as VNode, maxDepth)
-  }
-  return getChildren(targetNodes as VNode, maxDepth)
+  return (convertArray(nodes) as VNode[]).find(node => getValidNode(node, maxDepth))
 }
 
 /**

--- a/packages/components/cascader/src/contents/OverlayContent.tsx
+++ b/packages/components/cascader/src/contents/OverlayContent.tsx
@@ -9,6 +9,7 @@
 
 import { type VNode, computed, defineComponent, inject } from 'vue'
 
+import { callEmit } from '@idux/cdk/utils'
 import { ɵInput } from '@idux/components/_private/input'
 
 import { cascaderToken } from '../token'
@@ -40,7 +41,11 @@ export default defineComponent({
       return dataSource
     })
 
-    const handleInput = (evt: Event) => setInputValue((evt.target as HTMLInputElement).value)
+    const handleInput = (evt: Event) => {
+      const { value } = evt.target as HTMLInputElement
+      setInputValue(value)
+      props.searchable && callEmit(props.onSearch, value)
+    }
     const handleClear = () => setInputValue('')
 
     return () => {

--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -11,7 +11,7 @@ import { type ComputedRef, Slots, computed, defineComponent, normalizeClass, pro
 
 import { useAccessorAndControl } from '@idux/cdk/forms'
 import { type VirtualScrollToFn } from '@idux/cdk/scroll'
-import { type VKey, useState } from '@idux/cdk/utils'
+import { type VKey, callEmit, useState } from '@idux/cdk/utils'
 import { ɵInput } from '@idux/components/_private/input'
 import { ɵOverlay } from '@idux/components/_private/overlay'
 import { ɵSelector, type ɵSelectorInstance } from '@idux/components/_private/selector'
@@ -171,7 +171,11 @@ export default defineComponent({
       if (searchable === 'overlay') {
         const value = inputValue.value
         const clearIcon = props.clearIcon ?? config.clearIcon
-        const handleSearchInput = (evt: Event) => setInputValue((evt.target as HTMLInputElement).value)
+        const handleSearchInput = (evt: Event) => {
+          const { value } = evt.target as HTMLInputElement
+          setInputValue(value)
+          props.searchable && callEmit(props.onSearch, value)
+        }
         const handleSearchClear = () => setInputValue('')
 
         children.unshift(

--- a/packages/components/tree-select/src/content/Content.tsx
+++ b/packages/components/tree-select/src/content/Content.tsx
@@ -123,7 +123,11 @@ export default defineComponent({
     }
 
     const mergedClearIcon = computed(() => props.clearIcon ?? config.clearIcon)
-    const handleInput = (evt: Event) => setInputValue((evt.target as HTMLInputElement).value)
+    const handleInput = (evt: Event) => {
+      const { value } = evt.target as HTMLInputElement
+      setInputValue(value)
+      props.searchable && callEmit(props.onSearch, value)
+    }
     const handleClear = () => setInputValue('')
 
     return () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 设置  searchable='overlay' 的时候，onSearch 事件无法触发。
- 同时还有 tree-select， cascader 组件也有同样问题。

## What is the new behavior?


## Other information
