### PR TITLE
feat(comp:date-picker): add dateRangePicker `onSelect` event

### DIFF
--- a/packages/components/date-picker/__tests__/dateRangePicker.spec.ts
+++ b/packages/components/date-picker/__tests__/dateRangePicker.spec.ts
@@ -85,6 +85,25 @@ describe('DateRangePicker', () => {
     expect(findCell(wrapper, 'to', '11')?.classes()).toContain('ix-date-panel-cell-in-range')
   })
 
+  test('onSelect work', async () => {
+    const onSelect = vi.fn()
+    const wrapper = DateRangePickerMount({
+      props: {
+        value: [new Date('2021-10-01 00:00:00'), new Date('2021-11-11 00:00:00')],
+        onSelect,
+      },
+    })
+
+    await findCell(wrapper, 'from', '11')?.trigger('click')
+    expect(onSelect).toBeCalledWith([new Date('2021-10-11 00:00:00'), undefined])
+
+    onSelect.mockClear()
+
+    onSelect.mockClear()
+    await findCell(wrapper, 'to', '21')?.trigger('click')
+    expect(onSelect).toBeCalledWith([new Date('2021-10-11 00:00:00'), new Date('2021-11-21 00:00:00')])
+  })
+
   test('v-model:open work', async () => {
     const onUpdateOpen = vi.fn()
     const wrapper = DateRangePickerMount({ props: { open: false, 'onUpdate:open': onUpdateOpen } })

--- a/packages/components/date-picker/demo/AllowInput.md
+++ b/packages/components/date-picker/demo/AllowInput.md
@@ -2,7 +2,7 @@
 title:
   zh: 可输入
   en: AllowInput
-order: 1
+order: 10
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/Disabled.md
+++ b/packages/components/date-picker/demo/Disabled.md
@@ -2,7 +2,7 @@
 title:
   zh: 禁用
   en: Disabled
-order: 5
+order: 50
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/DisabledDate.md
+++ b/packages/components/date-picker/demo/DisabledDate.md
@@ -2,7 +2,7 @@
 title:
   zh: 禁用面板中的日期
   en: Disabled date in panel
-order: 6
+order: 60
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/Format.md
+++ b/packages/components/date-picker/demo/Format.md
@@ -2,7 +2,7 @@
 title:
   zh: 日期格式
   en: Date format
-order: 3
+order: 30
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/FormatCustom.md
+++ b/packages/components/date-picker/demo/FormatCustom.md
@@ -2,7 +2,7 @@
 title:
   zh: 高级格式
   en: Advanced format
-order: 4
+order: 40
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/OverlayRender.md
+++ b/packages/components/date-picker/demo/OverlayRender.md
@@ -2,7 +2,7 @@
 title:
   zh: 自定义面板
   en: Custom Panel
-order: 7
+order: 70
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/Range.md
+++ b/packages/components/date-picker/demo/Range.md
@@ -2,7 +2,7 @@
 title:
   zh: 日期范围
   en: Date range
-order: 2
+order: 20
 ---
 
 ## zh

--- a/packages/components/date-picker/demo/SelectRangeIn7Days.md
+++ b/packages/components/date-picker/demo/SelectRangeIn7Days.md
@@ -1,0 +1,14 @@
+---
+title:
+  zh: 选择7天内日期范围
+  en: Select range dates in 7 days
+order: 21
+---
+
+## zh
+
+通过 `onSelect` 以及 `disabledDate` 实现选中7天内的日期范围
+
+## en
+
+Select range dates in 7 days via `onSelect` and `disabledDate`.

--- a/packages/components/date-picker/demo/SelectRangeIn7Days.vue
+++ b/packages/components/date-picker/demo/SelectRangeIn7Days.vue
@@ -1,0 +1,32 @@
+<template>
+  <IxSpace vertical>
+    <IxDateRangePicker
+      v-model:value="value"
+      :disabled-date="disabledDate"
+      :on-select="handleSelect"
+      clearable
+    ></IxDateRangePicker>
+  </IxSpace>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { differenceInDays } from 'date-fns'
+
+const selectedDates = ref<(Date | undefined)[] | undefined>()
+const value = ref([])
+
+const disabledDate = (date: Date) => {
+  const dates = selectedDates.value
+  if (!dates?.[0] || !!dates[1]) {
+    return false
+  }
+
+  return Math.abs(differenceInDays(date, dates[0])) > 7
+}
+
+const handleSelect = (dates: (Date | undefined)[] | undefined) => {
+  selectedDates.value = dates
+}
+</script>

--- a/packages/components/date-picker/docs/Api.zh.md
+++ b/packages/components/date-picker/docs/Api.zh.md
@@ -92,8 +92,9 @@ const defaultFormat = {
 | `placeholder` | 选择框默认文本 | `string[] \| #placeholder=placement:'start'\|'end'` | - | - | 默认使用 `i18n` 配置 |
 | `separator` | 自定义分隔符图标 | `string \| VNode \| #separator` | - | ✅ | - |
 | `timePanelOptions` | 时间选择面板配置 | `PickerTimePanelOptions \| PickerTimePanelOptions[]` | - | - | 如果需要对前后的时间选择器使用不同配置，可以传入一个数组 |
-| `onChange` | 值改变后的回调 | `(value: Date[], oldValue: Date[]) => void` | - | - | - |
+| `onChange` | 选中的日期范围值改变后的回调 | `(value: Date[], oldValue: Date[]) => void` | - | - | - |
 | `onInput` | 输入后的回调 | `(isFrom: boolean, evt: Event) => void` | - | - | - |
+| `onSelect` | 面板选择的日期范围值改变的回调 | `(dates: (Date | undefined)[] | undefined) => void` | - | - | 仅选中起点或终点时也会触发 |
 
 ### IxDatePickerPanel
 
@@ -122,6 +123,7 @@ const defaultFormat = {
 | `timePanelOptions` | 时间选择面板配置 | `TimePanelOptions \| TimePanelOptions[]` | - | - | 如果需要对前后的时间选择器使用不同配置，可以传入一个数组 |
 | `visible` | 当前可见的面板 | `'datePanel' \| 'timePanel' \| boolean` | - | - | 在非 `datetime` 类型时，`timepanel` 无效 |
 | `onChange` | 值改变后的回调 | `(value: Date[] | undefined) => void` | - | - | - |
+| `onSelect` | 面板选择的日期范围值改变的回调 | `(dates: (Date | undefined)[] | undefined) => void` | - | - | 仅选中起点或终点时也会触发 |
 
 #### TimePanelOptions
 

--- a/packages/components/date-picker/src/composables/useRangePanelState.ts
+++ b/packages/components/date-picker/src/composables/useRangePanelState.ts
@@ -23,8 +23,9 @@ export interface RangePanelStateContext {
 }
 
 export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateConfig): RangePanelStateContext {
-  const [selectingDate, setSelectingDate] = useState<(Date | undefined)[] | undefined>(props.value)
+  const [selectingDates, setSelectingDates] = useState<(Date | undefined)[] | undefined>(props.value)
   const [isSelecting, setIsSelecting] = useState<boolean>(false)
+
   watch(
     () => props.visible,
     () => {
@@ -34,31 +35,34 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
 
   const panelValue = computed(() => {
     if (isSelecting.value) {
-      return sortRangeValue(dateConfig, [...convertArray(selectingDate.value)], 'date')
+      return sortRangeValue(dateConfig, [...convertArray(selectingDates.value)], 'date')
     }
 
     return convertArray(props.value)
   })
 
   const handleChange = (value: (Date | undefined)[]) => {
-    callEmit(props.onChange, sortRangeValue(dateConfig, value, 'date') as Date[])
+    const sortedRangeValue = sortRangeValue(dateConfig, value, 'date') as Date[]
+    callEmit(props.onChange, sortedRangeValue)
+    callEmit(props.onSelect, sortedRangeValue)
   }
 
   const handleDatePanelCellClick = (value: Date) => {
     if (!isSelecting.value) {
       setIsSelecting(true)
-      setSelectingDate([value, undefined])
+      setSelectingDates([value, undefined])
+      callEmit(props.onSelect, [value, undefined])
     } else {
       const propsValue = convertArray(props.value)
 
-      setIsSelecting(false)
       handleChange(
-        [selectingDate.value?.[0], value].map((dateValue, index) =>
+        [selectingDates.value?.[0], value].map((dateValue, index) =>
           propsValue[index]
             ? applyDateTime(dateConfig, propsValue[index], dateValue!, ['hour', 'minute', 'second'])
             : dateValue,
         ),
       )
+      setIsSelecting(false)
     }
   }
 
@@ -67,7 +71,7 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
       return
     }
 
-    setSelectingDate([selectingDate.value?.[0], value])
+    setSelectingDates([selectingDates.value?.[0], value])
   }
 
   return {

--- a/packages/components/date-picker/src/composables/useTimePanelProps.ts
+++ b/packages/components/date-picker/src/composables/useTimePanelProps.ts
@@ -6,7 +6,6 @@
  */
 
 import type { DatePickerProps, DateRangePickerProps, TimePanelOptions } from '../types'
-import type { ɵTimePanelProps } from '@idux/components/_private/time-panel'
 
 import { type ComputedRef, computed } from 'vue'
 
@@ -18,7 +17,7 @@ export function useTimePanelProps(
   minuteEnabled: ComputedRef<boolean>,
   secondEnabled: ComputedRef<boolean>,
   use12Hours: ComputedRef<boolean>,
-): ComputedRef<ɵTimePanelProps> {
+): ComputedRef<TimePanelOptions> {
   return computed(() => ({
     ...getTimePanelProps(props.timePanelOptions ?? {}),
     hourEnabled: hourEnabled.value,
@@ -34,7 +33,7 @@ export function useRangeTimePanelProps(
   minuteEnabled: ComputedRef<boolean>,
   secondEnabled: ComputedRef<boolean>,
   use12Hours: ComputedRef<boolean>,
-): ComputedRef<ɵTimePanelProps[]> {
+): ComputedRef<TimePanelOptions[]> {
   const getOptions = (isFrom: boolean) =>
     (isArray(props.timePanelOptions) ? props.timePanelOptions[isFrom ? 0 : 1] : props.timePanelOptions) ?? {}
 
@@ -55,7 +54,7 @@ export function useRangeTimePanelProps(
   return rangeTimePanelProps
 }
 
-function getTimePanelProps(timePanelOptions: TimePanelOptions): ɵTimePanelProps {
+function getTimePanelProps(timePanelOptions: TimePanelOptions): TimePanelOptions {
   const { disabledHours, disabledMinutes, disabledSeconds, hideDisabledOptions, hourStep, minuteStep, secondStep } =
     timePanelOptions
 

--- a/packages/components/date-picker/src/content/RangeContent.tsx
+++ b/packages/components/date-picker/src/content/RangeContent.tsx
@@ -144,6 +144,7 @@ export default defineComponent({
         timePanelOptions: timePanelProps.value,
         visible: overlayVisible.value && visiblePanel.value,
         onChange: handlePanelChange,
+        onSelect: props.onSelect,
       }
 
       const panelSlots = {

--- a/packages/components/date-picker/src/types.ts
+++ b/packages/components/date-picker/src/types.ts
@@ -104,9 +104,10 @@ export const datePickerProps = {
   footer: { type: [Boolean, Array, Object] as PropType<boolean | ɵFooterButtonProps[] | VNode>, default: false },
   placeholder: String,
   timePanelOptions: Object as PropType<PickerTimePanelOptions>,
-  'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: Date | undefined) => void>>,
+
   onChange: [Function, Array] as PropType<MaybeArray<(value: Date | undefined, oldValue: Date | undefined) => void>>,
   onInput: [Function, Array] as PropType<MaybeArray<(evt: Event) => void>>,
+  'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: Date | undefined) => void>>,
 } as const
 
 export type DatePickerProps = ExtractInnerPropTypes<typeof datePickerProps>
@@ -125,11 +126,13 @@ export const dateRangePickerProps = {
   placeholder: Array as PropType<string[]>,
   separator: [String, Object] as PropType<string | VNode>,
   timePanelOptions: [Object, Array] as PropType<PickerTimePanelOptions | PickerTimePanelOptions[]>,
-  'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: Date[] | undefined) => void>>,
+
   onChange: [Function, Array] as PropType<
     MaybeArray<(value: Date[] | undefined, oldValue: Date[] | undefined) => void>
   >,
   onInput: [Function, Array] as PropType<MaybeArray<(isFrom: boolean, evt: Event) => void>>,
+  onSelect: [Function, Array] as PropType<MaybeArray<(selectingDate: (Date | undefined)[] | undefined) => void>>,
+  'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: Date[] | undefined) => void>>,
 } as const
 
 export type DateRangePickerProps = ExtractInnerPropTypes<typeof dateRangePickerProps>
@@ -183,6 +186,7 @@ export const dateRangePanelProps = {
   visible: [String, Boolean] as PropType<'datePanel' | 'timePanel' | boolean>,
 
   onChange: [Function, Array] as PropType<MaybeArray<(value: Date[] | undefined) => void>>,
+  onSelect: [Function, Array] as PropType<MaybeArray<(selectingDate: (Date | undefined)[] | undefined) => void>>,
   'onUpdate:activeValue': [Function, Array] as PropType<MaybeArray<(date: Date[] | undefined) => void>>,
 } as const
 export type DateRangePanelProps = ExtractInnerPropTypes<typeof dateRangePanelProps>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
无法支持根据正在选择的日期范围动态计算应禁用的日期

## What is the new behavior?
增加 onSelect 事件，行为如下：
首次点击触发selecting状态，事件触发，参数为[date, undefined]
再次点击，解除selecting状态，事件触发，参数为[date, date]

## Other information
补充单测以及选择7天内范围的demo