### PR TITLE
fix(comp:date-picker): range panel date select shouldn't swap time

### DIFF
--- a/packages/components/date-picker/src/composables/useRangePanelState.ts
+++ b/packages/components/date-picker/src/composables/useRangePanelState.ts
@@ -17,7 +17,7 @@ import { applyDateTime, sortRangeValue } from '../utils'
 export interface RangePanelStateContext {
   panelValue: ComputedRef<(Date | undefined)[] | undefined>
   isSelecting: ComputedRef<boolean>
-  handleChange: (value: (Date | undefined)[]) => void
+  handleChange: (value: Date[] | undefined) => void
   handleDatePanelCellClick: (value: Date) => void
   handleDatePanelCellMouseenter: (value: Date) => void
 }
@@ -41,10 +41,9 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
     return convertArray(props.value)
   })
 
-  const handleChange = (value: (Date | undefined)[]) => {
-    const sortedRangeValue = sortRangeValue(dateConfig, value, 'date') as Date[]
-    callEmit(props.onChange, sortedRangeValue)
-    callEmit(props.onSelect, sortedRangeValue)
+  const handleChange = (value: Date[] | undefined) => {
+    callEmit(props.onChange, value)
+    callEmit(props.onSelect, value)
   }
 
   const handleDatePanelCellClick = (value: Date) => {
@@ -54,13 +53,12 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
       callEmit(props.onSelect, [value, undefined])
     } else {
       const propsValue = convertArray(props.value)
-
       handleChange(
-        [selectingDates.value?.[0], value].map((dateValue, index) =>
+        sortRangeValue(dateConfig, [selectingDates.value![0], value], 'date').map((dateValue, index) =>
           propsValue[index]
             ? applyDateTime(dateConfig, propsValue[index], dateValue!, ['hour', 'minute', 'second'])
             : dateValue,
-        ),
+        ) as Date[],
       )
       setIsSelecting(false)
     }

--- a/packages/components/date-picker/src/panel/RangePanel.tsx
+++ b/packages/components/date-picker/src/panel/RangePanel.tsx
@@ -16,6 +16,7 @@ import { useDateConfig, useGlobalConfig } from '@idux/components/config'
 import { useRangeActiveValue } from '../composables/useActiveValue'
 import { useRangePanelState } from '../composables/useRangePanelState'
 import { dateRangePanelProps } from '../types'
+import { sortRangeValue } from '../utils'
 
 export default defineComponent({
   name: 'IxDateRangePanel',
@@ -45,7 +46,13 @@ export default defineComponent({
       const activeValue = isFrom ? fromActiveValue.value : toActiveValue.value
 
       const handleTimePanelChange = (value: Date) => {
-        handleChange(isFrom ? [value, panelValue.value?.[1]] : [panelValue.value?.[0], value])
+        handleChange(
+          sortRangeValue(
+            dateConfig,
+            isFrom ? [value, panelValue.value?.[1]] : [panelValue.value?.[0], value],
+            'date',
+          ) as Date[],
+        )
       }
 
       const datePanelProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
日期范围面板反向选择日期范围会交换起始日期的时间，即结束日期的时间和开始日期的时间被互换了


## What is the new behavior?
修复以上问题

## Other information
