### PR TITLE
fix(comp:textarea,pro:textarea): scrollHeight miscalculated on firefox

### DIFF
--- a/packages/components/textarea/src/composables/useAutoRows.ts
+++ b/packages/components/textarea/src/composables/useAutoRows.ts
@@ -64,6 +64,9 @@ export function useAutoRows(
   function getTextareaScrollHeight() {
     return measureTextarea(textareaRef.value!, textarea => {
       textarea.value = textareaRef.value!.value
+
+      // trigger reflow to ensure scrollHeight is calculated when referenced
+      void textarea.scrollHeight
       return getHeightByScrollHeight(textarea.scrollHeight, boxSizingData.value)
     })
   }
@@ -82,6 +85,9 @@ export function useAutoRows(
       measureTextarea(textareaRef.value!, textarea => {
         textarea.style.height = ''
         textarea.value = textarea.placeholder
+
+        // trigger reflow to ensure scrollHeight is calculated when referenced
+        void textarea.scrollHeight
         cachedPlaceholderHeight = getHeightByScrollHeight(textarea.scrollHeight, boxSizingData.value)
       })
     }

--- a/packages/pro/textarea/src/composables/useRowsCounts.ts
+++ b/packages/pro/textarea/src/composables/useRowsCounts.ts
@@ -29,6 +29,9 @@ export function useRowCounts(
           textarea,
           el => {
             el.value = line || 'x'
+
+            // trigger reflow to ensure scrollHeight is calculated when referenced
+            void el.scrollHeight
             return Math.round((el.scrollHeight - paddingSize) / lineHeight.value)
           },
           true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
火狐浏览器下，对textarea的内容和属性变更之后立即获取scrollHeight，获取的还是变更前的高度

## What is the new behavior?
先通过对scrollHeight的引用强制触发变更，再次获取高度

## Other information
