### PR TITLE
fix(comp:cascader): selected and expanded status is display incorrectly

### DIFF
--- a/packages/components/cascader/src/composables/useExpandable.ts
+++ b/packages/components/cascader/src/composables/useExpandable.ts
@@ -18,6 +18,7 @@ import { type MergedData, convertMergedData, convertMergedDataMap } from './useD
 
 export interface ExpandableContext {
   expandedKeys: ComputedRef<VKey[]>
+  setExpandedKeys: (value: VKey[]) => void
   handleExpand: (key: VKey) => void
   loadingKeys: Ref<VKey[]>
 }
@@ -104,5 +105,5 @@ export function useExpandable(
     callChange(mergedDataMap, newKeys, onExpandedChange)
   }
 
-  return { expandedKeys, handleExpand, loadingKeys }
+  return { expandedKeys, setExpandedKeys, handleExpand, loadingKeys }
 }

--- a/packages/components/cascader/src/contents/OverlayOption.tsx
+++ b/packages/components/cascader/src/contents/OverlayOption.tsx
@@ -7,6 +7,8 @@
 
 import { type PropType, Slot, computed, defineComponent, inject, normalizeClass } from 'vue'
 
+import { isNil } from 'lodash-es'
+
 import { IxCheckbox } from '@idux/components/checkbox'
 import { convertIconVNode, useKey } from '@idux/components/utils'
 
@@ -35,9 +37,10 @@ export default defineComponent({
       activeKey,
       setActiveKey,
       expandedKeys,
+      setExpandedKeys,
       setOverlayOpened,
       loadingKeys,
-      selectedKeys,
+      selectedWithStrategyKeys,
       selectedLimit,
       selectedLimitTitle,
       indeterminateKeys,
@@ -48,7 +51,7 @@ export default defineComponent({
     const isDisabled = computed(() => props.rawData.disabled)
     const isExpanded = computed(() => expandedKeys.value.includes(key))
     const isLoading = computed(() => loadingKeys.value.includes(key))
-    const isSelected = computed(() => selectedKeys.value.includes(key))
+    const isSelected = computed(() => selectedWithStrategyKeys.value.includes(key))
     const isIndeterminate = computed(() => indeterminateKeys.value.includes(key))
 
     const classes = computed(() => {
@@ -71,6 +74,9 @@ export default defineComponent({
         }
         handleSelect(key)
         setOverlayOpened(false)
+
+        // 如果一级节点是叶子节点，被点击后关闭所有展开的节点。
+        isNil(props.parentKey) && setExpandedKeys([])
       } else {
         cascaderProps.strategy === 'off' && handleSelect(key)
         cascaderProps.expandTrigger === 'click' && handleExpand(key)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- strategy 为 parent 或者 child 的时候，选中状态展示不正确
![image](https://user-images.githubusercontent.com/25052421/210532137-7c1cab3c-3ece-4742-a043-97eda68f3c08.png)

- 当某一个一级节点为叶子节点时，选中此节点后，展开状态没有被重置
![image](https://user-images.githubusercontent.com/25052421/210531846-da4ff22c-8f5e-474a-bde0-d21c0dbe7202.png)


## What is the new behavior?


## Other information
