### PR TITLE
fix(comp:modal): prevent ok & cancel from triggering while animating

### DIFF
--- a/packages/components/modal/src/ModalWrapper.tsx
+++ b/packages/components/modal/src/ModalWrapper.tsx
@@ -112,6 +112,17 @@ export default defineComponent({
     )
     const draggableResult = ref()
 
+    const handleOk = (evt?: unknown) => {
+      if (visible.value) {
+        ok(evt)
+      }
+    }
+    const handleCancel = (evt?: unknown) => {
+      if (visible.value) {
+        cancel(evt)
+      }
+    }
+
     onMounted(() => watchVisibleChange(props, wrapperRef, sentinelStartRef, mask, draggableResult))
 
     watch(
@@ -172,13 +183,13 @@ export default defineComponent({
                 <ɵFooter
                   v-slots={slots}
                   class={`${prefixCls}-footer`}
-                  cancel={cancel}
+                  cancel={handleCancel}
                   cancelButton={props.cancelButton}
                   cancelLoading={cancelLoading.value}
                   cancelText={cancelText.value}
                   cancelVisible={cancelVisible.value}
                   footer={props.footer}
-                  ok={ok}
+                  ok={handleOk}
                   okButton={props.okButton}
                   okLoading={okLoading.value}
                   okText={okText.value}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在关闭过渡动画期间点击确定或者取消，会重复触发确定和取消事件


## What is the new behavior?
修复以上问题

## Other information
只有在visible为true时按钮点击触发对应回调