### PR TITLE
fix(comp:table): align not work with selectable

### DIFF
--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -100,10 +100,18 @@
   &-cell-align {
     &-center {
       text-align: center;
+
+      .@{table-prefix}-cell-triggers {
+        justify-content: center;
+      }
     }
 
     &-end {
       text-align: end;
+
+      .@{table-prefix}-cell-triggers {
+        justify-content: end;
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://user-images.githubusercontent.com/25052421/205909948-2f939ae5-ed0d-4641-92a6-51622deea67c.png)

slectable 列的 align 设置对表头不生效

## What is the new behavior?


## Other information
