### PR TITLE
refactor: mark all deprecated api

### DIFF
--- a/packages/cdk/forms/src/controls.ts
+++ b/packages/cdk/forms/src/controls.ts
@@ -23,7 +23,7 @@ import {
 
 import { isArray, isNil, isPlainObject, isString } from 'lodash-es'
 
-import { hasOwnProperty } from '@idux/cdk/utils'
+import { Logger, hasOwnProperty } from '@idux/cdk/utils'
 
 import {
   type AsyncValidatorFn,
@@ -196,6 +196,12 @@ export abstract class AbstractControl<T = any> {
     this._forEachControls(control => control.setParent(this))
     this._convertOptions(validatorOrOptions, asyncValidator)
     this._init()
+
+    if (__DEV__) {
+      if (isOptions(validatorOrOptions) && validatorOrOptions.trim) {
+        Logger.warn('cdk/forms', 'the `trim` of validatorOptions was deprecated.')
+      }
+    }
   }
 
   /**
@@ -335,6 +341,9 @@ export abstract class AbstractControl<T = any> {
    * @deprecated please use `setValidators` instead.
    */
   setValidator(newValidator?: ValidatorFn | ValidatorFn[]): void {
+    if (__DEV__) {
+      Logger.warn('cdk/forms', 'the `setValidator` was deprecated, please use `setValidators` instead.')
+    }
     this.setValidators(newValidator)
   }
 
@@ -352,6 +361,9 @@ export abstract class AbstractControl<T = any> {
    * @deprecated please use `setAsyncValidators` instead.
    */
   setAsyncValidator(newAsyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]): void {
+    if (__DEV__) {
+      Logger.warn('cdk/forms', 'the `setAsyncValidator` was deprecated, please use `setAsyncValidators` instead.')
+    }
     this.setAsyncValidators(newAsyncValidator)
   }
 

--- a/packages/cdk/forms/src/utils.ts
+++ b/packages/cdk/forms/src/utils.ts
@@ -232,6 +232,12 @@ export interface ValueControlOptions {
 export function useValueControl<T = any>(
   options: ValueControlOptions = {},
 ): ShallowRef<AbstractControl<T> | undefined> {
+  if (__DEV__) {
+    Logger.warn(
+      'cdk/forms',
+      'the `useValueControl` was deprecated, please use `useControl` or `useAccessorAndControl` instead.',
+    )
+  }
   const { controlKey = 'control' } = options
   const { props } = getCurrentInstance()!
   const parentControl = inject(FORMS_CONTROL_TOKEN, shallowRef<AbstractControl>())
@@ -291,6 +297,12 @@ export interface ValueAccessor<T = any> {
  * @deprecated please use `useAccessor` or `useAccessorAndControl` instead
  */
 export function useValueAccessor<T = any>(options: ValueAccessorOptions): ValueAccessor<T> {
+  if (__DEV__) {
+    Logger.warn(
+      'cdk/forms',
+      'the `useValueAccessor` was deprecated, please use `useAccessor` or `useAccessorAndControl` instead.',
+    )
+  }
   const { control, valueKey = 'value', disabledKey = 'disabled' } = options
   const { props } = getCurrentInstance()!
 

--- a/packages/cdk/resize/demo/Component.vue
+++ b/packages/cdk/resize/demo/Component.vue
@@ -1,7 +1,7 @@
 <template>
   <IxSpace vertical>
-    <IxButton @click="disabled = !disabled">Change disabled</IxButton>
-    <CdkResizeObserver :disabled="disabled" @resize="onResize">
+    <IxSwitch v-model:checked="enabled" :labels="['Enable', 'Disable']"></IxSwitch>
+    <CdkResizeObserver :disabled="!enabled" @resize="onResize">
       <IxTextarea :value="text" />
     </CdkResizeObserver>
   </IxSpace>
@@ -10,7 +10,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-const disabled = ref(false)
+const enabled = ref(true)
 const text = ref('')
 
 const onResize = (entry: ResizeObserverEntry) => {

--- a/packages/cdk/resize/src/resize-observer/useResizeObserver.ts
+++ b/packages/cdk/resize/src/resize-observer/useResizeObserver.ts
@@ -7,7 +7,7 @@
 
 import { watch } from 'vue'
 
-import { type MaybeElementRef, convertElement, tryOnScopeDispose } from '@idux/cdk/utils'
+import { Logger, type MaybeElementRef, convertElement, tryOnScopeDispose } from '@idux/cdk/utils'
 
 import { type ResizeListener, offResize, onResize } from './utils'
 
@@ -35,7 +35,18 @@ export function useResizeObserver(
     stopWatch()
   }
 
+  stop.stop = () => {
+    if (__DEV__) {
+      Logger.warn(
+        'cdk/resize',
+        'the `const { stop } = useResizeObserver()` was deprecated, please use `const stop = useResizeObserver()` instead.',
+      )
+    }
+    offResize(convertElement(target), listener)
+    stopWatch()
+  }
+
   tryOnScopeDispose(stop)
 
-  return { stop }
+  return stop
 }

--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -7,7 +7,7 @@
 
 import { type ComponentPublicInstance, computed, defineComponent, provide, ref, watch } from 'vue'
 
-import { callEmit, useState } from '@idux/cdk/utils'
+import { Logger, callEmit, useState } from '@idux/cdk/utils'
 
 import { useContainerHeight } from './composables/useContainerHeight'
 import { useGetKey } from './composables/useGetKey'
@@ -75,6 +75,11 @@ export default defineComponent({
     const mergedData = computed(() => props.dataSource.slice(startIndex.value, endIndex.value + 1))
     watch(mergedData, data => callEmit(props.onScrolledChange, startIndex.value, endIndex.value, data))
 
+    if (__DEV__) {
+      if (props.itemKey) {
+        Logger.warn('cdk/scroll', 'the `itemKey` of VirtualScrollProps was deprecated, please use `getKey` instead.')
+      }
+    }
     return () => {
       const getKeyFn = getKey.value
       const start = startIndex.value

--- a/packages/components/cascader/src/Cascader.tsx
+++ b/packages/components/cascader/src/Cascader.tsx
@@ -8,7 +8,7 @@
 import { computed, defineComponent, normalizeClass, provide, ref, watch } from 'vue'
 
 import { useAccessorAndControl } from '@idux/cdk/forms'
-import { type VKey, useState } from '@idux/cdk/utils'
+import { Logger, type VKey, useState } from '@idux/cdk/utils'
 import { ɵOverlay } from '@idux/components/_private/overlay'
 import { ɵSelector, type ɵSelectorInstance } from '@idux/components/_private/selector'
 import { useGlobalConfig } from '@idux/components/config'
@@ -169,6 +169,15 @@ export default defineComponent({
     )
 
     const renderContent = () => <OverlayContent onClick={handleOverlayClick} />
+
+    if (__DEV__) {
+      if (props.dataSource?.some(data => !!data.additional)) {
+        Logger.warn(
+          'components/cascader',
+          'the `additional` of CascaderData was deprecated, please use `customAdditional` instead.',
+        )
+      }
+    }
 
     return () => {
       const overlayProps = {

--- a/packages/components/checkbox/src/CheckboxGroup.tsx
+++ b/packages/components/checkbox/src/CheckboxGroup.tsx
@@ -43,12 +43,15 @@ export default defineComponent({
       return gap != null ? `gap: ${convertCssPixel(gap)};` : undefined
     })
 
+    if (__DEV__) {
+      if (props.options) {
+        Logger.warn('components/checkbox', 'the `options` was deprecated, please use `dataSource` instead.')
+      }
+    }
+
     return () => {
       const { options, dataSource, vertical } = props
 
-      if (options) {
-        Logger.warn('components/checkbox', '`options` was deprecated, please use `dataSource` instead')
-      }
       const data = options ?? dataSource
 
       let children: VNodeChild[] | undefined

--- a/packages/components/config/src/types.ts
+++ b/packages/components/config/src/types.ts
@@ -565,7 +565,7 @@ export interface TreeConfig {
   getKey: string | ((data: TreeNode<any>) => any)
   labelKey: string
   /**
-   * @deprecated please use `labelKey` instead'
+   * @deprecated please use `getKey` instead'
    */
   nodeKey?: string
   showLine: boolean
@@ -578,7 +578,7 @@ export interface TreeSelectConfig {
   getKey: string | ((data: TreeNode<any>) => any)
   labelKey: string
   /**
-   * @deprecated please use `labelKey` instead'
+   * @deprecated please use `getKey` instead'
    */
   nodeKey?: string
   overlayContainer?: PortalTargetType

--- a/packages/components/divider/src/Divider.tsx
+++ b/packages/components/divider/src/Divider.tsx
@@ -33,11 +33,6 @@ export default defineComponent({
         vertical,
       } = props
 
-      __DEV__ &&
-        position &&
-        Logger.warn('components/divider', '`position` was deprecated, please use `labelPlacement` instead')
-      __DEV__ && type && Logger.warn('components/divider', '`type` was deprecated, please use `vertical` instead')
-
       const withLabel = !!label || !!slots.default
       const prefixCls = mergedPrefixCls.value
       return normalizeClass({
@@ -51,6 +46,12 @@ export default defineComponent({
         [`${prefixCls}-with-label-${position || labelPlacement}`]: withLabel,
       })
     })
+
+    if (__DEV__) {
+      props.position &&
+        Logger.warn('components/divider', 'the `position` was deprecated, please use `labelPlacement` instead.')
+      props.type && Logger.warn('components/divider', 'the `type` was deprecated, please use `vertical` instead.')
+    }
 
     return () => {
       const prefixCls = mergedPrefixCls.value

--- a/packages/components/drawer/src/Drawer.tsx
+++ b/packages/components/drawer/src/Drawer.tsx
@@ -22,7 +22,7 @@ import {
 
 import { CdkPortal } from '@idux/cdk/portal'
 import { BlockScrollStrategy, type ScrollStrategy } from '@idux/cdk/scroll'
-import { callEmit, useControlledProp } from '@idux/cdk/utils'
+import { Logger, callEmit, useControlledProp } from '@idux/cdk/utils'
 import { ɵMask } from '@idux/components/_private/mask'
 import { useGlobalConfig } from '@idux/components/config'
 import { usePortalTarget, useZIndex } from '@idux/components/utils'
@@ -70,6 +70,15 @@ export default defineComponent({
     expose(apis)
 
     useScrollStrategy(props, mask, mergedVisible)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/drawer', 'the `target` was deprecated, please use `container` instead.')
+      }
+      if (props.wrapperClassName) {
+        Logger.warn('components/drawer', 'the `wrapperClassName` was deprecated.')
+      }
+    }
 
     return () => {
       if (!mergedVisible.value && props.destroyOnHide) {

--- a/packages/components/dropdown/src/Dropdown.tsx
+++ b/packages/components/dropdown/src/Dropdown.tsx
@@ -7,7 +7,7 @@
 
 import { computed, defineComponent, provide, toRef } from 'vue'
 
-import { useControlledProp } from '@idux/cdk/utils'
+import { Logger, useControlledProp } from '@idux/cdk/utils'
 import { ɵOverlay } from '@idux/components/_private/overlay'
 import { type DropdownConfig, useGlobalConfig } from '@idux/components/config'
 import { useOverlayContainer } from '@idux/components/utils'
@@ -31,6 +31,11 @@ export default defineComponent({
 
     provide(dropdownToken, { hideOnClick: toRef(props, 'hideOnClick'), setVisibility })
 
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/dropdown', 'the `target`  was deprecated, please use `overlayContainer` instead.')
+      }
+    }
     return () => {
       return (
         <ɵOverlay

--- a/packages/components/form/src/Form.tsx
+++ b/packages/components/form/src/Form.tsx
@@ -8,6 +8,7 @@
 import { computed, defineComponent, normalizeClass, provide } from 'vue'
 
 import { FORMS_CONTROL_TOKEN, useControl } from '@idux/cdk/forms'
+import { Logger } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 
 import { FORM_TOKEN, formToken } from './token'
@@ -29,6 +30,15 @@ export default defineComponent({
     provide(formToken, { props, config })
 
     provide(FORM_TOKEN, { size })
+
+    if (__DEV__) {
+      if (props.hasFeedback) {
+        Logger.warn('components/form', 'the `hasFeedback` was deprecated.')
+      }
+      if (props.statusIcon) {
+        Logger.warn('components/form', 'the `statusIcon` was deprecated.')
+      }
+    }
 
     const classes = computed(() => {
       const prefixCls = mergedPrefixCls.value

--- a/packages/components/form/src/FormItem.tsx
+++ b/packages/components/form/src/FormItem.tsx
@@ -71,6 +71,18 @@ export default defineComponent({
       })
     })
 
+    if (__DEV__) {
+      if (props.extra || slots.extra) {
+        Logger.warn('components/form', 'the `extra` was deprecated, please use `description` instead.')
+      }
+      if (props.extraMessage || slots.extraMessage) {
+        Logger.warn('components/form', 'the `extraMessage` was deprecated, please use `description` instead.')
+      }
+      if (props.statusIcon || slots.statusIcon) {
+        Logger.warn('components/form', 'the `statusIcon` was deprecated.')
+      }
+    }
+
     return () => {
       const prefixCls = mergedPrefixCls.value
       return (
@@ -141,12 +153,6 @@ function renderControl(
     description: descriptionSlot,
     message: messageSlot,
   } = slots
-  if (__DEV__ && (extra || extraSlot)) {
-    Logger.warn('components/form', '`extra` was deprecated, please use `description` instead.')
-  }
-  if (__DEV__ && (extraMessage || extraMessageSlot)) {
-    Logger.warn('components/form', '`extraMessage` was deprecated, please use `description` instead.')
-  }
 
   const tooltipNode = renderTooltip(controlTooltipSlot, controlTooltip, controlTooltipIcon.value)
   const inputNode = (

--- a/packages/components/form/src/composables/public.ts
+++ b/packages/components/form/src/composables/public.ts
@@ -25,6 +25,7 @@ import {
   useValueAccessor,
   useValueControl,
 } from '@idux/cdk/forms'
+import { Logger } from '@idux/cdk/utils'
 import { useKey } from '@idux/components/utils'
 
 import { FORM_ITEM_TOKEN, FORM_TOKEN } from '../token'
@@ -45,6 +46,12 @@ export function useFormItemRegister(control: ShallowRef<AbstractControl | undefi
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useFormAccessor<T = any>(valueKey?: string): ValueAccessor<T> {
+  if (__DEV__) {
+    Logger.warn(
+      'components/form',
+      'the `useFormAccessor` was deprecated, please use `useAccessorAndControl` + `useFormItemRegister` instead.',
+    )
+  }
   const control = useValueControl()
   const accessor = useValueAccessor({ control, valueKey })
 

--- a/packages/components/image/src/ImageViewer.tsx
+++ b/packages/components/image/src/ImageViewer.tsx
@@ -9,7 +9,7 @@ import { Ref, Transition, computed, defineComponent, onBeforeUnmount, onMounted,
 
 import { isFirefox } from '@idux/cdk/platform'
 import { CdkPortal } from '@idux/cdk/portal'
-import { useControlledProp } from '@idux/cdk/utils'
+import { Logger, useControlledProp } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 import { usePortalTarget, useZIndex } from '@idux/components/utils'
 
@@ -70,6 +70,12 @@ export default defineComponent({
     })
 
     const style = computed(() => `z-index: ${currentZIndex.value}`)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/image', 'the `target` was deprecated, please use `container` instead.')
+      }
+    }
 
     return () => {
       const prefixCls = mergedPrefixCls.value

--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -7,7 +7,7 @@
 
 import { computed, defineComponent, inject, normalizeClass, provide } from 'vue'
 
-import { type VKey, callEmit } from '@idux/cdk/utils'
+import { Logger, type VKey, callEmit } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 import { ɵDropdownToken } from '@idux/components/dropdown'
 import { useGetKey } from '@idux/components/utils'
@@ -66,6 +66,24 @@ export default defineComponent({
       })
     })
     const dateSource = useDataSource(props, slots)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/menu', 'the `target` was deprecated, please use `overlayContainer` instead.')
+      }
+      if (props.dataSource?.some(data => !!data.additional)) {
+        Logger.warn(
+          'components/menu',
+          'the `additional` of MenuData was deprecated, please use `customAdditional` instead.',
+        )
+      }
+      if (props.dataSource?.some(data => !!data.slots)) {
+        Logger.warn(
+          'components/menu',
+          'the `slots` of MenuData was deprecated, please use `customIcon` and `customLabel` instead.',
+        )
+      }
+    }
 
     return () => {
       return <ul class={classes.value}>{coverChildren(dateSource.value, mergedGetKey.value)}</ul>

--- a/packages/components/menu/src/contents/MenuDivider.tsx
+++ b/packages/components/menu/src/contents/MenuDivider.tsx
@@ -20,6 +20,7 @@ const MenuDivider: FunctionalComponent<
   const customAdditional = menuProps.customAdditional
     ? menuProps.customAdditional({ data: props.data, index: props.index })
     : undefined
+
   return <li class={`${mergedPrefixCls.value}-divider`} {...props.data.additional} {...customAdditional}></li>
 }
 MenuDivider.displayName = 'MenuDivider'

--- a/packages/components/menu/src/contents/MenuItem.tsx
+++ b/packages/components/menu/src/contents/MenuItem.tsx
@@ -9,7 +9,6 @@ import { computed, defineComponent, inject, normalizeClass } from 'vue'
 
 import { isString } from 'lodash-es'
 
-import { Logger } from '@idux/cdk/utils'
 import { useKey } from '@idux/components/utils'
 
 import { usePaddingLeft } from '../composables/usePaddingLeft'
@@ -62,12 +61,7 @@ export default defineComponent({
 
     return () => {
       const { additional, disabled, icon, label, slots = {}, customIcon, customLabel } = props.data
-      if (__DEV__ && (slots.icon || slots.label)) {
-        Logger.warn(
-          'components/menu',
-          '`slots` of `MenuItem` was deprecated, please use `customIcon` and `customLabel` instead',
-        )
-      }
+
       const iconRender = customIcon ?? slots.icon ?? 'itemIcon'
       const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
       const labelRender = customLabel ?? slots.label ?? 'itemLabel'

--- a/packages/components/menu/src/contents/MenuItemGroup.tsx
+++ b/packages/components/menu/src/contents/MenuItemGroup.tsx
@@ -9,7 +9,6 @@ import { computed, defineComponent, inject, provide } from 'vue'
 
 import { isString } from 'lodash-es'
 
-import { Logger } from '@idux/cdk/utils'
 import { useKey } from '@idux/components/utils'
 
 import { usePaddingLeft } from '../composables/usePaddingLeft'
@@ -48,12 +47,7 @@ export default defineComponent({
 
     return () => {
       const { additional, icon, label, children, slots = {}, customIcon, customLabel } = props.data
-      if (__DEV__ && (slots.icon || slots.label)) {
-        Logger.warn(
-          'components/menu',
-          '`slots` of `MenuItemGroup` was deprecated, please use `customIcon` and `customLabel` instead',
-        )
-      }
+
       const iconRender = customIcon ?? slots.icon ?? 'itemGroupIcon'
       const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
       const labelRender = customLabel ?? slots.label ?? 'itemGroupLabel'

--- a/packages/components/menu/src/contents/menu-sub/Label.tsx
+++ b/packages/components/menu/src/contents/menu-sub/Label.tsx
@@ -9,8 +9,6 @@ import { computed, defineComponent, inject } from 'vue'
 
 import { isString } from 'lodash-es'
 
-import { Logger } from '@idux/cdk/utils'
-
 import { menuSubToken, menuToken } from '../../token'
 import { coverIcon } from '../Utils'
 
@@ -55,12 +53,6 @@ export default defineComponent({
 
     return () => {
       const { icon, label, slots = {}, customIcon, customLabel, customSuffix } = props.data
-      if (__DEV__ && (slots.icon || slots.label || slots.suffix)) {
-        Logger.warn(
-          'components/menu',
-          '`slots` of `MenuSub` was deprecated, please use `customIcon`, `customLabel` and `customSuffix` instead',
-        )
-      }
       const iconRender = customIcon ?? slots.icon ?? 'subIcon'
       const iconSlot = isString(iconRender) ? menuSlots[iconRender] : iconRender
       const labelRender = customLabel ?? slots.label ?? 'subLabel'

--- a/packages/components/message/src/MessageProvider.tsx
+++ b/packages/components/message/src/MessageProvider.tsx
@@ -5,20 +5,16 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { MessageOptions, MessageRef } from './types'
-import type { VKey } from '@idux/cdk/utils'
-import type { ComputedRef, VNode } from 'vue'
-
-import { TransitionGroup, computed, defineComponent, provide, ref } from 'vue'
+import { type ComputedRef, TransitionGroup, type VNode, computed, defineComponent, provide, ref } from 'vue'
 
 import { CdkPortal } from '@idux/cdk/portal'
-import { callEmit, convertArray, convertCssPixel, uniqueId } from '@idux/cdk/utils'
+import { Logger, VKey, callEmit, convertArray, convertCssPixel, uniqueId } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 import { usePortalTarget } from '@idux/components/utils'
 
 import Message from './Message'
 import { messageProviderToken } from './token'
-import { messageProviderProps } from './types'
+import { type MessageOptions, type MessageRef, messageProviderProps } from './types'
 
 export default defineComponent({
   name: 'IxMessageProvider',
@@ -39,6 +35,12 @@ export default defineComponent({
 
     provide(messageProviderToken, apis)
     expose(apis)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/message', 'the `target` was deprecated, please use `container` instead.')
+      }
+    }
 
     return () => {
       const child = messages.value.map(item => {

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -20,7 +20,7 @@ import {
 
 import { CdkPortal } from '@idux/cdk/portal'
 import { BlockScrollStrategy, type ScrollStrategy } from '@idux/cdk/scroll'
-import { callEmit, isPromise, useControlledProp } from '@idux/cdk/utils'
+import { Logger, callEmit, isPromise, useControlledProp } from '@idux/cdk/utils'
 import { ɵMask } from '@idux/components/_private/mask'
 import { useGlobalConfig } from '@idux/components/config'
 import { usePortalTarget, useZIndex } from '@idux/components/utils'
@@ -66,6 +66,15 @@ export default defineComponent({
     expose(apis)
 
     useScrollStrategy(props, mask, mergedVisible)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/modal', 'the `target` was deprecated, please use `container` instead.')
+      }
+      if (props.wrapperClassName) {
+        Logger.warn('components/modal', 'the `wrapperClassName` was deprecated.')
+      }
+    }
 
     return () => {
       if (!mergedVisible.value && props.destroyOnHide) {

--- a/packages/components/notification/src/NotificationProvider.tsx
+++ b/packages/components/notification/src/NotificationProvider.tsx
@@ -12,7 +12,6 @@ import type {
   NotificationProviderProps,
   NotificationRef,
 } from './types'
-import type { VKey } from '@idux/cdk/utils'
 import type { CommonConfig, NotificationConfig } from '@idux/components/config'
 
 import { ComputedRef, Ref, TransitionGroup, cloneVNode, computed, defineComponent, isVNode, provide, ref } from 'vue'
@@ -20,7 +19,7 @@ import { ComputedRef, Ref, TransitionGroup, cloneVNode, computed, defineComponen
 import { isArray, isUndefined, pickBy } from 'lodash-es'
 
 import { CdkPortal } from '@idux/cdk/portal'
-import { callEmit, convertArray, convertCssPixel, uniqueId } from '@idux/cdk/utils'
+import { Logger, VKey, callEmit, convertArray, convertCssPixel, uniqueId } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 import { usePortalTarget } from '@idux/components/utils'
 
@@ -53,6 +52,12 @@ export default defineComponent({
 
     provide(notificationProviderToken, apis)
     expose(apis)
+
+    if (__DEV__) {
+      if (props.target) {
+        Logger.warn('components/notification', 'the `target` was deprecated, please use `container` instead.')
+      }
+    }
 
     return () => {
       const getChild = (notifications: NotificationOptions[]) => {

--- a/packages/components/radio/src/RadioGroup.tsx
+++ b/packages/components/radio/src/RadioGroup.tsx
@@ -45,11 +45,14 @@ export default defineComponent({
       return gap != null ? `gap: ${convertCssPixel(gap)};` : undefined
     })
 
+    if (__DEV__) {
+      if (props.options) {
+        Logger.warn('components/radio', 'the `options` was deprecated, please use `dataSource` instead.')
+      }
+    }
+
     return () => {
       const { options, dataSource, vertical } = props
-      if (options) {
-        Logger.warn('components/radio', '`options` was deprecated, please use `dataSource` instead')
-      }
       const data = options ?? dataSource
       let children: VNodeChild[] | undefined
       if (data) {

--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -11,7 +11,7 @@ import { type ComputedRef, Slots, computed, defineComponent, normalizeClass, pro
 
 import { useAccessorAndControl } from '@idux/cdk/forms'
 import { type VirtualScrollToFn } from '@idux/cdk/scroll'
-import { type VKey, callEmit, useState } from '@idux/cdk/utils'
+import { Logger, type VKey, callEmit, useState } from '@idux/cdk/utils'
 import { ɵInput } from '@idux/components/_private/input'
 import { ɵOverlay } from '@idux/components/_private/overlay'
 import { ɵSelector, type ɵSelectorInstance } from '@idux/components/_private/selector'
@@ -191,6 +191,31 @@ export default defineComponent({
       }
 
       return <div>{overlayRender ? overlayRender(children) : children}</div>
+    }
+
+    if (__DEV__) {
+      if (props.options) {
+        Logger.warn('components/select', 'the `options` was deprecated, please use `dataSource` instead.')
+      }
+      if (props.searchFilter) {
+        Logger.warn('components/select', 'the `searchFilter` was deprecated, please use `searchFn` instead.')
+      }
+      if (props.maxLabelCount) {
+        Logger.warn('components/select', 'the `maxLabelCount` was deprecated, please use `maxLabel` instead.')
+      }
+      if (props.target) {
+        Logger.warn('components/select', 'the `target` was deprecated, please use `overlayContainer` instead.')
+      }
+      if (props.valueKey) {
+        Logger.warn('components/select', 'the `valueKey` was deprecated, please use `getKey` instead.')
+      }
+
+      if (props.dataSource?.some(data => !!data.additional)) {
+        Logger.warn(
+          'components/select',
+          'the `additional` of SelectData was deprecated, please use `customAdditional` instead.',
+        )
+      }
     }
 
     return () => {

--- a/packages/components/select/src/composables/useOptions.ts
+++ b/packages/components/select/src/composables/useOptions.ts
@@ -14,7 +14,7 @@ import { computed } from 'vue'
 
 import { isFunction, isNil } from 'lodash-es'
 
-import { Logger, type VKey, flattenNode } from '@idux/cdk/utils'
+import { type VKey, flattenNode } from '@idux/cdk/utils'
 
 import { optionGroupKey, optionKey } from '../option'
 import { generateOption } from '../utils/generateOption'
@@ -32,9 +32,6 @@ export function useConvertedOptions(props: SelectProps, slots: Slots): ComputedR
   return computed(() => {
     const dataSource = props.options ?? props.dataSource
     if (dataSource) {
-      if (__DEV__ && props.options) {
-        Logger.warn('components/select', '`options` was deprecated, please use `dataSource` instead')
-      }
       return dataSource
     }
 
@@ -175,9 +172,6 @@ function useSearchFn(props: SelectProps, mergedLabelKey: ComputedRef<string>) {
   return computed(() => {
     const searchFn = props.searchFilter ?? props.searchFn
     if (isFunction(searchFn)) {
-      if (__DEV__ && props.searchFilter) {
-        Logger.warn('components/select', '`searchFilter` was deprecated, please use `searchFn` instead')
-      }
       return searchFn
     }
     return searchFn ? getDefaultSearchFn(mergedLabelKey.value) : false

--- a/packages/components/select/src/panel/OptionGroup.tsx
+++ b/packages/components/select/src/panel/OptionGroup.tsx
@@ -16,6 +16,7 @@ export default defineComponent({
   props: optionGroupProps,
   setup(props) {
     const { props: selectProps, slots, mergedPrefixCls } = inject(selectPanelContext)!
+
     return () => {
       const { label, rawData } = props
       const _label = toString(label)

--- a/packages/components/space/src/Space.tsx
+++ b/packages/components/space/src/Space.tsx
@@ -35,7 +35,6 @@ export default defineComponent({
     const vertical = computed(() => {
       const { direction, vertical } = props
       if (direction) {
-        __DEV__ && Logger.warn('components/space', '`direction` was deprecated, please use `vertical` instead')
         return direction === 'vertical'
       }
       return vertical
@@ -68,6 +67,15 @@ export default defineComponent({
       }
     })
 
+    if (__DEV__) {
+      if (props.direction) {
+        Logger.warn('components/space', 'the `direction` was deprecated, please use `vertical` instead.')
+      }
+      if (props.split || slots.split) {
+        Logger.warn('components/space', 'the `split` was deprecated, please use `separator` instead.')
+      }
+    }
+
     return () => {
       const nodes = flattenNode(slots.default?.())
       if (nodes.length === 0) {
@@ -78,9 +86,7 @@ export default defineComponent({
       const children: VNode[] = []
 
       let separatorNode = convertStringVNode(slots, props, 'split')
-      if (separatorNode) {
-        __DEV__ && Logger.warn('components/space', '`split` was deprecated, please use `separator` instead')
-      } else {
+      if (!separatorNode) {
         separatorNode = convertStringVNode(slots, props, 'separator')
       }
 

--- a/packages/components/space/src/types.ts
+++ b/packages/components/space/src/types.ts
@@ -25,6 +25,9 @@ export const spaceProps = {
   direction: String as PropType<SpaceDirection>,
   justify: String as PropType<SpaceJustify>,
   size: [Number, String, Array] as PropType<number | string | (string | number)[]>,
+  /**
+   * @deprecated please use `separator` instead'
+   */
   split: String,
   separator: String,
   vertical: {

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -11,6 +11,7 @@ import { computed, defineComponent, normalizeClass, provide } from 'vue'
 
 import { isBoolean } from 'lodash-es'
 
+import { Logger } from '@idux/cdk/utils'
 import { ɵHeader } from '@idux/components/_private/header'
 import { useGlobalConfig } from '@idux/components/config'
 import { IxSpin } from '@idux/components/spin'
@@ -111,6 +112,36 @@ export default defineComponent({
         [`${prefixCls}-${mergedSize.value}`]: true,
       })
     })
+
+    if (__DEV__) {
+      if (props.rowClassName) {
+        Logger.warn('components/table', 'the `rowClassName` was deprecated, please use `customAdditional` instead.')
+      }
+      if (props.rowKey) {
+        Logger.warn('components/table', 'the `rowKey` was deprecated, please use `getKey` instead.')
+      }
+      if (props.scroll?.x) {
+        Logger.warn('components/table', 'the `scroll.x` was deprecated, please use `scroll.width` instead.')
+      }
+      if (props.scroll?.y) {
+        Logger.warn('components/table', 'the `scroll.y` was deprecated, please use `scroll.height` instead.')
+      }
+      if (props.columns.some(col => !!col.additional)) {
+        Logger.warn(
+          'components/table',
+          'the `additional` of TableColumn was deprecated, please use `customAdditional` instead.',
+        )
+      }
+      if (props.columns.some(col => !!col.customRender)) {
+        Logger.warn(
+          'components/table',
+          'the `customRender` of TableColumn was deprecated, please use `customCell` instead.',
+        )
+      }
+      if (props.columns.some(col => !!col.responsive)) {
+        Logger.warn('components/table', 'the `responsive` of TableColumn was deprecated.')
+      }
+    }
 
     return () => {
       const prefixCls = mergedPrefixCls.value

--- a/packages/components/table/src/composables/useScroll.ts
+++ b/packages/components/table/src/composables/useScroll.ts
@@ -39,14 +39,6 @@ export function useScroll(
     setStickyScrollLeft,
   )
 
-  __DEV__ &&
-    props.scroll?.x &&
-    Logger.warn('components/table', '`scroll.x` was deprecated, please use `scroll.width` instead')
-
-  __DEV__ &&
-    props.scroll?.y &&
-    Logger.warn('components/table', '`scroll.y` was deprecated, please use `scroll.height` instead')
-
   const scrollWithAutoHeight = useScrollWithAutoHeight(props, mergedAutoHeight, scrollBodyRef, scrollContentRef)
   const scrollWidth = computed(() => convertCssPixel(props.scroll?.width || props.scroll?.x))
   const scrollHeight = computed(() => {

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -9,7 +9,7 @@ import { type ComputedRef, type Slots, type VNodeChild, computed, defineComponen
 
 import { isFunction, isNil, isString } from 'lodash-es'
 
-import { Logger, convertArray, convertCssPixel } from '@idux/cdk/utils'
+import { convertArray, convertCssPixel } from '@idux/cdk/utils'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { IxIcon } from '@idux/components/icon'
 import { IxRadio } from '@idux/components/radio'
@@ -160,9 +160,6 @@ function useDataValue(props: TableBodyCellProps) {
 function renderChildren(props: TableBodyCellProps, slots: Slots, value: string) {
   const { record, rowIndex, column } = props
   const { customRender, customCell } = column
-  if (__DEV__ && customRender) {
-    Logger.warn('components/table', '`customRender` was deprecated, please use `customCell` instead')
-  }
 
   const cellRender = customRender ?? customCell
   if (isFunction(cellRender)) {

--- a/packages/components/tree-select/src/TreeSelect.tsx
+++ b/packages/components/tree-select/src/TreeSelect.tsx
@@ -181,9 +181,24 @@ export default defineComponent({
     if (__DEV__) {
       props.cascade &&
         Logger.warn(
-          'components/tree',
-          '`cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.',
+          'components/tree-select',
+          'the `cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.',
         )
+      if (props.maxLabelCount) {
+        Logger.warn('components/tree-select', 'the `maxLabelCount` are deprecated, please use `maxLabel` instead.')
+      }
+      if (props.nodeKey) {
+        Logger.warn('components/tree-select', 'the `nodeKey` are deprecated, please use `getKey` instead.')
+      }
+      if (props.target) {
+        Logger.warn('components/tree-select', 'the `target` are deprecated, please use `overlayContainer` instead.')
+      }
+      if (props.dataSource?.some(data => data.additional)) {
+        Logger.warn(
+          'components/tree-select',
+          'the `additional` of TreeNode was deprecated, please use `customAdditional` instead.',
+        )
+      }
     }
 
     return () => {

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -171,8 +171,17 @@ export default defineComponent({
       props.cascade &&
         Logger.warn(
           'components/tree',
-          '`cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.',
+          'the `cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.',
         )
+      if (props.nodeKey) {
+        Logger.warn('components/tree', 'the `nodeKey` are deprecated, please use `getKey` instead.')
+      }
+      if (props.dataSource?.some(data => data.additional)) {
+        Logger.warn(
+          'components/tree',
+          'the `additional` of TreeNode was deprecated, please use `customAdditional` instead.',
+        )
+      }
     }
 
     return () => {

--- a/packages/components/typography/src/typography.ts
+++ b/packages/components/typography/src/typography.ts
@@ -12,7 +12,13 @@ import { isObject } from 'lodash-es'
 
 import { Logger, addClass, removeClass } from '@idux/cdk/utils'
 
+/**
+ * @deprecated
+ */
 const typography: FunctionDirective<HTMLElement, TypographyProps> = (el, binding) => {
+  if (__DEV__) {
+    Logger.warn('components/typography', 'the `typography` was deprecated.')
+  }
   const className: string[] = ['ix-typography']
   const { value, oldValue } = binding
 

--- a/scripts/gulp/site/utils.ts
+++ b/scripts/gulp/site/utils.ts
@@ -35,7 +35,16 @@ export function initSite(): void {
   })
 
   const filterPackageName = ['site']
-  const filterComponentName = ['_private', 'config', 'locales', 'node_modules', 'style', 'utils', 'version']
+  const filterComponentName = [
+    '_private',
+    'config',
+    'locales',
+    'node_modules',
+    'style',
+    `typography`,
+    'utils',
+    'version',
+  ]
   readdirSync(packageRoot).forEach(packageName => {
     if (filterPackageName.includes(packageName)) {
       return


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
标记出所有被废弃的 API， 统计如下：

# V1.0.0 breaking changes

## CDK

- click-outside
  - the  `clickOutside` was deprecated, please use `vClickOutside` instead'
- forms
  - the `trim` of `ValidatorOptions` was deprecated.
  - the `setValidator` was deprecated, please use `setValidators` instead.
  - the `setAsyncValidator` was deprecated, please use `setAsyncValidators` instead.
  - the `useValueControl` was deprecated, please use `useControl` or `useAccessorAndControl` instead.
  - the `useValueAccessor` was deprecated, please use `useAccessor` or `useAccessorAndControl` instead.
- resize
  - the `const { stop } = useResizeObserver()` was deprecated, please use `const stop = useResizeObserver()` instead.
- scroll
  - the `itemKey` of `VirtualScrollProps` was deprecated, please use `getKey` instead.

## Components

- cascader
  - the `additional` of `CascaderData` was deprecated, please use `customAdditional` instead.
- checkbox
  - the `options` was deprecated, please use `dataSource` instead.
- config
  - the `target` of `DrawerConfig` was deprecated, please use `container` instead.
  - the `target` of `DropdownConfig` was deprecated, please use `overlayContainer` instead.
  - the `target` of `ImageViewerConfig` was deprecated, please use `container` instead.
  - the `target` of `MenuConfig` was deprecated, please use `overlayContainer` instead.
  - the `target` of `MessageConfig` was deprecated, please use `container` instead.
  - the `target` of `ModalConfig` was deprecated, please use `container` instead.
  - the `target` of `NotificationConfig` was deprecated, please use `container` instead.
  - the `target` of `PopconfirmConfig` was deprecated, please use `overlayContainer` instead.
  - the `target` of `PopoverConfig` was deprecated, please use `overlayContainer` instead.
  - the `target` of `SelectConfig` was deprecated, please use `overlayContainer` instead.
  - the `valueKey` of `SelectConfig` was deprecated, please use `getKey` instead.
  - the `rowKey` of `TableConfig` was deprecated, please use `getKey` instead.
  - the `target` of `TooltipConfig` was deprecated, please use `overlayContainer` instead.
  - the `nodeKey` of `TreeConfig` was deprecated, please use `getKey` instead.
  - the `nodeKey` of `TreeSelectConfig` was deprecated, please use `getKey` instead.
  - the `target` of `TreeSelectConfig` was deprecated, please use `overlayContainer` instead.
- divider
  - the `position` was deprecated, please use `labelPlacement` instead.
  - the `type` was deprecated, please use `vertical` instead.
- drawer
  - the `target` was deprecated, please use `container` instead.
  - the `wrapperClassName` was deprecated.
- dropdown
  - the `target` was deprecated, please use `overlayContainer` instead.
- form
  - the `hasFeedback` was deprecated.
  - the `statusIcon` was deprecated.
  - the `extra` was deprecated, please use `description` instead.
  - the `extraMessage` was deprecated, please use `description` instead.
  - the `useFormAccessor` was deprecated, please use `useAccessorAndControl` + `useFormItemRegister` instead.
- image
  - the `target` was deprecated, please use `container` instead.
- menu
  - the `target` was deprecated, please use `overlayContainer` instead.
  - the `additional` of `MenuIData` was deprecated, please use `customAdditional` instead'.
  - the `slots` of `MenuData` was deprecated, please use `customIcon` and `customLabel` instead'.
- message
  - the `target` was deprecated, please use `container` instead.
- modal
  - the `target` was deprecated, please use `container` instead.
  - the `wrapperClassName` was deprecated.
- notification
  - the `target` was deprecated, please use `container` instead.
- radio
  - the `options` was deprecated, please use `dataSource` instead.
- select
  - the `maxLabelCount` was deprecated, please use `maxLabel` instead.
  - the `options` was deprecated, please use `dataSource` instead.
  - the `searchFilter`  was deprecated, please use `searchFn` instead'.
  - the `target` was deprecated, please use `overlayContainer` instead.
  - the `valueKey` was deprecated, please use `getKey` instead.
  - the `additional` of `SelectData` was deprecated, please use `customAdditional` instead.
- space
  - the `direction` was deprecated, please use `vertical` instead.
  - the `split` was deprecated, please use `separator` instead.
- table
  - the `rowClassName` was deprecated, please use `customAdditional` instead.
  - the `rowKey` was deprecated, please use `getKey` instead.
  - the `scrll.x` was deprecated, please use `scrll.width` instead.
  - the `scrll.y` was deprecated, please use `scrll.height` instead.
  - the `additional` of `TableColumn` was deprecated, please use `customAdditional` instead'.
  - the `customRender` of `TableColumn` was deprecated, please use `customCell` of TableColumn instead'.
  - the `responsive` of `TableColumn` was deprecated.
- tooltip, popover, popconfirm
  - the `target` was deprecated, please use `overlayContainer` instead.
- tree
  - the `cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.
  - the `nodeKey` are deprecated, please use `getKey` instead.
  - the `additional` of `TreeNode` was deprecated, please use `customAdditional` instead'.
- tree-select
  - the `cascade` and `checkStrategy` are deprecated, please use `cascaderStrategy` instead.
  - the `maxLabelCount` are deprecated, please use `maxLabel` instead.
  - the `nodeKey` are deprecated, please use `getKey` instead.
  - the `target` are deprecated, please use `overlayContainer` instead.
  - the `additional` of `TreeNode` was deprecated, please use `customAdditional` instead.
- typography
  - the directive  was deprecated.

## What is the new behavior?


## Other information
