### PR TITLE
fix(comp:table): th with center align not work

### DIFF
--- a/packages/components/table/src/main/head/HeadCell.tsx
+++ b/packages/components/table/src/main/head/HeadCell.tsx
@@ -71,7 +71,7 @@ export default defineComponent({
         [`${prefixCls}-cell-${type}`]: !!type,
         [`${prefixCls}-cell-filterable`]: !!filterable,
         [`${prefixCls}-cell-sortable`]: !!sortable,
-        [`${prefixCls}-cell-align-center`]: hasChildren,
+        [`${prefixCls}-cell-align-center`]: hasChildren || align === 'center',
         [`${prefixCls}-cell-align-end`]: !hasChildren && align === 'end',
         [`${prefixCls}-cell-ellipsis`]: !!ellipsis,
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

设置列的 align: center 不生效

## What is the new behavior?


## Other information
