### PR TITLE
fix(cdk:scroll): scrollTop error caused by miscalculation

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useScrollPlacement.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useScrollPlacement.ts
@@ -39,7 +39,7 @@ export function useScrollPlacement(
 ): ScrollPlacementContext {
   const maxScrollHeight = computed(() => {
     const height = scrollHeight.value
-    return height > 0 ? height - props.height : NaN
+    return height > 0 ? Math.max(height - props.height, 0) : NaN
   })
 
   const scrolledTop = computed(() => scrollTop.value <= 0)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 虚拟滚动设置height且fullHeight为false时，会出现scollTop计算为负的情况，导致渲染数据计算异常


## What is the new behavior?
1. 修复以上问题

## Other information
