### PR TITLE
fix(comp:tree): correct param `checked` of `onCheck`

### DIFF
--- a/packages/components/tree/src/composables/useCheckable.ts
+++ b/packages/components/tree/src/composables/useCheckable.ts
@@ -80,14 +80,15 @@ export function useCheckable(props: TreeProps, mergedNodeMap: ComputedRef<Map<VK
     const cascaderEnabled = cascaderStrategy !== 'off'
     const childrenKeys = cascaderEnabled ? getChildrenKeys(node, disabledKeys) : []
     const index = allCheckedKeys.value.indexOf(currKey)
-    const checked = index > -1
+
     let tempKeys = [...allCheckedKeys.value]
 
-    if (
-      checked ||
-      (childrenKeys.length &&
+    const checked =
+      index > -1 ||
+      (!!childrenKeys.length &&
         childrenKeys.every(key => tempKeys.includes(key) || indeterminateKeys.value.includes(key)))
-    ) {
+
+    if (checked) {
       const parentKeys = cascaderEnabled ? getParentKeys(nodeMap, node, disabledKeys) : []
       tempKeys.splice(index, 1)
       tempKeys = tempKeys.filter(key => !parentKeys.includes(key) && !childrenKeys.includes(key))


### PR DESCRIPTION
`checked` should  be the state of check operation instead of state of node

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
节点处于半选状态时，onCheck 的 `checked` 参数 始终是 true

## What is the new behavior?
onCheck 的 `checked` 参数应当为当前操作的状态，即使节点处于半选状态, `checked` 也应当变化

## Other information
