### PR TITLE
fix(pro:search): searchItem mousedown doesn't trigger focused

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -98,6 +98,17 @@ export default defineComponent({
         zIndex: currentZIndex.value,
       }),
     )
+    const searchItemContainerStyle = computed(() => {
+      if (!focused.value) {
+        return normalizeStyle({
+          height: 0,
+          width: 0,
+          opacity: 0,
+        })
+      }
+
+      return undefined
+    })
 
     expose({ focus, blur })
 
@@ -167,7 +178,7 @@ export default defineComponent({
                 getKey={item => item.key}
                 maxLabel={props.maxLabel}
               />
-              <div class={`${prefixCls}-search-item-container`} v-show={focused.value}>
+              <div class={`${prefixCls}-search-item-container`} style={searchItemContainerStyle.value}>
                 {searchItems.value?.map(item => (
                   <SearchItemComp key={item.key} searchItem={item} />
                 ))}

--- a/packages/pro/search/src/composables/useFocusedState.ts
+++ b/packages/pro/search/src/composables/useFocusedState.ts
@@ -62,15 +62,20 @@ export function useFocusedState(
     setFocused(false)
   }
 
-  registerHandlers(elementRef, () => getContainerEl(commonOverlayProps.value.container), _handleFocus, handleBlur)
+  registerHandlers(elementRef, () => getContainerEl(commonOverlayProps.value), _handleFocus, handleBlur)
 
   return { focused, focus, blur }
 }
 
-function getContainerEl(containerProp: ɵOverlayProps['container']): HTMLElement | null {
-  const container = isFunction(containerProp) ? containerProp() : containerProp
+function getContainerEl(commonOverlayProps: ɵOverlayProps): HTMLElement | null {
+  const container = isFunction(commonOverlayProps.container)
+    ? commonOverlayProps.container()
+    : commonOverlayProps.container
+  const resolvedContainer = container ?? commonOverlayProps.containerFallback
 
-  return isString(container) ? document.querySelector(/^[.#]/.test(container) ? container : `.${container}`) : container
+  return isString(resolvedContainer)
+    ? document.querySelector(/^[.#]/.test(resolvedContainer) ? resolvedContainer : `.${resolvedContainer}`)
+    : resolvedContainer
 }
 
 function useFocusHandlers(

--- a/packages/pro/search/src/searchItem/SearchItem.tsx
+++ b/packages/pro/search/src/searchItem/SearchItem.tsx
@@ -54,7 +54,6 @@ export default defineComponent({
     const classes = computed(() => {
       return normalizeClass({
         [prefixCls.value]: true,
-        [`${prefixCls.value}-tag`]: !isActive.value,
         [`${prefixCls.value}-invalid`]: !!props.searchItem?.error,
       })
     })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
点击搜索项没有触发focus
overlayContainer的dom查找不正确

## What is the new behavior?
修复以上问题

## Other information
display:none导致元素内的focus事件不能正常触发，隐藏样式修改为使用 `height:0;width:0;opacity:0` 实现
加入了overlayContainerFallback之后没有调整overlay容器Dom获取计算