### PR TITLE
fix(comp:upload): fix incorrect class name when has not status

### DIFF
--- a/packages/components/upload/src/component/ImageCardList.tsx
+++ b/packages/components/upload/src/component/ImageCardList.tsx
@@ -66,7 +66,10 @@ function renderItem(
   locale: Locale,
   getThumbNode: UseThumb['getThumbNode'],
 ) {
-  const fileClasses = normalizeClass([`${cpmClasses.value}-file`, `${cpmClasses.value}-file-${file.status}`])
+  const fileClasses = normalizeClass({
+    [`${cpmClasses.value}-file`]: true,
+    [`${cpmClasses.value}-file-${file.status}`]: !!file.status,
+  })
   const uploadStatusNode = renderUploadStatus(uploadProps, file, locale, cpmClasses)
   const thumbNode = getThumbNode(file)
   const { retryNode, downloadNode, removeNode, previewNode } = renderOprIcon(

--- a/packages/components/upload/src/component/ImageList.tsx
+++ b/packages/components/upload/src/component/ImageList.tsx
@@ -62,7 +62,10 @@ function renderItem(
   locale: Locale,
   getThumbNode: UseThumb['getThumbNode'],
 ) {
-  const fileClasses = normalizeClass([`${cpmClasses.value}-file`, `${cpmClasses.value}-file-${file.status}`])
+  const fileClasses = normalizeClass({
+    [`${cpmClasses.value}-file`]: true,
+    [`${cpmClasses.value}-file-${file.status}`]: !!file.status,
+  })
   const fileNameClasses = normalizeClass([`${cpmClasses.value}-name`, `${cpmClasses.value}-name-pointer`])
   const errorTipNode = renderIcon('exclamation-circle', { class: `${cpmClasses.value}-icon-error` })
   const { retryNode, downloadNode, removeNode } = renderOprIcon(file, icons, cpmClasses, fileOperation, locale)

--- a/packages/components/upload/src/component/TextList.tsx
+++ b/packages/components/upload/src/component/TextList.tsx
@@ -55,7 +55,10 @@ function renderItem(
   fileOperation: FileOperation,
   locale: Locale,
 ) {
-  const fileClasses = normalizeClass([`${cpmClasses.value}-file`, `${cpmClasses.value}-file-${file.status}`])
+  const fileClasses = normalizeClass({
+    [`${cpmClasses.value}-file`]: true,
+    [`${cpmClasses.value}-file-${file.status}`]: !!file.status,
+  })
   const fileNameClasses = normalizeClass([`${cpmClasses.value}-name`, `${cpmClasses.value}-name-pointer`])
   const errorTipNode = renderIcon('exclamation-circle', { class: `${cpmClasses.value}-icon-error` })
   const { retryNode, downloadNode, removeNode } = renderOprIcon(file, icons, cpmClasses, fileOperation, locale)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

当文件没有状态status时，类名展示错误
<img width="635" alt="image" src="https://user-images.githubusercontent.com/17819018/189123331-1d6b6532-86a4-4026-9aa2-65488e9dd4ac.png">

## What is the new behavior?
当文件没有状态status时，不展示相应类名

## Other information
