### PR TITLE
fix(comp:header): remove the default padding

### DIFF
--- a/packages/components/button/docs/Theme.zh.md
+++ b/packages/components/button/docs/Theme.zh.md
@@ -38,4 +38,4 @@
 | `@button-ghost-background-color-active` | `var(--ix-background-color)` | - | - |
 | `@button-ghost-background-color-disabled` | `rgba(255, 255, 255, 0.4)` | - | - |
 | `@button-icon-color` | `inherit` | `var(--ix-text-color-secondary)` | - |
-| `@button-icon-font-size` | `var(--ix-font-size-lg)` | - | - |
+| `@button-icon-font-size` | `var(--ix-font-size-icon)` | - | - |

--- a/packages/components/button/style/index.less
+++ b/packages/components/button/style/index.less
@@ -311,6 +311,7 @@
 }
 
 .@{button-prefix}-group {
+  align-items: center;
   line-height: 0;
 
   .@{button-prefix} {

--- a/packages/components/button/style/themes/default.variable.less
+++ b/packages/components/button/style/themes/default.variable.less
@@ -44,4 +44,4 @@
 @button-ghost-background-color-disabled: rgba(255, 255, 255, 0.4);
 
 @button-icon-color: inherit;
-@button-icon-font-size: var(--ix-font-size-lg);
+@button-icon-font-size: var(--ix-font-size-icon);

--- a/packages/components/header/style/index.less
+++ b/packages/components/header/style/index.less
@@ -61,6 +61,7 @@
 
   &-prefix,
   &-suffix {
+    display: inline-block;
     cursor: pointer;
 
     .@{icon-prefix} {
@@ -135,7 +136,6 @@
   font-size: @font-size;
   line-height: @line-height;
   min-height: @height;
-  padding: @padding 0;
 
   &.@{header-prefix}-with-bar {
     &::before {
@@ -146,5 +146,7 @@
 
   &.@{header-prefix}-with-description {
     min-height: calc(@height + 16px);
+    padding-top: @padding;
+    padding-bottom: @padding;
   }
 }

--- a/packages/site/src/styles/docs.less
+++ b/packages/site/src/styles/docs.less
@@ -9,9 +9,9 @@
       padding: 4px;
 
       .ix-button {
-        background-color: transparent;
         min-width: 64px;
-        border: none;
+        background-color: transparent;
+        border-color: transparent;
         border-radius: 16px;
 
         &.ix-radio-checked {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```html
  <IxHeader size="sm">
    Title
    <template #suffix>
      <IxButtonGroup :gap="8" size="xs">
        <IxButton icon="setting" @click="onSuffixClick" />
        <IxButton icon="setting" @click="onSuffixClick" />
        <IxButton icon="setting" @click="onSuffixClick" />
        <IxButton icon="menu" @click="onSuffixClick" />
      </IxButtonGroup>
    </template>
  </IxHeader>
```
上面这种情况会导致高度超过了 40px

## What is the new behavior?

- 移除了默认的 padding，依赖 display: flex, align-items: center 进行布局。

## Other information
