### PR TITLE
fix(pro:table): the sorter should not be triggered on resize end

### DIFF
--- a/packages/pro/table/demo/Resizable.vue
+++ b/packages/pro/table/demo/Resizable.vue
@@ -61,6 +61,9 @@ const columns: ProTableColumn<Data>[] = [
     changeFixed: false,
     width: 100,
     resizable: true,
+    sortable: {
+      sorter: (curr, next) => curr.age - next.age,
+    },
   },
   {
     title: 'Address',

--- a/packages/pro/table/src/contents/ResizableHeadCell.tsx
+++ b/packages/pro/table/src/contents/ResizableHeadCell.tsx
@@ -5,31 +5,45 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { defineComponent, reactive, ref } from 'vue'
+import { defineComponent, reactive, ref, watch } from 'vue'
 
 import { CdkResizableHandle, type ResizableEvent, type ResizableOptions, useResizable } from '@idux/cdk/resize'
 import { callEmit } from '@idux/cdk/utils'
 
 export default defineComponent({
   // eslint-disable-next-line vue/require-prop-types
-  props: ['column', 'onResizeEnd'],
+  props: ['column', 'onClick', 'onResizeEnd'],
   setup(props, { slots }) {
     const elementRef = ref<HTMLDivElement>()
     const onResizeEnd: ResizableEvent = position => {
       callEmit(props.onResizeEnd, props.column.key, position.width)
     }
-
     const resizableOptions = reactive<ResizableOptions>({
       maxWidth: props.column.maxWidth,
       minWidth: props.column.minWidth,
       onResizeEnd,
     })
-
     const { resizing, position } = useResizable(elementRef, resizableOptions)
+
+    const canTriggerClick = ref(!resizing.value)
+    watch(resizing, value => {
+      if (value) {
+        canTriggerClick.value = false
+      } else {
+        // 拖拽结束的瞬间会触发 th 的 click 事件, 如果开启了 sortable, 就会触发排序
+        // 这里用 setTimeout 做一下延迟
+        setTimeout(() => (canTriggerClick.value = true))
+      }
+    })
+    const onClick = (evt: MouseEvent) => {
+      if (canTriggerClick.value) {
+        callEmit(props.onClick, evt)
+      }
+    }
 
     return () => {
       if (!props.column.resizable) {
-        return <th>{slots.default?.()}</th>
+        return <th onClick={onClick}>{slots.default?.()}</th>
       }
 
       const children = [<CdkResizableHandle placement="end" />]
@@ -38,7 +52,7 @@ export default defineComponent({
         children.push(<div class="cdk-resizable-preview" style={`width:${width}px;height:${height}px`}></div>)
       }
       return (
-        <th ref={elementRef}>
+        <th ref={elementRef} onClick={onClick}>
           {slots.default?.()}
           {children}
         </th>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 同时开始 sortable, resizable, 在拖拽结束时会触发排序

## What is the new behavior?


## Other information
