### PR TITLE
fix(comp:table): scrollbar always appear, when scroll.width is set

### DIFF
--- a/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
+++ b/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
@@ -10,24 +10,21 @@ exports[`Table > basic work > render work 1`] = `
         <colgroup>
           <col class=\\"ix-table-col-expandable\\">
           <col class=\\"ix-table-col-selectable\\">
-          <col class=\\"\\">
-          <col class=\\"\\">
-          <col class=\\"\\">
-          <col class=\\"\\">
-          <col class=\\"\\">
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
         </colgroup>
         <thead class=\\"ix-table-thead\\">
           <tr class=\\"ix-table-row\\">
             <th class=\\"ix-table-cell ix-table-cell-expandable\\">
               <!---->
             </th>
-            <th class=\\"ix-table-cell ix-table-cell-selectable\\">
-              <div class=\\"ix-table-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
-                  <!---->
-                  <!---->
-                </label>
-                <!---->
-              </div>
+            <th class=\\"ix-table-cell ix-table-cell-selectable\\"><span class=\\"ix-table-cell-triggers\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"></span></span>
+              <!---->
+              <!----></label>
+              <!----></span>
             </th>
             <th class=\\"ix-table-cell\\">Name</th>
             <th class=\\"ix-table-cell\\">Age</th>

--- a/packages/components/table/demo/Fixed.vue
+++ b/packages/components/table/demo/Fixed.vue
@@ -64,26 +64,22 @@ const columns: TableColumn<Data>[] = [
   {
     title: 'Column 5',
     dataKey: 'address',
-    width: '10%',
     key: 'Column 5',
   },
   {
     title: 'Column 6',
     dataKey: 'address',
-    width: '10%',
     key: 'Column 6',
   },
   {
     title: 'Column 7',
     dataKey: 'address',
-    width: '10%',
     key: 'Column 7',
   },
   {
     title: 'Column 8',
     dataKey: 'address',
     key: 'Column 8',
-    width: '10%',
   },
   {
     title: 'Action',

--- a/packages/components/table/src/composables/useTableLayout.ts
+++ b/packages/components/table/src/composables/useTableLayout.ts
@@ -21,10 +21,10 @@ export function useTableLayout(
     if (props.tableLayout) {
       return props.tableLayout
     }
-    if (scrollHeight.value && hasFixed.value) {
+    if (scrollWidth.value && hasFixed.value) {
       return scrollWidth.value === 'max-content' ? 'auto' : 'fixed'
     }
-    if (scrollWidth.value || isSticky.value || hasEllipsis.value || props.virtual) {
+    if (scrollHeight.value || isSticky.value || hasEllipsis.value || props.virtual) {
       return 'fixed'
     }
     return 'auto'

--- a/packages/components/table/src/main/ColGroup.tsx
+++ b/packages/components/table/src/main/ColGroup.tsx
@@ -5,6 +5,8 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
+/* eslint-disable indent */
+
 import { defineComponent, inject, normalizeClass } from 'vue'
 
 import { convertCssPixel } from '@idux/cdk/utils'
@@ -17,7 +19,6 @@ export default defineComponent({
     const {
       flattedColumns,
       flattedColumnsWithScrollBar,
-      columnWidths,
       columnWidthsWithScrollBar,
       mergedSelectableMenus,
       mergedPrefixCls,
@@ -26,24 +27,27 @@ export default defineComponent({
     return () => {
       const { isFixedHolder } = props
       const columns = isFixedHolder ? flattedColumnsWithScrollBar.value : flattedColumns.value
-      if (!columns.some(column => !!column.width || 'type' in column)) {
+
+      // 所有列的宽度都不存在且没有特殊列的时候，跳过渲染
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (columns.every(column => !column.width && !column.type)) {
         return
       }
 
       const prefixCls = mergedPrefixCls.value
-      const widths = isFixedHolder ? columnWidthsWithScrollBar.value : columnWidths.value
       const children = columns.map((column, colIndex) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const { key, type } = column
-        // resizable：对于固定表头，widths[colIndex] 的优先级高于 column.width， 其他情况则相反。
-        const mergedWidth = isFixedHolder ? widths[colIndex] ?? column.width : column.width ?? widths[colIndex]
-        const className = normalizeClass({
-          [`${prefixCls}-col-${type}`]: !!type,
-          [`${prefixCls}-selectable-with-dropdown`]: type === 'selectable' && mergedSelectableMenus.value.length > 0,
-        })
-
-        const style = mergedWidth ? { width: convertCssPixel(mergedWidth) } : undefined
+        const mergedWidth = isFixedHolder ? columnWidthsWithScrollBar.value[colIndex] : column.width
+        const className = type
+          ? normalizeClass({
+              [`${prefixCls}-col-${type}`]: true,
+              [`${prefixCls}-col-with-dropdown`]: type === 'selectable' && mergedSelectableMenus.value.length > 0,
+            })
+          : undefined
+        const style = mergedWidth ? `width: ${convertCssPixel(mergedWidth)}` : undefined
         return <col key={key} class={className} style={style}></col>
       })
 

--- a/packages/components/table/src/main/head/triggers/SelectableTrigger.tsx
+++ b/packages/components/table/src/main/head/triggers/SelectableTrigger.tsx
@@ -59,7 +59,7 @@ export default defineComponent({
       }
 
       return (
-        <div class={`${mergedPrefixCls.value}-selectable`}>
+        <span class={`${mergedPrefixCls.value}-cell-triggers`}>
           <IxCheckbox
             checked={currentPageAllSelected.value}
             indeterminate={currentPageSomeSelected.value}
@@ -67,7 +67,7 @@ export default defineComponent({
             onChange={handleHeadSelectChange}
           />
           {renderDropDown()}
-        </div>
+        </span>
       )
     }
   },

--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -152,8 +152,7 @@
   }
 
   // --------- Expandable ---------
-  & &-expandable-trigger {
-    margin-right: @spacing-xs;
+  &-expandable-trigger {
     color: @table-expandable-icon-color;
     background-color: transparent;
     border-style: none;
@@ -162,6 +161,10 @@
 
     &-disabled {
       cursor: unset;
+    }
+
+    & + * {
+      margin-left: @spacing-xs;
     }
   }
 
@@ -175,17 +178,10 @@
   }
 
   // --------- Selectable ---------
-  & &-cell-selectable {
-    .@{table-prefix}-selectable {
-      display: flex;
-      align-items: center;
-
-      &-trigger {
-        margin-left: @spacing-xs;
-        color: @table-head-icon-color;
-        cursor: pointer;
-      }
-    }
+  &-selectable-trigger {
+    margin-left: @spacing-xs;
+    color: @table-head-icon-color;
+    cursor: pointer;
   }
 
   & tr&-row-selected {

--- a/packages/components/table/style/size.less
+++ b/packages/components/table/style/size.less
@@ -46,7 +46,7 @@
     width: 32px;
   }
 
-  .@{table-prefix}-col-selectable&-selectable-with-dropdown {
+  .@{table-prefix}-col-selectable&-col-with-dropdown {
     width: 52px;
   }
 }
@@ -59,7 +59,7 @@
     width: 40px;
   }
 
-  .@{table-prefix}-col-selectable&-selectable-with-dropdown {
+  .@{table-prefix}-col-selectable.@{table-prefix}-col-with-dropdown {
     width: 60px;
   }
 }
@@ -72,7 +72,7 @@
     width: 48px;
   }
 
-  .@{table-prefix}-col-selectable&-selectable-with-dropdown {
+  .@{table-prefix}-col-selectable.@{table-prefix}-col-with-dropdown {
     width: 68px;
   }
 }

--- a/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
+++ b/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
@@ -44,7 +44,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
             <!---->
             <!---->
             <div
-              class="ix-table-container ix-table-scroll-vertical"
+              class="ix-table-container ix-table-fixed-layout ix-table-scroll-vertical"
             >
               
               <div
@@ -59,15 +59,9 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     <col
                       class="ix-table-col-selectable"
                     />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
+                    <col />
+                    <col />
+                    <col />
                     
                   </colgroup>
                   
@@ -82,8 +76,8 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <th
                         class="ix-table-cell ix-table-cell-selectable"
                       >
-                        <div
-                          class="ix-table-selectable"
+                        <span
+                          class="ix-table-cell-triggers"
                         >
                           <label
                             aria-checked="false"
@@ -107,7 +101,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                             <!---->
                           </label>
                           <!---->
-                        </div>
+                        </span>
                       </th>
                       <th
                         class="ix-table-cell"
@@ -137,22 +131,16 @@ exports[`ProTransfer > table transfer render work 1`] = `
               >
                 <table
                   class="ix-table-table"
