### PR TITLE
fix(comp:table): scrollbar hides when not vertically overflowed

### DIFF
--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -36,10 +36,6 @@
     &::after {
       right: 0;
     }
-
-    .cdk-virtual-scroll-holder {
-      overflow-y: scroll;
-    }
   }
 
   table {

--- a/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
+++ b/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
@@ -44,15 +44,16 @@ exports[`ProTransfer > table transfer render work 1`] = `
             <!---->
             <!---->
             <div
-              class="ix-table-container ix-table-scroll-vertical"
+              class="ix-table-container"
             >
               
               <div
-                class="ix-table-fixed-holder"
-                style="overflow: hidden;"
+                class="ix-table-content"
+                style="max-height: auto;"
               >
                 <table
-                  style="table-layout: fixed; visibility: hidden;"
+                  class="ix-table-table"
+                  style="table-layout: auto;"
                 >
                   <colgroup>
                     
@@ -70,7 +71,6 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     />
                     
                   </colgroup>
-                  
                   <thead
                     class="ix-table-thead"
                   >
@@ -128,33 +128,6 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     </tr>
                     
                   </thead>
-                  
-                </table>
-              </div>
-              <div
-                class="ix-table-content"
-                style="overflow-y: scroll; max-height: auto;"
-              >
-                <table
-                  class="ix-table-table"
-                  style="table-layout: auto;"
-                >
-                  <colgroup>
-                    
-                    <col
-                      class="ix-table-col-selectable"
-                    />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
-                    
-                  </colgroup>
                   <tbody
                     class="ix-table-tbody"
                   >
@@ -1107,15 +1080,16 @@ exports[`ProTransfer > table transfer render work 1`] = `
             <!---->
             <!---->
             <div
-              class="ix-table-container ix-table-scroll-vertical"
+              class="ix-table-container"
             >
               
               <div
-                class="ix-table-fixed-holder"
-                style="overflow: hidden;"
+                class="ix-table-content"
+                style="max-height: auto;"
               >
                 <table
-                  style="table-layout: fixed; visibility: hidden;"
+                  class="ix-table-table"
+                  style="table-layout: auto;"
                 >
                   <colgroup>
                     
@@ -1127,7 +1101,6 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     />
                     
                   </colgroup>
-                  
                   <thead
                     class="ix-table-thead"
                   >
@@ -1175,27 +1148,6 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     </tr>
                     
                   </thead>
-                  
-                </table>
-              </div>
-              <div
-                class="ix-table-content"
-                style="overflow-y: scroll; max-height: auto;"
-              >
-                <table
-                  class="ix-table-table"
-                  style="table-layout: auto;"
-                >
-                  <colgroup>
-                    
-                    <col
-                      class="ix-table-col-selectable"
-                    />
-                    <col
-                      class=""
-                    />
-                    
-                  </colgroup>
                   <tbody
                     class="ix-table-tbody"
                   >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
竖向内容不需要滚动时，仍然存在竖向滚动条

## What is the new behavior?
修复以上问题

## Other information
无论是否是虚拟滚动，只有在各自方向有内容溢出才展示滚动条