### PR TITLE
fix(pro:transfer): modify treeProps and tableProps type

### DIFF
--- a/packages/pro/transfer/docs/Api.zh.md
+++ b/packages/pro/transfer/docs/Api.zh.md
@@ -62,24 +62,22 @@ export interface TransferPaginationProps {
   onChange?: (isSource: boolean, pageIndex: number, pageSize: number) => void
 }
 
-export interface ProTransferTableProps {
-  sourceColumns: TableColumn[]
-  targetColumns: TableColumn[]
-  tableLayout?: 'auto' | 'fixed'
-  ellipsis?: boolean
-  borderless?: boolean
-}
+export type ProTransferTableProps<T = any, K = VKey> = {
+  sourceColumns: TableColumn<T, K>[]
+  targetColumns: TableColumn<T, K>[]
+} & Pick<TableProps, 'tableLayout' | 'ellipsis' | 'borderless'>
 
-export interface ProTransferTreeProps {
-  showLine?: boolean
-  childrenKey?: string
-  expandIcon?: string
-  labelKey?: string
-  leafLineIcon?: string
-  loadChildren?: <C extends VKey = VKey>(node: TreeTransferData<C>) => TreeTransferData<C>[]
-  onExpand?: MaybeArray<(expanded: boolean, node: TreeNode) => void>
-  onExpandedChange?: MaybeArray<(expendedKeys: VKey[], expendedNodes: TreeNode[]) => void>
-}
+export type ProTransferTreeProps = Pick<
+  TreeProps,
+  | 'showLine'
+  | 'childrenKey'
+  | 'expandIcon'
+  | 'labelKey'
+  | 'leafLineIcon'
+  | 'loadChildren'
+  | 'onExpand'
+  | 'onExpandedChange'
+>
 ```
 
 #### ProTransferSlots

--- a/packages/pro/transfer/src/types.ts
+++ b/packages/pro/transfer/src/types.ts
@@ -10,7 +10,7 @@
 import type { VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
-import type { TableColumn } from '@idux/components/table'
+import type { TableColumn, TableProps } from '@idux/components/table'
 import type {
   SearchFn,
   TransferData,
@@ -18,7 +18,7 @@ import type {
   TransferPaginationProps,
   TransferScroll,
 } from '@idux/components/transfer'
-import type { TreeNode } from '@idux/components/tree'
+import type { TreeProps } from '@idux/components/tree'
 import type { DefineComponent, HTMLAttributes, PropType } from 'vue'
 
 export type ProTransferTypes = 'table' | 'tree'
@@ -28,24 +28,22 @@ export type TreeTransferData<C extends VKey = 'children'> = TransferData & {
   [key in C]?: TreeTransferData<C>[]
 }
 
-export interface ProTransferTableProps<T = any, K = VKey> {
+export type ProTransferTableProps<T = any, K = VKey> = {
   sourceColumns: TableColumn<T, K>[]
   targetColumns: TableColumn<T, K>[]
-  tableLayout?: 'auto' | 'fixed'
-  ellipsis?: boolean
-  borderless?: boolean
-}
+} & Pick<TableProps, 'tableLayout' | 'ellipsis' | 'borderless'>
 
-export interface ProTransferTreeProps {
-  showLine?: boolean
-  childrenKey?: string
-  expandIcon?: string
-  labelKey?: string
-  leafLineIcon?: string
-  loadChildren?: (node: TreeTransferData<any>) => TreeTransferData<any>[]
-  onExpand?: MaybeArray<(expanded: boolean, node: TreeNode<any>) => void>
-  onExpandedChange?: MaybeArray<(expendedKeys: any[], expendedNodes: TreeNode<any>[]) => void>
-}
+export type ProTransferTreeProps = Pick<
+  TreeProps,
+  | 'showLine'
+  | 'childrenKey'
+  | 'expandIcon'
+  | 'labelKey'
+  | 'leafLineIcon'
+  | 'loadChildren'
+  | 'onExpand'
+  | 'onExpandedChange'
+>
 
 export const proTransferProps = {
   type: {


### PR DESCRIPTION
treeProps and tableProps type shoud be consistent with table and tree

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
treeProps和tableProps中的属性类型没有对应tree和table


## What is the new behavior?
修改类型，使用Pick与原类型一致

## Other information
