### PR TITLE
fix(comp:transfer): empty suffix node shouldn't be rendered

### DIFF
--- a/packages/cdk/utils/src/vNode.ts
+++ b/packages/cdk/utils/src/vNode.ts
@@ -50,12 +50,13 @@ export function hasSlot(slots: Slots, key = 'default'): boolean {
   return !isNil(slots[key])
 }
 
-export function isEmptyNode(node: VNodeChild): boolean {
-  return (
-    !node ||
-    isComment(node) ||
-    (isFragment(node) && (node as any).children.length === 0) ||
-    (isText(node) && (node as any).children.trim() === '')
+export function isEmptyNode(nodes: VNodeChild): boolean {
+  return convertArray(nodes).every(
+    node =>
+      !node ||
+      isComment(node) ||
+      (isFragment(node) && (node as any).children.length === 0) ||
+      (isText(node) && (node as any).children.trim() === ''),
   )
 }
 

--- a/packages/components/transfer/src/content/Header.tsx
+++ b/packages/components/transfer/src/content/Header.tsx
@@ -7,9 +7,7 @@
 
 import { type VNodeTypes, defineComponent, inject, normalizeClass, onMounted, ref, watch, withKeys } from 'vue'
 
-import { isArray } from 'lodash-es'
-
-import { useState } from '@idux/cdk/utils'
+import { isEmptyNode, useState } from '@idux/cdk/utils'
 import { ɵInput, type ɵInputInstance } from '@idux/components/_private/input'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { IxIcon } from '@idux/components/icon'
@@ -142,7 +140,11 @@ export default defineComponent({
     const renderSuffix = (prefixCls: string) => {
       const suffix = slots.headerSuffix?.({ isSource: props.isSource })
 
-      return suffix && <span class={`${prefixCls}-suffix`}>{suffix}</span>
+      if (isEmptyNode(suffix)) {
+        return
+      }
+
+      return <span class={`${prefixCls}-suffix`}>{suffix}</span>
     }
 
     const renderHeader = (prefixCls: string) => {
@@ -166,7 +168,7 @@ export default defineComponent({
 
       const children = renderHeader(prefixCls)
 
-      if (!children || (isArray(children) && children.length <= 0)) {
+      if (isEmptyNode(children)) {
         return
       }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
slot渲染的空suffix（包含Fragment、Comment、或者空数组等），没有被判空导致渲染了空的suffix节点占位置

## What is the new behavior?
修复以上问题

## Other information
