### PR TITLE
fix(comp:upload): customRequest allows optional and async

### DIFF
--- a/packages/components/upload/docs/Api.zh.md
+++ b/packages/components/upload/docs/Api.zh.md
@@ -16,7 +16,7 @@
 | `progress` | 进度条配置，见 [ProgressProps](/components/progress/zh#ProgressProps) | `ProgressProps` | - | - | - |
 | `name` | 发到后台的文件参数名 | `string` | `file` | ✅  | - |
 | `withCredentials` | 请求是否携带cookie | `boolean` | `false` | ✅ | - |
-| `customRequest` | 覆盖内置的上传行为，自定义上传实现 | `(option: UploadRequestOption) => { abort: () => void }` | 基于XMLHttpRequest实现  | - | - |
+| `customRequest` | 覆盖内置的上传行为，自定义上传实现 | `(option: UploadRequestOption) => Promise<UploadRequestHandler \| void> \| UploadRequestHandler \| void` | 基于XMLHttpRequest实现  | - | - |
 | `requestData` | 上传附加的参数  | `Record<string, unknown> \| ((file: UploadFile) => Record<string, unknown> \| Promise<Record<string, unknown>>)` | - | - | - |
 | `requestHeaders` | 设置上传请求的请求头  | `UploadRequestHeader` | -  | -  | -  |
 | `requestMethod` | 上传请求的http method | `UploadRequestMethod` | `post` | ✅ | - |

--- a/packages/components/upload/src/composables/useRequest.ts
+++ b/packages/components/upload/src/composables/useRequest.ts
@@ -105,7 +105,8 @@ export function useRequest(props: UploadProps, files: ComputedRef<UploadFile[]>)
       })
     setFileStatus(file, 'uploading', props.onFileStatusChange)
     file.percent = 0
-    aborts.set(file.key, uploadHttpRequest(requestOption)?.abort ?? (() => {}))
+    const requestHandler = await uploadHttpRequest(requestOption)
+    aborts.set(file.key, requestHandler?.abort ?? (() => {}))
     fileUploading.value.push(file)
   }
 

--- a/packages/components/upload/src/types.ts
+++ b/packages/components/upload/src/types.ts
@@ -18,6 +18,9 @@ export type UploadRequestStatus = 'loadstart' | 'progress' | 'abort' | 'error' |
 export type UploadFileStatus = 'selected' | 'cancel' | 'uploading' | 'error' | 'success' | 'abort'
 export type UploadFilesType = 'text' | 'image' | 'imageCard'
 export type UploadIconType = 'file' | 'preview' | 'download' | 'remove' | 'retry'
+export interface UploadRequestHandler {
+  abort?: () => void
+}
 export interface UploadProgressEvent extends ProgressEvent {
   percent?: number
 }
@@ -88,7 +91,9 @@ export const uploadProps = {
   },
   progress: Object as PropType<ProgressProps>,
   name: String,
-  customRequest: Function as PropType<(option: UploadRequestOption<any>) => { abort: () => void }>,
+  customRequest: Function as PropType<
+    (option: UploadRequestOption<any>) => Promise<UploadRequestHandler | void> | UploadRequestHandler | void
+  >,
   withCredentials: {
     type: Boolean,
     default: undefined,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

customRequest 不支持async，同时返回值类型强制要求包含`abort`，约束比较大

## What is the new behavior?

customRequest 支持async，返回值abort是可选的

![image](https://user-images.githubusercontent.com/17819018/206120736-93454e79-5bf6-4ea5-8b96-3592f8a0620f.png)


## Other information

@danranVm 