### PR TITLE
fix(comp:*): overlay destory on hide caused popper position error

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -69,7 +69,13 @@ export default defineComponent({
     watch(popperOptions, options => update(options))
     watch(
       () => props.visible,
-      visible => (visible ? show() : hide()),
+      visible => {
+        visible ? show() : hide()
+
+        if (visible && props.destroyOnHide) {
+          initialize()
+        }
+      },
     )
     watch(
       contentArrowRef,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
overlay destroyOnHide 之后，popper不再计算位置

## What is the new behavior?
修复以上问题，在visible改变并且destroyOnHide 为true时重新初始化popper

## Other information
