### PR TITLE
fix(pro:search): overlay zIndex should be larger than container

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -137,6 +137,7 @@ export default defineComponent({
       locale: locale.search,
       mergedPrefixCls,
       commonOverlayProps,
+      focused,
 
       ...searchStateContext,
       ...activeSegmentContext,

--- a/packages/pro/search/src/searchItem/Segment.tsx
+++ b/packages/pro/search/src/searchItem/Segment.tsx
@@ -32,7 +32,7 @@ export default defineComponent({
   props: segmentProps,
   setup(props: SegmentProps) {
     const context = inject(proSearchContext)!
-    const { mergedPrefixCls, commonOverlayProps, activeSegment, searchStates, setActiveSegment } = context
+    const { mergedPrefixCls, commonOverlayProps, focused, activeSegment, searchStates, setActiveSegment } = context
     const overlayRef = ref<ɵOverlayInstance>()
     const segmentInputRef = ref<HTMLInputElement>()
     const measureSpanRef = ref<HTMLSpanElement>()
@@ -59,7 +59,7 @@ export default defineComponent({
     const isActive = computed(
       () => activeSegment.value?.itemKey === props.itemKey && activeSegment.value.name === props.segment.name,
     )
-    const overlayOpened = computed(() => isActive.value && !!activeSegment.value?.overlayOpened)
+    const overlayOpened = computed(() => focused.value && isActive.value && !!activeSegment.value?.overlayOpened)
 
     const inputWidth = useInputWidth(measureSpanRef)
     const inputStyle = computed(() => ({
@@ -170,12 +170,8 @@ export default defineComponent({
       ></input>
     )
 
-    const renderContent = () => {
-      if (!overlayOpened.value) {
-        return
-      }
-
-      const renderedContent = props.segment.panelRenderer?.({
+    const renderContent = () =>
+      props.segment.panelRenderer?.({
         input: props.input ?? '',
         value: props.value,
         cancel: handleCancel,
@@ -183,9 +179,6 @@ export default defineComponent({
         setValue: handleChange,
         setOnKeyDown: setPanelOnKeyDown,
       })
-
-      return renderedContent
-    }
 
     return () => {
       const { panelRenderer } = props.segment

--- a/packages/pro/search/src/token.ts
+++ b/packages/pro/search/src/token.ts
@@ -21,6 +21,7 @@ export interface ProSearchContext extends SearchStateContext, ActiveSegmentConte
   locale: ProSearchLocale
   mergedPrefixCls: ComputedRef<string>
   commonOverlayProps: ComputedRef<ɵOverlayProps>
+  focused: ComputedRef<boolean>
 }
 
 export interface SearchItemContext extends SegmentOverlayUpdateContext, SegmentStatesContext {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
从非聚焦状态下直接点击搜索项，搜索项浮层的z-index计算会先于输入框，导致搜索项浮层被遮盖

## What is the new behavior?
修复以上问题

## Other information
