### PR TITLE
fix(pro:transfer): transfer tree should show scrollbar

### DIFF
--- a/packages/pro/transfer/src/composables/useTransferTreeProps.ts
+++ b/packages/pro/transfer/src/composables/useTransferTreeProps.ts
@@ -79,7 +79,7 @@ export function useTransferTreeProps(
     const height = isNumber(props.scroll?.height) ? props.scroll?.height : undefined
 
     return {
-      autoHeight: !height,
+      autoHeight: !height || !props.virtual,
       ...(props.treeProps ?? {}),
       blocked: true,
       cascade: true,


### PR DESCRIPTION
tansfer tree should show scrollbar when scroll.height is set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树穿梭框，在不配置 virtual时配置scroll.height，滚动失效


## What is the new behavior?
修复以上问题

## Other information
