### PR TITLE
fix(cdk:scroll): virtual scroll scrolledBottom event

### DIFF
--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -46,7 +46,7 @@ export default defineComponent({
       heights,
     )
 
-    const { syncScrollTop } = useScrollPlacement(
+    const { syncScrollTop, handleScroll } = useScrollPlacement(
       props,
       holderRef,
       scrollTop,
@@ -66,6 +66,7 @@ export default defineComponent({
       scrollHeight,
       scrollOffset,
       syncScrollTop,
+      handleScroll,
     })
 
     const scrollTo = useScrollTo(props, holderRef, getKey, heights, collectHeights, syncScrollTop)

--- a/packages/cdk/scroll/src/virtual/composables/useScrollTo.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useScrollTo.ts
@@ -36,7 +36,7 @@ export function useScrollTo(
     const { dataSource, itemHeight } = props
 
     if (typeof option === 'number') {
-      syncScrollTop(option)
+      syncScrollTop(option, true)
     } else if (typeof option === 'object') {
       const { align, offset = 0 } = option
       let index: number
@@ -102,7 +102,7 @@ export function useScrollTo(
           }
 
           if (targetTop !== null && targetTop !== holderElement.scrollTop) {
-            syncScrollTop(targetTop)
+            syncScrollTop(targetTop, true)
           }
         }
 

--- a/packages/cdk/scroll/src/virtual/contents/Holder.tsx
+++ b/packages/cdk/scroll/src/virtual/contents/Holder.tsx
@@ -10,7 +10,6 @@ import { type CSSProperties, computed, defineComponent, inject, onBeforeUnmount,
 import { isString, throttle } from 'lodash-es'
 
 import { offResize, onResize } from '@idux/cdk/resize'
-import { callEmit } from '@idux/cdk/utils'
 
 import { virtualScrollToken } from '../token'
 
@@ -24,8 +23,7 @@ export default defineComponent({
       collectHeights,
       scrollHeight,
       scrollOffset,
-      scrollTop,
-      syncScrollTop,
+      handleScroll,
     } = inject(virtualScrollToken)!
 
     const style = computed<CSSProperties | undefined>(() => {
@@ -67,14 +65,6 @@ export default defineComponent({
         top: 0,
       }
     })
-
-    const handleScroll = (evt: Event) => {
-      const { scrollTop: newScrollTop } = evt.currentTarget as Element
-      if (newScrollTop !== scrollTop.value) {
-        syncScrollTop(newScrollTop)
-      }
-      callEmit(props.onScroll, evt)
-    }
 
     const contentRef = ref<HTMLDivElement>()
     const onContentResize = throttle(collectHeights, 16)

--- a/packages/cdk/scroll/src/virtual/token.ts
+++ b/packages/cdk/scroll/src/virtual/token.ts
@@ -20,6 +20,7 @@ export interface VirtualScrollContext {
   scrollHeight: Ref<number>
   scrollOffset: Ref<number | undefined>
   syncScrollTop: SyncScrollTop
+  handleScroll: (evt: Event) => void
 }
 
 export const virtualScrollToken: InjectionKey<VirtualScrollContext> = Symbol('virtualScrollToken')


### PR DESCRIPTION
scrolledBottom event shouldn't trigger when maxheight change

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
虚拟滚动的scrolledBottom在初始化以及高度改变时异常触发


## What is the new behavior?
仅在滚动事件触发的前提下触发scrolledBottom事件

## Other information
