### PR TITLE
fix(comp:input): input suffix is `icon size` only when it's icon

### DIFF
--- a/packages/components/input/style/index.less
+++ b/packages/components/input/style/index.less
@@ -216,7 +216,10 @@
     display: inline-flex;
     align-items: center;
     color: @input-icon-color;
-    font-size: @input-icon-font-size;
+
+    .@{icon-prefix} {
+      font-size: @input-icon-font-size;
+    }
   }
 
   &-prefix {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
icon-size修改为16px后，当suffix仅是文字时，字体大小也是16px，看起来很突兀


## What is the new behavior?
修改，仅当suffix是icon时，font-size 为 icon-size

## Other information
