### PR TITLE
fix(comp:textarea):  lineheight error when not rendered initially

### DIFF
--- a/packages/components/textarea/__tests__/__snapshots__/textarea.spec.ts.snap
+++ b/packages/components/textarea/__tests__/__snapshots__/textarea.spec.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`Textarea > render work 1`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: vertical;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 1`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; line-height: -4px; height: 0px; overflow: hidden;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 1`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 2`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; line-height: -4px; height: 0px; overflow: hidden;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 2`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 3`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; line-height: -4px; height: 0px; overflow: hidden; max-height: -4px;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 3`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none;\\"></textarea><!----></span>"`;
 
-exports[`Textarea > resize and autoRows work 4`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none; line-height: -4px; height: 0px; overflow: hidden; max-height: -4px;\\"></textarea><!----></span>"`;
+exports[`Textarea > resize and autoRows work 4`] = `"<span class=\\"ix-textarea ix-textarea-md\\" data-count=\\"\\"><textarea class=\\"ix-textarea-inner\\" style=\\"resize: none;\\"></textarea><!----></span>"`;

--- a/packages/components/textarea/src/composables/useAutoRows.ts
+++ b/packages/components/textarea/src/composables/useAutoRows.ts
@@ -20,7 +20,7 @@ import { useLineHeight } from './useLineHeight'
 
 export interface AutoRowsContext {
   resizeToFitContent: (force?: boolean) => void
-  lineHeight: ComputedRef<number>
+  lineHeight: Ref<number>
   boxSizingData: ComputedRef<BoxSizingData>
 }
 

--- a/packages/pro/textarea/src/token.ts
+++ b/packages/pro/textarea/src/token.ts
@@ -15,7 +15,7 @@ export interface ProTextareaContext extends ErrorLinesContext {
   props: ProTextareaProps
   accessor: FormAccessor
   boxSizingData: ComputedRef<ɵBoxSizingData>
-  lineHeight: ComputedRef<number>
+  lineHeight: Ref<number>
   mergedPrefixCls: ComputedRef<string>
   rowCounts: ComputedRef<number[]>
   textareaRef: Ref<HTMLTextAreaElement | undefined>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
textarea元素如果在一开始未渲染，例如所属DOM树 display:none，lineheight计算为负数，且重新显示后不会重新计算

## What is the new behavior?
修复以上问题

## Other information
