### PR TITLE
fix(pro:transfer): remove icon isn't displayed

### DIFF
--- a/packages/pro/transfer/src/composables/useTransferTableProps.ts
+++ b/packages/pro/transfer/src/composables/useTransferTableProps.ts
@@ -107,6 +107,7 @@ function convertTableColumns(
           return renderRemovableLabel(
             key,
             disabledDataSourceKeys.value.has(key),
+            false,
             null,
             triggerRemove,
             mergedPrefixCls.value,
@@ -114,7 +115,7 @@ function convertTableColumns(
         },
       })
     } else {
-      const originalCustomCell = lastCol.customCell
+      const { customCell: originalCustomCell, ellipsis } = lastCol
       //eslint-disable-next-line @typescript-eslint/no-explicit-any
       const renderLabel = (data: { value: any; record: any; rowIndex: number }) => {
         if (!originalCustomCell) {
@@ -135,6 +136,7 @@ function convertTableColumns(
           return renderRemovableLabel(
             key,
             disabledDataSourceKeys.value.has(key),
+            !!ellipsis,
             () => renderLabel(data),
             triggerRemove,
             mergedPrefixCls.value,

--- a/packages/pro/transfer/src/content/RenderRemovableLabel.tsx
+++ b/packages/pro/transfer/src/content/RenderRemovableLabel.tsx
@@ -13,6 +13,7 @@ import { IxIcon } from '@idux/components/icon'
 export function renderRemovableLabel(
   key: VKey,
   disabled: boolean,
+  ellipsis: boolean,
   defaultSlot: Slot | null,
   triggerRemove: (keys: VKey[]) => void,
   prefixCls: string,
@@ -20,9 +21,14 @@ export function renderRemovableLabel(
   const onClick = () => {
     triggerRemove([key])
   }
+
+  const classes = {
+    [`${prefixCls}-removable-label`]: true,
+    [`${prefixCls}-removable-label-ellipsis`]: !!ellipsis,
+  }
   return (
-    <span class={`${prefixCls}-removable-label`}>
-      {defaultSlot?.()}
+    <span class={classes}>
+      <span class={`${prefixCls}-removable-label-text`}>{defaultSlot?.()}</span>
       {!disabled && renderRemoveIcon(prefixCls, onClick)}
     </span>
   )

--- a/packages/pro/transfer/style/index.less
+++ b/packages/pro/transfer/style/index.less
@@ -1,4 +1,5 @@
 @import '../../style/mixins/reset.less';
+@import '../../../components/style/mixins/ellipsis.less';
 
 .@{pro-transfer-prefix} {
   .reset-component();
@@ -41,6 +42,10 @@
       width: 100%;
       align-items: center;
       line-height: @checkbox-line-height;
+
+      &-ellipsis &-text {
+        .ellipsis();
+      }
     }
     &-close-icon {
       padding: @pro-transfer-table-close-icon-padding;


### PR DESCRIPTION
remove icon isn't displayed when table column ellipsis is set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格穿梭框目标表格列配置 ellipsis时，删除图标不显示

## What is the new behavior?
修复以上问题

## Other information
