### PR TITLE
fix(comp:table): default selectable column shouldn't show ellipsis

### DIFF
--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -177,7 +177,7 @@
   // --------- Selectable ---------
 
   & &-col-selectable {
-    width: 40px;
+    width: 41px;
   }
 
   & &-col-selectable&-selectable-with-dropdown {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格配置 ellipsis 后，selectable 列显示省略号

## What is the new behavior?
增加默认selectable列宽度，避免默认selectable列显示省略号

## Other information
