### PR TITLE
fix(comp:table): the scroll body is incorrect, when virtual enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "tslib": "^2.4.0",
     "typescript": "^4.7.4",
     "unplugin-vue-components": "^0.22.4",
-    "vite": "^3.1.0",
+    "vite": "3.1.3",
     "vitest": "^0.21.1",
     "vue": "^3.2.39",
     "yaml-front-matter": "^4.1.1"

--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -70,7 +70,7 @@ export default defineComponent({
     })
 
     const scrollTo = useScrollTo(props, holderRef, getKey, heights, collectHeights, syncScrollTop)
-    expose({ scrollTo })
+    expose({ scrollTo, holderRef })
 
     const mergedData = computed(() => props.dataSource.slice(startIndex.value, endIndex.value + 1))
     watch(mergedData, data => callEmit(props.onScrolledChange, startIndex.value, endIndex.value, data))

--- a/packages/cdk/scroll/src/virtual/contents/Holder.tsx
+++ b/packages/cdk/scroll/src/virtual/contents/Holder.tsx
@@ -10,6 +10,7 @@ import { type CSSProperties, computed, defineComponent, inject, onBeforeUnmount,
 import { isString, throttle } from 'lodash-es'
 
 import { offResize, onResize } from '@idux/cdk/resize'
+import { convertCssPixel } from '@idux/cdk/utils'
 
 import { virtualScrollToken } from '../token'
 
@@ -28,7 +29,7 @@ export default defineComponent({
 
     const style = computed<CSSProperties | undefined>(() => {
       const { height, fullHeight } = props
-      if (!height) {
+      if (!height || height <= 0) {
         return undefined
       }
 
@@ -36,13 +37,7 @@ export default defineComponent({
         return { height }
       }
 
-      /* eslint-disable indent */
-      return height <= 0
-        ? undefined
-        : {
-            [fullHeight ? 'height' : 'maxHeight']: height + 'px',
-          }
-      /* eslint-enable indent */
+      return { [fullHeight ? 'height' : 'maxHeight']: convertCssPixel(height) }
     })
 
     const fillerStyle = computed<CSSProperties | undefined>(() => {

--- a/packages/components/table/docs/Api.zh.md
+++ b/packages/components/table/docs/Api.zh.md
@@ -179,7 +179,7 @@ export type TablePaginationPosition = 'topStart' | 'top' | 'topEnd' | 'bottomSta
 
 | 名称 | 说明 | 参数类型 | 备注 |
 | --- | --- | --- | --- |
-| `scrollTo` | 滚动到指定位置 | `(option?: number \| VirtualScrollToOptions) => void` | 仅 `virtual` 模式下可用 |
+| `scrollTo` | 滚动到指定高度或位置 | `(option?: number \| VirtualScrollToOptions) => void` | `VirtualScrollToOptions` 参数仅 `virtual` 模式下可用 |
 
 ### IxTableColumn
 

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -71,7 +71,7 @@ export default defineComponent({
     )
     const selectableContext = useSelectable(props, locale, columnsContext.flattedColumns, dataContext)
 
-    useScrollOnChange(props, config, scrollContext.scrollBodyRef, mergedPagination, activeSorters, activeFilters)
+    useScrollOnChange(props, config, mergedPagination, activeSorters, activeFilters, scrollContext.scrollTo)
 
     const context = {
       props,

--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -50,6 +50,7 @@ export default defineComponent({
       flattedData,
       isSticky,
       mergedSticky,
+      virtualScrollRef,
       scrollBodyRef,
       scrollContentRef,
       handleScroll,
@@ -184,7 +185,7 @@ export default defineComponent({
 
           children.push(
             <CdkVirtualScroll
-              ref={scrollBodyRef}
+              ref={virtualScrollRef}
               style={contentStyle.value}
               dataSource={flattedData.value}
               fullHeight={scroll?.fullHeight}

--- a/packages/components/transfer/src/list/List.tsx
+++ b/packages/components/transfer/src/list/List.tsx
@@ -29,7 +29,7 @@ export default defineComponent({
     })
 
     const transferListApi: TransferListApi = {
-      scrollTo: (...params) => virtualScrollRef.value?.scrollTo(...params),
+      scrollTo: option => virtualScrollRef.value?.scrollTo(option),
     }
 
     expose(transferListApi)

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -142,7 +142,7 @@ export default defineComponent({
       inputRef?.value?.blur()
     }
     const scrollTo = (option?: number | VirtualScrollToOptions) => {
-      virtualScrollRef?.value?.scrollTo(option)
+      virtualScrollRef.value?.scrollTo(option)
     }
 
     const getNode = (key: VKey) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

表格开启 virtual 和 列固定后, 重新加载数据 fixed 效果没了, 要重新拖动滚动条才能重新出现

原因是因为开启虚拟滚动后，scroll body 拿错了。

## What is the new behavior?



## Other information
