### PR TITLE
fix(cdk:popper): vue warning when watch on non-reactive options

### DIFF
--- a/packages/cdk/popper/src/composables/useOptions.ts
+++ b/packages/cdk/popper/src/composables/useOptions.ts
@@ -7,7 +7,7 @@
 
 import type { PopperOptions } from '../types'
 
-import { type ComputedRef, computed, reactive, watch } from 'vue'
+import { type ComputedRef, computed, isReactive, reactive, watch } from 'vue'
 
 import { isEqual } from 'lodash-es'
 
@@ -39,9 +39,11 @@ export function usePopperOptions(options: PopperOptions): {
     })
   }
 
-  watch(options, _options => {
-    updateOptions(_options)
-  })
+  if (isReactive(options)) {
+    watch(options, _options => {
+      updateOptions(_options)
+    })
+  }
 
   return {
     popperOptions,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
对非响应式的对象进行了监听


## What is the new behavior?
判断只监听响应式对象

## Other information
