### PR TITLE
fix(comp:modal): update modal content with `update` doesn't work

### DIFF
--- a/packages/components/modal/src/ModalBody.tsx
+++ b/packages/components/modal/src/ModalBody.tsx
@@ -36,7 +36,7 @@ export default defineComponent({
 
     return () => {
       const prefixCls = `${mergedPrefixCls.value}-body`
-      const defaultNode = slots.default?.()
+      const defaultNode = slots.default?.() ?? props.__content_node
 
       if (isDefault.value) {
         return <div class={prefixCls}>{defaultNode}</div>

--- a/packages/components/modal/src/ModalProvider.tsx
+++ b/packages/components/modal/src/ModalProvider.tsx
@@ -35,11 +35,7 @@ export default defineComponent({
         const mergedProps = { key, visible, ref: setRef, 'onUpdate:visible': onUpdateVisible, onAfterClose }
 
         const contentNode = isVNode(content) ? cloneVNode(content, contentProps, true) : content
-        return (
-          <Modal {...mergedProps} {...restProps}>
-            {contentNode}
-          </Modal>
-        )
+        return <Modal {...mergedProps} {...restProps} __content_node={contentNode} />
       })
       return (
         <>

--- a/packages/components/modal/src/types.ts
+++ b/packages/components/modal/src/types.ts
@@ -103,10 +103,13 @@ export const modalProps = {
   onClose: [Function, Array] as PropType<MaybeArray<(evt?: Event | unknown) => void>>,
   onCancel: [Function, Array] as PropType<MaybeArray<(evt?: Event | unknown) => unknown>>,
   onOk: [Function, Array] as PropType<MaybeArray<(evt?: Event | unknown) => unknown>>,
+
+  // private
+  __content_node: [String, Object] as PropType<string | VNode>,
 } as const
 
 export type ModalProps = ExtractInnerPropTypes<typeof modalProps>
-export type ModalPublicProps = ExtractPublicPropTypes<typeof modalProps>
+export type ModalPublicProps = Omit<ExtractPublicPropTypes<typeof modalProps>, '__content_node'>
 export interface ModalBindings {
   open: () => void
   close: (evt?: Event | unknown) => Promise<void>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
调用 userModal 创建的 modalRef 的update 更新 content，无法触发更新


## What is the new behavior?
修复以上问题

## Other information
添加私有属性 __content_prop用来传递content