### PR TITLE
fix(comp:*): overlay should be initialized before calling show

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -70,6 +70,7 @@ export default defineComponent({
       visible => {
         visible ? show() : hide()
       },
+      { flush: 'post' },
     )
     watch(
       contentArrowRef,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
受控模式下改变visible，内部调用show在初始化之前


## What is the new behavior?
调整初始化和show调用的内部顺序，保证show在初始化之后调用

## Other information