-                  style="table-layout: auto;"
+                  style="table-layout: fixed;"
                 >
                   <colgroup>
                     
                     <col
                       class="ix-table-col-selectable"
                     />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
-                    <col
-                      class=""
-                    />
+                    <col />
+                    <col />
+                    <col />
                     
                   </colgroup>
                   <tbody
@@ -1107,7 +1095,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
             <!---->
             <!---->
             <div
-              class="ix-table-container ix-table-scroll-vertical"
+              class="ix-table-container ix-table-fixed-layout ix-table-scroll-vertical"
             >
               
               <div
@@ -1122,9 +1110,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                     <col
                       class="ix-table-col-selectable"
                     />
-                    <col
-                      class=""
-                    />
+                    <col />
                     
                   </colgroup>
                   
@@ -1139,8 +1125,8 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <th
                         class="ix-table-cell ix-table-cell-selectable"
                       >
-                        <div
-                          class="ix-table-selectable"
+                        <span
+                          class="ix-table-cell-triggers"
                         >
                           <label
                             aria-checked="false"
@@ -1164,7 +1150,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                             <!---->
                           </label>
                           <!---->
-                        </div>
+                        </span>
                       </th>
                       <th
                         class="ix-table-cell"
@@ -1184,16 +1170,14 @@ exports[`ProTransfer > table transfer render work 1`] = `
               >
                 <table
                   class="ix-table-table"
-                  style="table-layout: auto;"
+                  style="table-layout: fixed;"
                 >
                   <colgroup>
                     
                     <col
                       class="ix-table-col-selectable"
                     />
-                    <col
-                      class=""
-                    />
+                    <col />
                     
                   </colgroup>
                   <tbody


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 设置 scroll.width 后，始终会出现滚动条
  - 原因是 body 的 col 也都设置了 width, 由于计算 MeasureCol  的宽度并不精确，会存在四舍五入的情况。
  - 导致 body 所有的列加起来的宽度超过了表格本身的宽度，然后出现滚动条。
 
## What is the new behavior?


## Other information
