### PR TITLE
fix(comp:table): can't reverse select, when multiple of selectable is…

### DIFF
--- a/packages/components/_private/date-panel/__tests__/__snapshots__/datePanel.spec.ts.snap
+++ b/packages/components/_private/date-panel/__tests__/__snapshots__/datePanel.spec.ts.snap
@@ -632,12 +632,12 @@ exports[`DatePanel > year type disabledDate work 1`] = `
           </td>
         </tr>
         <tr role=\\"row\\" class=\\"ix-date-panel-row\\">
-          <td class=\\"ix-date-panel-cell ix-date-panel-cell-disabled ix-date-panel-cell-current\\" role=\\"gridcell\\">
+          <td class=\\"ix-date-panel-cell ix-date-panel-cell-disabled\\" role=\\"gridcell\\">
             <div class=\\"ix-date-panel-cell-inner\\">
               <div class=\\"ix-date-panel-cell-trigger\\">2022</div>
             </div>
           </td>
-          <td class=\\"ix-date-panel-cell\\" role=\\"gridcell\\">
+          <td class=\\"ix-date-panel-cell ix-date-panel-cell-current\\" role=\\"gridcell\\">
             <div class=\\"ix-date-panel-cell-inner\\">
               <div class=\\"ix-date-panel-cell-trigger\\">2023</div>
             </div>

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -214,7 +214,7 @@ function renderSelectableChildren(
   mergedPagination: ComputedRef<TablePagination | null>,
 ) {
   const { selected: checked, indeterminate, disabled, isHover, handleSelect: onChange } = props
-  const { showIndex, multiple, customCell } = selectable.value!
+  const { showIndex, multiple, customCell, trigger } = selectable.value!
 
   if (!checked && !isHover && showIndex) {
     return renderIndexableChildren(props, slots, config.columnIndexable as TableColumnIndexable, mergedPagination)
@@ -222,11 +222,22 @@ function renderSelectableChildren(
 
   const customRender = isString(customCell) ? slots[customCell] : customCell
   if (multiple) {
-    const checkboxProps = { checked, disabled, indeterminate, onChange, onClick }
-    return customRender ? customRender(checkboxProps) : <IxCheckbox {...checkboxProps}></IxCheckbox>
+    // 存在trigger时将事件代理到bodyCell进行处理
+    const exitTriggerCheckboxProps = { checked, disabled, indeterminate }
+    const checkboxProps = { ...exitTriggerCheckboxProps, onChange, onClick }
+    return customRender ? (
+      customRender(trigger ? exitTriggerCheckboxProps : checkboxProps)
+    ) : (
+      <IxCheckbox {...(trigger ? exitTriggerCheckboxProps : checkboxProps)}></IxCheckbox>
+    )
   } else {
-    const radioProps = { checked, disabled, onChange, onClick }
-    return customRender ? customRender(radioProps) : <IxRadio {...radioProps}></IxRadio>
+    const exitTriggerRadioProps = { checked, disabled }
+    const radioProps = { ...exitTriggerRadioProps, onChange, onClick }
+    return customRender ? (
+      customRender(radioProps)
+    ) : (
+      <IxRadio {...(trigger ? exitTriggerRadioProps : radioProps)}></IxRadio>
+    )
   }
 }
 

--- a/packages/pro/transfer/__tests__/proTransfer.spec.ts
+++ b/packages/pro/transfer/__tests__/proTransfer.spec.ts
@@ -143,19 +143,19 @@ describe('ProTransfer', () => {
       .findAll('tr:not(.ix-table-measure-row)')[0]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await sourceTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[1]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await sourceTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[2]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
 
     await appendTrigger.trigger('click')
     expect(onChange).toBeCalledWith([0, 1, 2, 3, 4, 5, 7], [0, 1, 2, 3, 4])
@@ -165,19 +165,19 @@ describe('ProTransfer', () => {
       .findAll('tr:not(.ix-table-measure-row)')[0]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await targetTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[1]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await targetTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[2]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await removeTrigger.trigger('click')
     expect(onChange).toBeCalledWith([1, 3, 4], [0, 1, 2, 3, 4])
   })
@@ -219,25 +219,25 @@ describe('ProTransfer', () => {
       .findAll('tr:not(.ix-table-measure-row)')[0]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await sourceTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[1]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await sourceTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[2]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
     await sourceTable
       .find('tbody')
       .findAll('tr:not(.ix-table-measure-row)')[3]
       .find('.ix-checkbox')
       .find('input')
-      .setValue(true)
+      .trigger('click')
 
     const [, targetTable] = wrapper.findAll('.ix-table')
 


### PR DESCRIPTION
… false

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
当设置了trigger后，可以通过点击每行其他列进行反选，但是没法点击 radio进行反选
![image](https://user-images.githubusercontent.com/26105153/210308227-cd361feb-bd41-4810-ae06-312c27326920.png)

## What is the new behavior?
可以进行反选

## Other information
