### PR TITLE
fix(comp:select): selector suffix should stay on top

### DIFF
--- a/packages/components/_private/selector/style/index.less
+++ b/packages/components/_private/selector/style/index.less
@@ -57,13 +57,22 @@
     .ellipsis();
   }
 
-  &-suffix {
-    .selector-icon();
+  &-sm &-suffix,
+  &-sm &-clear {
+    .selector-icon(@select-height-sm);
+  }
+
+  &-md &-suffix,
+  &-md &-clear {
+    .selector-icon(@select-height-md);
+  }
+
+  &-lg &-suffix,
+  &-lg &-clear {
+    .selector-icon(@select-height-lg);
   }
 
   &-clear {
-    .selector-icon();
-
     z-index: 1;
     opacity: 0;
     background-color: @select-icon-background-color;
@@ -124,11 +133,14 @@
   }
 }
 
-.selector-icon() {
+.selector-icon(@selector-height) {
   position: absolute;
-  top: 50%;
-  margin-top: -(@select-icon-font-size / 2);
+  top: 0;
   right: @select-icon-margin-right;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  height: @selector-height - 2 * @select-border-width;
   line-height: 1;
   font-size: @select-icon-font-size;
   color: @select-icon-color;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
selector的suffix始终居中展示


## What is the new behavior?
selector的suffix应当固定在顶部，撑开后不改变位置

## Other information
视觉检视