### PR TITLE
fix(pro:search):  error when deleting previsous item with backspace

### DIFF
--- a/packages/pro/search/src/searchItem/Segment.tsx
+++ b/packages/pro/search/src/searchItem/Segment.tsx
@@ -262,7 +262,7 @@ function useInputEvents(
     const currentStateIndex = searchStates.value.findIndex(state => state.key === props.itemKey)
     const previousState = searchStates.value[currentStateIndex - 1]
 
-    if (previousState.key) {
+    if (previousState?.key) {
       removeSearchState(previousState.key)
     }
   }


### PR DESCRIPTION
error when previousState doesn't exist

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
ProSearch 退格键删除上一个搜索项目时，在上一个搜索项不存在时报错


## What is the new behavior?
修复以上问题

## Other information
