### PR TITLE
fix(comp:tree): indeterminateKeys shouldn't check disabled state

### DIFF
--- a/packages/components/tree/src/composables/useCheckable.ts
+++ b/packages/components/tree/src/composables/useCheckable.ts
@@ -55,20 +55,15 @@ export function useCheckable(props: TreeProps, mergedNodeMap: ComputedRef<Map<VK
     }
 
     const indeterminateKeySet = new Set<VKey>()
-    const disabledKeys = checkDisabledKeys.value
     const nodeMap = mergedNodeMap.value
     _checkedKeys.forEach(key => {
       const { parentKey } = nodeMap.get(key) || {}
       if (!isNil(parentKey)) {
         let parent = nodeMap.get(parentKey)
         if (parent && !_checkedKeys.includes(parent.key)) {
-          if (!disabledKeys.includes(parentKey)) {
-            indeterminateKeySet.add(parentKey)
-          }
+          indeterminateKeySet.add(parentKey)
           while (parent && !isNil(parent.parentKey)) {
-            if (!disabledKeys.includes(parent.parentKey)) {
-              indeterminateKeySet.add(parent.parentKey)
-            }
+            indeterminateKeySet.add(parent.parentKey)
             parent = nodeMap.get(parent.parentKey)
           }
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树的半选状态在节点禁用状态下显示不正常

## What is the new behavior?
树的半选状态不应该和disabled相关联，无论是否禁用，半选状态都应该被计算

## Other information
