### PR TITLE
fix(comp:cascader): set expandedKeys with default value

### DIFF
--- a/packages/components/cascader/src/Cascader.tsx
+++ b/packages/components/cascader/src/Cascader.tsx
@@ -78,6 +78,7 @@ export default defineComponent({
       mergedLabelKey,
       mergedFullPath,
       mergedDataMap,
+      selectedStateContext.selectedKeys,
     )
 
     watch(overlayOpened, opened => {

--- a/packages/components/cascader/src/composables/useExpandable.ts
+++ b/packages/components/cascader/src/composables/useExpandable.ts
@@ -7,6 +7,8 @@
 
 import { type ComputedRef, type Ref, type WritableComputedRef, ref } from 'vue'
 
+import { isNil } from 'lodash-es'
+
 import { type VKey, callEmit, useControlledProp } from '@idux/cdk/utils'
 import { type GetKeyFn } from '@idux/components/utils'
 
@@ -27,8 +29,19 @@ export function useExpandable(
   mergedLabelKey: ComputedRef<string>,
   mergedFullPath: ComputedRef<boolean>,
   mergedDataMap: ComputedRef<Map<VKey, MergedData>>,
+  selectedKeys: ComputedRef<VKey[]>,
 ): ExpandableContext {
-  const [expandedKeys, setExpandedKeys] = useControlledProp(props, 'expandedKeys', () => [])
+  const getDefaultExpandedKeys = (firstSelectedKey: VKey) => {
+    if (isNil(firstSelectedKey)) {
+      return []
+    }
+    const dataMap = mergedDataMap.value
+    const currData = dataMap.get(firstSelectedKey)
+    return getParentKeys(dataMap, currData, false)
+  }
+  const [expandedKeys, setExpandedKeys] = useControlledProp(props, 'expandedKeys', () =>
+    getDefaultExpandedKeys(selectedKeys.value[0]),
+  )
   const [loadedKeys, setLoadedKeys] = useControlledProp(props, 'loadedKeys', () => [])
   const loadingKeys = ref<VKey[]>([])
 


### PR DESCRIPTION
fix #1192

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

存在默认值的时候，打开面板没有展开对应的 option

## What is the new behavior?


## Other information
