### PR TITLE
fix(pro:search): name segment overlay isn't automatically opened now

### DIFF
--- a/packages/pro/search/demo/MergeItems.vue
+++ b/packages/pro/search/demo/MergeItems.vue
@@ -103,7 +103,9 @@ const handleValueUpdate = (searchValues: SearchValue[] | undefined) => {
   }
 
   const currentValue = securityStateValues.pop()!
-  value.value = [...searchValues!.filter(v => v.key !== 'security_state'), currentValue]
+  value.value = !securityStateValues.length
+    ? searchValues!
+    : [...searchValues!.filter(v => v.key !== 'security_state'), currentValue]
 
   securityStateField.defaultValue = currentValue.value
 }

--- a/packages/pro/search/src/composables/useActiveSegment.ts
+++ b/packages/pro/search/src/composables/useActiveSegment.ts
@@ -18,11 +18,12 @@ export interface ActiveSegmentContext {
   setActiveSegment: (segment: ActiveSegment | undefined) => void
   changeActive: (offset: number, crossItem?: boolean) => void
   setInactive: (blur?: boolean) => void
-  setTempActive: (name?: string) => void
+  setTempActive: (overlayOpened?: boolean) => void
 }
 export interface ActiveSegment {
   itemKey: VKey
   name: string
+  overlayOpened: boolean
 }
 type FlattenedSegment = Segment & { itemKey: VKey }
 
@@ -43,7 +44,11 @@ export function useActiveSegment(
   )
 
   const updateActiveSegment = (segment: ActiveSegment | undefined) => {
-    if (activeSegment.value?.itemKey === segment?.itemKey && activeSegment.value?.name === segment?.name) {
+    if (
+      activeSegment.value?.itemKey === segment?.itemKey &&
+      activeSegment.value?.name === segment?.name &&
+      activeSegment.value?.overlayOpened === segment?.overlayOpened
+    ) {
       return
     }
 
@@ -63,6 +68,7 @@ export function useActiveSegment(
       updateActiveSegment({
         itemKey: activeItem.value!.key,
         name: activeItem.value!.segments[offset < 0 ? 0 : activeItem.value!.segments.length - 1].name,
+        overlayOpened: !crossItem,
       })
       return
     }
@@ -73,6 +79,7 @@ export function useActiveSegment(
         ? {
             itemKey: targetSegment.itemKey,
             name: targetSegment.name,
+            overlayOpened: !crossItem,
           }
         : undefined,
     )
@@ -89,13 +96,14 @@ export function useActiveSegment(
     }
   }
 
-  const setTempActive = (name?: string) => {
+  const setTempActive = (overlayOpened = false) => {
     if (!tempSearchStateAvailable.value) {
       setInactive()
     } else {
       setActiveSegment({
         itemKey: tempSearchStateKey,
-        name: name ?? 'name',
+        name: 'name',
+        overlayOpened,
       })
     }
   }

--- a/packages/pro/search/src/composables/useFocusedState.ts
+++ b/packages/pro/search/src/composables/useFocusedState.ts
@@ -38,7 +38,7 @@ export function useFocusedState(
 
   watch([activeSegment, searchStates], ([segment]) => {
     if (!segment && focused.value) {
-      setTempActive()
+      nextTick(setTempActive)
     }
   })
 
@@ -49,7 +49,7 @@ export function useFocusedState(
 
     handleFocus(evt, () => {
       if (evt.target === elementRef.value) {
-        setTempActive()
+        setTempActive(true)
       }
     })
   }

--- a/packages/pro/search/src/searchItem/SearchItem.tsx
+++ b/packages/pro/search/src/searchItem/SearchItem.tsx
@@ -73,6 +73,7 @@ export default defineComponent({
       setActiveSegment({
         itemKey: props.searchItem!.key,
         name,
+        overlayOpened: true,
       })
     }
     const handleCloseIconClick = (evt: Event) => {

--- a/packages/pro/search/src/segments/CreateNameSegment.tsx
+++ b/packages/pro/search/src/segments/CreateNameSegment.tsx
@@ -26,11 +26,16 @@ export function createNameSegment(
       setValue(value[0])
       ok()
     }
+    const filteredDataSource = filterSelectDataSourceByInput(names, getRawInput(input))
+    if (!filteredDataSource?.length) {
+      return
+    }
+
     return (
       <SelectPanel
         class={`${prefixCls}-name-segment-panel`}
         value={convertArray(value)}
-        dataSource={filterSelectDataSourceByInput(names, getRawInput(input))}
+        dataSource={filteredDataSource}
         multiple={false}
         onChange={handleChange}
         onConfirm={ok}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
完成一个搜索项的确认之后会自动弹出搜索条件名称选择的面板


## What is the new behavior?
不再自动弹出该面板（搜索值和操作符的面板不变），在有键盘操作时再弹出，并按esc收回

搜索项名称选择面板在根据输入过滤结果为空时收起

## Other information
