### PR TITLE
fix(comp:slider): slider thumb tooltip shouldn't blink

### DIFF
--- a/packages/components/slider/src/Thumb.tsx
+++ b/packages/components/slider/src/Thumb.tsx
@@ -78,6 +78,8 @@ export default defineComponent({
           visible={mergedTooltipVisible.value}
           placement={tooltipPlacement.value}
           trigger="manual"
+          onMouseenter={handleMouseEnter}
+          onMouseleave={handleMouseLeave}
           v-slots={{
             title: () =>
               isFunction(tooltipFormatter.value) ? tooltipFormatter.value(props.value!) : <span>{props.value}</span>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
鼠标移动到 slider thumb上触发mouseleave, tooltip关闭，接着触发mouseenter, tooltip开启，导致tooltip闪烁


## What is the new behavior?
将mouseenter、mouseleave事件同时绑定到thumb以及tooltip上，防止闪烁

## Other information
