### PR TITLE
feat(comp:textarea): autoRows supports setting min and max separately

### DIFF
--- a/packages/components/textarea/docs/Api.zh.md
+++ b/packages/components/textarea/docs/Api.zh.md
@@ -10,7 +10,7 @@
 | --- | --- | --- | --- | --- | --- |
 | `v-model:value` | 控件值 | `string` | - | - | 使用 `control` 时，此配置无效 |
 | `control` | 控件控制器 | `string \| number \| AbstractControl` | - | - | 配合 `@idux/cdk/forms` 使用, 参考 [Form](/components/form/zh) |
-| `autoRows` | 是否显示自适应 `rows` | `boolean \| { minRows: number, maxRows: number }` | `false` | ✅ | - |
+| `autoRows` | 是否显示自适应 `rows` | `boolean \| { minRows?: number, maxRows?: number }` | `false` | ✅ | - |
 | `clearable` | 是否显示清除图标 | `boolean` | `false` | ✅ | - |
 | `clearIcon` | 设置清除图标 | `string \| #clearIcon` | `'close-circle'` | ✅ | - |
 | `computeCount` | 自定义计算字符数的函数 | `(value: string) => string` | - | ✅ | 优先级高于 `maxCount` |

--- a/packages/components/textarea/src/composables/useAutoRows.ts
+++ b/packages/components/textarea/src/composables/useAutoRows.ts
@@ -9,7 +9,7 @@ import type { TextareaAutoRows } from '../types'
 
 import { type ComputedRef, type Ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
 
-import { isNumber, isObject, throttle } from 'lodash-es'
+import { isBoolean, isNumber, isObject, throttle } from 'lodash-es'
 
 import { useResizeObserver } from '@idux/cdk/resize'
 import { rAF } from '@idux/cdk/utils'
@@ -26,7 +26,7 @@ export interface AutoRowsContext {
 
 const isAutoRowsObject = (value: unknown): value is TextareaAutoRows => {
   return (
-    isObject(value) && isNumber((value as TextareaAutoRows).minRows) && isNumber((value as TextareaAutoRows).maxRows)
+    isObject(value) && (isNumber((value as TextareaAutoRows).minRows) || isNumber((value as TextareaAutoRows).maxRows))
   )
 }
 
@@ -43,15 +43,15 @@ export function useAutoRows(
 ): AutoRowsContext {
   /** Keep track of the previous textarea value to avoid resizing when the value hasn't changed. */
   let previousValue: string | undefined
-  let previousMinRows: number | null = null
+  let previousMinRows: number | undefined
   let initialHeight: string | undefined
   let isFunctioning = false
   let currentOverflow: string | undefined
   let cachedPlaceholderHeight: number | undefined
 
-  const enabled = computed(() => isAutoRowsObject(autoRows.value) || !!autoRows.value)
-  const minRows = computed(() => (isAutoRowsObject(autoRows.value) ? autoRows.value.minRows : null))
-  const maxRows = computed(() => (isAutoRowsObject(autoRows.value) ? autoRows.value.maxRows : null))
+  const enabled = computed(() => isAutoRowsObject(autoRows.value) || (isBoolean(autoRows.value) && !!autoRows.value))
+  const minRows = computed(() => (isAutoRowsObject(autoRows.value) ? autoRows.value.minRows : undefined))
+  const maxRows = computed(() => (isAutoRowsObject(autoRows.value) ? autoRows.value.maxRows : undefined))
   const cachedLineHeight = useLineHeight(textareaRef)
   const boxSizingData = computed(() => {
     if (!textareaRef.value) {

--- a/packages/components/textarea/src/types.ts
+++ b/packages/components/textarea/src/types.ts
@@ -32,4 +32,4 @@ export type TextareaComponent = DefineComponent<
 export type TextareaInstance = InstanceType<DefineComponent<TextareaProps, TextareaBindings>>
 
 export type TextareaResize = 'none' | 'both' | 'horizontal' | 'vertical'
-export type TextareaAutoRows = { minRows: number; maxRows: number }
+export type TextareaAutoRows = { minRows?: number; maxRows?: number }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
autoRows 不支持 minRows和 maxRows 单独配置


## What is the new behavior?
支持 单独配置 minRows和 maxRows

## Other information
