### PR TITLE
fix(pro:search): fix onVisibleChange and segment state initialization

### DIFF
--- a/packages/pro/search/src/composables/useActiveSegment.ts
+++ b/packages/pro/search/src/composables/useActiveSegment.ts
@@ -82,6 +82,8 @@ export function useActiveSegment(
   const setInactive = (blur?: boolean) => {
     setActiveSegment(undefined)
 
+    // when no segment is active the component will lose focus
+    // so set the container element focused if we do not intend to blur the component
     if (!blur) {
       elementRef.value?.focus()
     }

--- a/packages/pro/search/src/searchItem/SearchItem.tsx
+++ b/packages/pro/search/src/searchItem/SearchItem.tsx
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { computed, defineComponent, inject, normalizeClass, provide } from 'vue'
+import { computed, defineComponent, inject, normalizeClass, provide, watch } from 'vue'
 
 import { IxTooltip } from '@idux/components/tooltip'
 
@@ -34,7 +34,7 @@ export default defineComponent({
 
     const segmentStateContext = useSegmentStates(props, proSearchProps, context)
     const segmentOverlayUpdateContext = useSegmentOverlayUpdate()
-    const { segmentStates } = segmentStateContext
+    const { segmentStates, initSegmentStates } = segmentStateContext
 
     provide(searchItemContext, {
       ...segmentStateContext,
@@ -55,6 +55,11 @@ export default defineComponent({
     })
 
     const isActive = computed(() => activeSegment.value?.itemKey === props.searchItem!.key)
+    watch(isActive, active => {
+      if (!active) {
+        initSegmentStates()
+      }
+    })
 
     const classes = computed(() => {
       return normalizeClass({
@@ -79,8 +84,6 @@ export default defineComponent({
       if (proSearchProps.disabled) {
         return
       }
-      evt.preventDefault()
-      evt.stopPropagation()
 
       setSegmentActive(name)
 
@@ -144,6 +147,7 @@ export default defineComponent({
         <span
           class={classes.value}
           v-show={(isActive.value && !proSearchProps.disabled) || props.searchItem?.key !== tempSearchStateKey}
+          onMousedown={evt => evt.preventDefault()}
         >
           {children}
         </span>

--- a/packages/pro/search/src/searchItem/Segment.tsx
+++ b/packages/pro/search/src/searchItem/Segment.tsx
@@ -94,20 +94,18 @@ export default defineComponent({
       stopActiveSegmentWatch = watch(
         isActive,
         (active, preActive) => {
-          if (active) {
-            nextTick(() => {
+          nextTick(() => {
+            if (active) {
               segmentInputRef.value?.focus()
-            })
-            setOverlayOpened(true)
-            nextTick(() => {
+              setOverlayOpened(true)
               if (!props.value && props.segment.defaultValue) {
                 handleSegmentChange(props.segment.name, props.segment.defaultValue)
                 handleSegmentConfirm(props.segment.name, false)
               }
-            })
-          } else if (preActive) {
-            setOverlayOpened(false)
-          }
+            } else if (preActive) {
+              setOverlayOpened(false)
+            }
+          })
         },
         { immediate: true },
       )

--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -57,7 +57,7 @@ export function createSelectSegment(
       }
     }
     const handleSelectAll = () => {
-      setValue(selectableKeys.length !== panelValue.length ? selectableKeys : [])
+      setValue(selectableKeys.length !== panelValue.length ? selectableKeys : undefined)
     }
 
     return (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 被激活的下一个segment触发onPanelVisibleChange时，触发了上一个segment的回调函数
2. select在多选时，取消全选应当设置值为undefined而非[]
3. 搜索项从激活到未激活后状态没有初始化


## What is the new behavior?
修复以上问题

## Other information
