### PR TITLE
fix(comp:cascader): update overlay position after edging

### DIFF
--- a/packages/cdk/click-outside/docs/Api.zh.md
+++ b/packages/cdk/click-outside/docs/Api.zh.md
@@ -29,8 +29,6 @@ export type ClickOutsideHandler = (evt: MouseEvent) => void
 
 ### useClickOutside
 
-对 [ResizeObserver](https://developer.mozilla.org/zh-CN/docs/Web/API/ResizeObserver) 的进一步封装。
-
 ```ts
 /**
  * 为除了特定元素外添加全局点击事件

--- a/packages/cdk/popper/src/types.ts
+++ b/packages/cdk/popper/src/types.ts
@@ -112,7 +112,7 @@ export interface PopperInstance<TE extends PopperElement = PopperElement, PE ext
   /**
    * Update popper.
    */
-  update(options: Partial<PopperOptions>): void
+  update(options?: Partial<PopperOptions>): void
   /**
    * Force update popper
    */

--- a/packages/components/cascader/src/Cascader.tsx
+++ b/packages/components/cascader/src/Cascader.tsx
@@ -111,6 +111,7 @@ export default defineComponent({
       setInputValue,
       overlayOpened,
       setOverlayOpened,
+      updateOverlay,
       mergedData,
       mergedDataMap,
       ...activeStateContext,

--- a/packages/components/cascader/src/contents/OverlayContent.tsx
+++ b/packages/components/cascader/src/contents/OverlayContent.tsx
@@ -7,7 +7,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { type VNode, computed, defineComponent, inject } from 'vue'
+import { type VNode, computed, defineComponent, inject, watch } from 'vue'
 
 import { callEmit } from '@idux/cdk/utils'
 import { ɵInput } from '@idux/components/_private/input'
@@ -27,6 +27,7 @@ export default defineComponent({
       expandedKeys,
       inputValue,
       setInputValue,
+      updateOverlay,
     } = inject(cascaderToken)!
 
     const contentData = computed(() => {
@@ -39,6 +40,10 @@ export default defineComponent({
         }
       })
       return dataSource
+    })
+
+    watch([() => contentData.value.length, inputValue], () => {
+      updateOverlay()
     })
 
     const handleInput = (evt: Event) => {

--- a/packages/components/cascader/src/token.ts
+++ b/packages/components/cascader/src/token.ts
@@ -39,6 +39,7 @@ export interface CascaderContext
   setInputValue: (value: string) => void
   overlayOpened: ComputedRef<boolean>
   setOverlayOpened: (open: boolean) => void
+  updateOverlay: () => void
 }
 
 export const cascaderToken: InjectionKey<CascaderContext> = Symbol('cascaderToken')

--- a/packages/components/select/src/composables/useOverlayState.ts
+++ b/packages/components/select/src/composables/useOverlayState.ts
@@ -14,7 +14,7 @@ import { type ɵSelectorInstance } from '@idux/components/_private/selector'
 export interface OverlayStateContext {
   overlayRef: Ref<ɵOverlayInstance | undefined>
   overlayStyle: ComputedRef<CSSProperties>
-  updateOverlay: (rect: DOMRect) => void
+  updateOverlay: (rect?: DOMRect) => void
   overlayOpened: ComputedRef<boolean>
   setOverlayOpened: (open: boolean) => void
 }
@@ -36,10 +36,14 @@ export function useOverlayState(
   })
   const [overlayOpened, setOverlayOpened] = useControlledProp(props, 'open', false)
 
-  const updateOverlay = (rect: DOMRect) => {
-    const { width } = rect
-    if (width > 0) {
-      setOverlayWidth(convertCssPixel(width))
+  const updateOverlay = (rect?: DOMRect) => {
+    if (rect) {
+      const { width } = rect
+      if (width > 0) {
+        setOverlayWidth(convertCssPixel(width))
+        overlayOpened.value && overlayRef.value?.updatePopper()
+      }
+    } else {
       overlayOpened.value && overlayRef.value?.updatePopper()
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

级联组件贴近浏览器边缘后，再打开下一级菜单，此时下一级菜单会到窗口外（看不见）。

## What is the new behavior?

每次打开下一级菜单的时候，会更新一下 overlay 的位置，避免上述情况的出现。


## Other information
