### PR TITLE
fix(comp:select): clicking selector when opened should trigger focus

### DIFF
--- a/packages/components/_private/selector/src/Selector.tsx
+++ b/packages/components/_private/selector/src/Selector.tsx
@@ -173,6 +173,16 @@ export default defineComponent({
       }
 
       const children: VNodeChild[] = []
+
+      if (showPlaceholder.value) {
+        const placeholderNode = slots.placeholder ? slots.placeholder() : props.placeholder
+        children.push(
+          <div key="__placeholder" class={`${prefixCls}-placeholder`}>
+            {placeholderNode}
+          </div>,
+        )
+      }
+
       if (multiple) {
         const renderRest = (rest: unknown[]) => {
           const key = '__IDUX_SELECT_MAX_ITEM'
@@ -204,15 +214,6 @@ export default defineComponent({
           dataSource.forEach(item => children.push(renderItem(item)))
         }
         children.push(<Input />)
-      }
-
-      if (showPlaceholder.value) {
-        const placeholderNode = slots.placeholder ? slots.placeholder() : props.placeholder
-        children.push(
-          <div key="__placeholder" class={`${prefixCls}-placeholder`}>
-            {placeholderNode}
-          </div>,
-        )
       }
 
       const suffixProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在overlay opend 的时候，点击selector，由于placeholder在上层，无法focus到input上


## What is the new behavior?
修复以上问题

## Other information
