### PR TITLE
feat(comp:tooltip): supports closeOnDeactivated

### DIFF
--- a/packages/components/drawer/docs/Api.zh.md
+++ b/packages/components/drawer/docs/Api.zh.md
@@ -9,6 +9,7 @@
 | `v-model:visible` | 是否可见 | `boolean` | - | - | - |
 | `closable` | 是否显示右上角的关闭按钮 | `boolean` | `true` | ✅ | - |
 | `closeIcon` | 自定义关闭图标 | `string \| VNode \| #closeIcon` | `close` | ✅ | - |
+| `closeOnDeactivated` | 是否在 [onDeactivated](https://cn.vuejs.org/api/composition-api-lifecycle.html#ondeactivated) 时关闭 | `boolean` | `true` | - | - |
 | `closeOnEsc` | 是否支持键盘 `esc` 关闭 | `boolean` | `true` | ✅ | - |
 | `container` | 自定义抽屉挂载的容器节点  | `string \| HTMLElement \| () => string \| HTMLElement` | - | ✅ | - |
 | `destroyOnHide` | 关闭时销毁子元素 | `boolean` | `false` | - | - |

--- a/packages/components/drawer/src/Drawer.tsx
+++ b/packages/components/drawer/src/Drawer.tsx
@@ -5,14 +5,23 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { DrawerProps } from './types'
-import type { ScrollStrategy } from '@idux/cdk/scroll'
-import type { ComputedRef, Ref } from 'vue'
-
-import { computed, defineComponent, inject, onBeforeUnmount, onMounted, provide, ref, toRef, watch } from 'vue'
+import {
+  type ComputedRef,
+  type Ref,
+  computed,
+  defineComponent,
+  inject,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  provide,
+  ref,
+  toRef,
+  watch,
+} from 'vue'
 
 import { CdkPortal } from '@idux/cdk/portal'
-import { BlockScrollStrategy } from '@idux/cdk/scroll'
+import { BlockScrollStrategy, type ScrollStrategy } from '@idux/cdk/scroll'
 import { callEmit, useControlledProp } from '@idux/cdk/utils'
 import { ɵMask } from '@idux/components/_private/mask'
 import { useGlobalConfig } from '@idux/components/config'
@@ -20,7 +29,7 @@ import { usePortalTarget, useZIndex } from '@idux/components/utils'
 
 import DrawerWrapper from './DrawerWrapper'
 import { DRAWER_TOKEN, drawerToken } from './token'
-import { drawerProps } from './types'
+import { type DrawerProps, drawerProps } from './types'
 
 export default defineComponent({
   name: 'IxDrawer',
@@ -92,6 +101,12 @@ function useVisible(props: DrawerProps) {
       return currVisible
     }
     return currAnimatedVisible
+  })
+
+  onDeactivated(() => {
+    if (mergedVisible.value && props.closeOnDeactivated) {
+      setVisible(false)
+    }
   })
 
   return { visible, setVisible, animatedVisible, mergedVisible }

--- a/packages/components/drawer/src/types.ts
+++ b/packages/components/drawer/src/types.ts
@@ -42,6 +42,10 @@ export const drawerProps = {
     default: undefined,
   },
   closeIcon: [String, Object] as PropType<string | VNode>,
+  closeOnDeactivated: {
+    type: Boolean,
+    default: true,
+  },
   closeOnEsc: {
     type: Boolean,
     default: undefined,

--- a/packages/components/modal/docs/Api.zh.md
+++ b/packages/components/modal/docs/Api.zh.md
@@ -12,6 +12,7 @@
 | `centered` | 垂直居中展示 | `boolean` | `false` | ✅ | - |
 | `closable` | 是否显示右上角的关闭按钮 | `boolean` | `true` | ✅ | - |
 | `closeIcon` | 自定义关闭图标 | `string \| VNode \| #closeIcon` | `close` | ✅ | - |
+| `closeOnDeactivated` | 是否在 [onDeactivated](https://cn.vuejs.org/api/composition-api-lifecycle.html#ondeactivated) 时关闭 | `boolean` | `true` | - | - |
 | `closeOnEsc` | 是否支持键盘 `esc` 关闭 | `boolean` | `true` | ✅ | - |
 | `container` | 自定义对话框挂载的容器节点  | `string \| HTMLElement \| () => string \| HTMLElement` | - | ✅ | - |
 | `destroyOnHide` | 关闭时销毁子元素 | `boolean` | `false` | - | - |

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -10,6 +10,7 @@ import {
   computed,
   defineComponent,
   onBeforeUnmount,
+  onDeactivated,
   onMounted,
   provide,
   ref,
@@ -88,7 +89,6 @@ export default defineComponent({
 
 function useVisible(props: ModalProps) {
   const [visible, setVisible] = useControlledProp(props, 'visible', false)
-
   const animatedVisible = ref<boolean>()
 
   const mergedVisible = computed(() => {
@@ -98,6 +98,12 @@ function useVisible(props: ModalProps) {
       return currVisible
     }
     return currAnimatedVisible
+  })
+
+  onDeactivated(() => {
+    if (mergedVisible.value && props.closeOnDeactivated) {
+      setVisible(false)
+    }
   })
 
   return { visible, setVisible, animatedVisible, mergedVisible }

--- a/packages/components/modal/src/types.ts
+++ b/packages/components/modal/src/types.ts
@@ -43,6 +43,10 @@ export const modalProps = {
     default: undefined,
   },
   closeIcon: [String, Object] as PropType<string | VNode>,
+  closeOnDeactivated: {
+    type: Boolean,
+    default: true,
+  },
   closeOnEsc: {
     type: Boolean,
     default: undefined,

--- a/packages/components/tooltip/docs/Api.zh.md
+++ b/packages/components/tooltip/docs/Api.zh.md
@@ -8,6 +8,7 @@
 | --- | --- | --- | --- | --- | --- |
 | `v-model:visible` | 是否显隐 | `boolean` | - | - | - |
 | `autoAdjust` | 浮层被遮挡时自动调整位置 | `boolean` | `true` | ✅ | - |
+| `closeOnDeactivated` | 是否在 [onDeactivated](https://cn.vuejs.org/api/composition-api-lifecycle.html#ondeactivated) 时关闭 | `boolean` | `true` | - | - |
 | `destroyOnHide` | 隐藏时是否销毁浮层 | `boolean` | `false` | ✅ | - |
 | `delay` | 浮层显示隐藏延时 | `number \| [number, number]` | `100` | ✅ | - |
 | `overlayContainer` | 自定义容器节点 | `string \| HTMLElement \| () => string \| HTMLElement` | - | ✅ | - |

--- a/packages/components/tooltip/src/types.ts
+++ b/packages/components/tooltip/src/types.ts
@@ -20,6 +20,10 @@ export const tooltipProps = {
     type: Boolean,
     default: undefined,
   },
+  closeOnDeactivated: {
+    type: Boolean,
+    default: true,
+  },
   destroyOnHide: {
     type: Boolean,
     default: undefined,

--- a/packages/components/tooltip/src/useTooltipOverlay.ts
+++ b/packages/components/tooltip/src/useTooltipOverlay.ts
@@ -5,14 +5,14 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { TooltipProps } from './types'
-import type { ɵOverlayInstance, ɵOverlayProps } from '@idux/components/_private/overlay'
-import type { CommonConfig, TooltipConfig } from '@idux/components/config'
-
-import { ComputedRef, Ref, computed, ref, toRef } from 'vue'
+import { type ComputedRef, type Ref, computed, onDeactivated, ref, toRef } from 'vue'
 
 import { useControlledProp } from '@idux/cdk/utils'
+import { type ɵOverlayInstance, type ɵOverlayProps } from '@idux/components/_private/overlay'
+import { type CommonConfig, type TooltipConfig } from '@idux/components/config'
 import { useOverlayContainer, useZIndex } from '@idux/components/utils'
+
+import { type TooltipProps } from './types'
 
 const defaultOffset: [number, number] = [0, 12]
 
@@ -37,6 +37,12 @@ export function useTooltipOverlay(
 
   const [visible, setVisible] = useControlledProp(props, 'visible', false)
   const { currentZIndex } = useZIndex(toRef(props, 'zIndex'), toRef(common, 'overlayZIndex'), visible)
+
+  onDeactivated(() => {
+    if (visible.value && props.closeOnDeactivated) {
+      setVisible(false)
+    }
+  })
 
   const overlayProps = computed(() => {
     const trigger = props.trigger ?? config.trigger


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

开启 Keep Alive 的时候，tooltip 等组件不会关闭，任然悬浮在界面中。

## What is the new behavior?

- 支持设置 closeOnDeactivated， 在 onDeactivated 关闭相关浮层组件。
- 支持的组件有：tooltip, popover, popconfirm, modal, drawer

## Other information
