### PR TITLE
fix(comp:input-number): Strictly check whether value is a number

### DIFF
--- a/packages/components/input-number/src/useInputNumber.ts
+++ b/packages/components/input-number/src/useInputNumber.ts
@@ -77,16 +77,20 @@ export function useInputNumber(props: InputNumberProps, config: InputNumberConfi
 
   function updateDisplayValueFromAccessor() {
     const { value } = accessor
-    if (value === null || value === undefined) {
+    // Check whether value is empty.
+    if ((!value && value !== 0) || !String(value).trim()) {
       displayValue.value = ''
-    } else if (Number.isNaN(value)) {
+
+      // Check whether value is not a number.
+    } else if (Number.isNaN(Number(value)) || (typeof value !== 'number' && typeof value !== 'string')) {
       displayValue.value = ''
       if (__DEV__) {
         Logger.warn('components/input-number', `model value(${value}) is not a number.`)
       }
     } else {
-      if (displayValue.value === '' || value !== Number(displayValue.value)) {
-        displayValue.value = value.toFixed(precision.value)
+      const newValue = Number(value)
+      if (displayValue.value === '' || newValue !== Number(displayValue.value)) {
+        displayValue.value = newValue.toFixed(precision.value)
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The value passed in from calling formGroup.setValue is not strictly checked.

## What is the new behavior?

Strictly check if value is a number when calling formControl.setValue function.

```
// value is empty(not a number, but can be covert to number), 
// don't throw any error, set the value to null.
formControl.setValue({ value: '' })

// value is not a number(NaN), throw the error when environment is 'development',
// and set the value to null.
formControl.setValue({ value: {} })

// value is a string, not empty and can be covert to number,
// so set the value to the converted number.
formControl.setValue({ value: '123' })

// value is a string, not empty and can't be covert to number,
// so set the value to null and throw the error when environment is 'development'.
formControl.setValue({ value: '123a' })
```

## Other information
