### PR TITLE
fix(pro:search): zIndex should be updated only when focused change

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -64,8 +64,7 @@ export default defineComponent({
       activeSegmentContext,
     )
 
-    //TODO: fix ref(true)
-    const currentZIndex = useZIndex(toRef(props, 'zIndex'), toRef(componentCommon, 'overlayZIndex'), ref(true))
+    const currentZIndex = useZIndex(toRef(props, 'zIndex'), toRef(componentCommon, 'overlayZIndex'), focused)
 
     const { initSearchStates, clearSearchState } = searchStateContext
     const { activeSegment } = activeSegmentContext


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
proSearch的z-index计算不正确，应当只在focused（即激活）时更新zIndex

## What is the new behavior?
渲染时就默认更新了zIndex，引发了渲染在弹窗开启之后而导致的zIndex异常
![image](https://user-images.githubusercontent.com/28892824/207495116-33cdd69f-96fa-48de-a631-d4572771b207.png)


## Other information
