### PR TITLE
fix(pro:search): all tags should be displayed when focused

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -138,14 +138,14 @@ export default defineComponent({
           <div class={`${prefixCls}-input-container`} style={containerStyle.value}>
             <div class={`${prefixCls}-input-content`}>
               <ɵOverflow
-                v-show={!activeSegment.value}
+                v-show={!focused.value}
                 v-slots={overflowSlots}
                 prefixCls={prefixCls}
                 dataSource={searchItems.value}
                 getKey={item => item.key}
                 maxLabel={props.maxLabel}
               />
-              <div class={`${prefixCls}-search-item-container`} v-show={activeSegment.value}>
+              <div class={`${prefixCls}-search-item-container`} v-show={focused.value}>
                 {searchItems.value?.map(item => (
                   <SearchItemComp key={item.key} searchItem={item} />
                 ))}


### PR DESCRIPTION
overflowed tag shouldn't show when no segment is active under focused state

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
没有任何搜索项处于激活状态，且复合搜索组件处于聚焦状态时，溢出的标签没有展示


## What is the new behavior?
修复以上问题，即使没有任何搜索项处于激活状态，全部标签依然展示完全

## Other information
