### PR TITLE
fix(pro:search): clickside should exclude overlay container

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -50,11 +50,6 @@ export default defineComponent({
     const activeSegmentContext = useActiveSegment(props, searchItems, searchStateContext.tempSearchStateAvailable)
     const commonOverlayProps = useCommonOverlayProps(mergedPrefixCls, props, config)
 
-    const overlayContainer = computed(() => {
-      const target = commonOverlayProps.value.target
-      return isFunction(target) ? target() : target
-    })
-
     const { initSearchStates, updateSearchState, clearSearchState, tempSearchState } = searchStateContext
     const { activeSegment, setInactive, setTempActive } = activeSegmentContext
 
@@ -101,6 +96,13 @@ export default defineComponent({
       evt.preventDefault()
       setTempSegmentActive()
     }
+
+    const getContainerEl = () => {
+      const containerProp = commonOverlayProps.value.container
+      const container = isFunction(containerProp) ? containerProp() : containerProp
+
+      return isString(container) ? document.querySelector(container) : container
+    }
     const handleClickOutside = (evt: MouseEvent) => {
       if (!activeSegment.value) {
         previousActiveSegmentName = undefined
@@ -108,11 +110,9 @@ export default defineComponent({
       }
 
       const paths = evt.composedPath()
-      const target = overlayContainer.value
+      const container = getContainerEl()
 
-      if (
-        paths.some(path => (isString(target) ? (path as HTMLElement).classList?.contains(target) : path === target))
-      ) {
+      if (container && paths.includes(container)) {
         return
       }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
proSearch clickoutside 没有过滤掉浮层点击


## What is the new behavior?
修复以上问题

## Other information
