### PR TITLE
fix(comp:spin): compatible with the resize of target, when useSpin is…

### DIFF
--- a/packages/components/spin/__tests__/__snapshots__/spinProvider.spec.ts.snap
+++ b/packages/components/spin/__tests__/__snapshots__/spinProvider.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1
 
-exports[`SpinProvider > basic > render work 1`] = `"<div class=\\"ix-spin-provider\\">content</div>"`;
+exports[`SpinProvider > basic > render work 1`] = `"content"`;

--- a/packages/components/spin/demo/UseSpin.md
+++ b/packages/components/spin/demo/UseSpin.md
@@ -8,7 +8,7 @@ hidden: true
 
 ## zh
 
-你可以通过`useSpin`来灵活的使用`spin`组件，前提是需要把子组件包裹在`IxSpinProvider`里面
+你可以通过`useSpin`来灵活的使用`spin`组件，前提是需要把子组件包裹在`IxSpinProvider`里面，此方法兼容`scroll`和`resize`存在的情况
 
 ``` html
 <IxSpinProvider>

--- a/packages/components/spin/demo/UseSpin.vue
+++ b/packages/components/spin/demo/UseSpin.vue
@@ -1,7 +1,27 @@
 <template>
   <IxSpace vertical :size="20">
-    <div class="card">
-      <div class="content">content</div>
+    <div class="resizable-container">
+      <CdkResizable
+        class="resizable-box"
+        free
+        :handlers="[]"
+        :maxWidth="800"
+        :maxHeight="400"
+        :minWidth="120"
+        :minHeight="140"
+      >
+        <div class="card">
+          <div class="content">Resizable!</div>
+        </div>
+        <CdkResizableHandle placement="end">
+          <div class="handle-end">
+            <IxIcon class="handle-end-icon" name="holder" />
+          </div>
+        </CdkResizableHandle>
+        <CdkResizableHandle placement="bottomEnd">
+          <IxIcon class="handle-bottom-end-icon" name="caret-up-filled" :rotate="135" />
+        </CdkResizableHandle>
+      </CdkResizable>
     </div>
     <IxSpace>
       <IxButton @click="openSpin">Open</IxButton>
@@ -51,15 +71,53 @@ const destroyAllSpin = () => {
 }
 </script>
 <style lang="less" scoped>
+.resizable-container {
+  display: block;
+  height: 300px;
+}
+
+.resizable-box {
+  width: 300px;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #eee;
+  border: 1px solid #ddd;
+}
+
+.handle-end {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &-icon {
+    background: #fff;
+    border: 1px solid #ddd;
+    text-align: center;
+    font-size: 12px;
+    height: 20px;
+    line-height: 20px;
+  }
+}
+
+.handle-bottom-end-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 .card {
   text-align: center;
-  padding: 50px;
-  background-color: #eee;
-  height: 300px;
+  background-color: #aea;
+  width: 90%;
+  height: 100%;
   overflow: auto;
 
   .content {
-    height: 500px;
+    width: 260px;
+    height: 260px;
   }
 }
 </style>

--- a/packages/components/spin/src/types.ts
+++ b/packages/components/spin/src/types.ts
@@ -50,6 +50,8 @@ export interface SpinMergedOptions extends SpinOptions {
   hasScroll: boolean
   isFullScreen: boolean
   staticPosition: boolean
+
+  stopResizeWatch?: () => void
 }
 
 export interface SpinRef {


### PR DESCRIPTION
… used

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 当使用useSpin遮住target时，如果target发生了resize事件，spin无法适配
2. IxSpinProvider组件产生了多余的ix-spin-provider节点


## What is the new behavior?
1. useSpin是将spin组件传送到target内部，从而实现遮罩效果，若target不存在滚动条则可以使用css的absolute定位去遮住整个区域；但当存在滚动条时且用户滚动时，无法满足；

 - 解决方案为： 当存在滚动条时动态设置spin的宽高为整个target的宽高，从而实现遮住滚动区域的效果，反之利用css的absolute解决；
`tips:` 还有一个解决方案为不设置宽高，而是动态设置spin的偏移 (transform: translate)，只遮住可视区域，但是此方案需要同时处理scroll和resize两个事件，而且当滚动条滚得太快时，视觉上会有晃动的，所以放弃。

     此解决方案有一个难点在于当target产生resize事件时，由于spin拥有了宽高且位于target内部，所以无法准确获取当前target产生resize之后的宽高从而判断是否还存在滚动条，所以此难点解决办法为，当产生resize时，将spin宽高置为0，在nextTick中再进行判断


2. 由于vue3可以使用无根节点的组件，所以直接去除ix-spin-provider节点 即可

## Other information
