### PR TITLE
fix(pro:transfer): overide transfer tree node selected bg color

### DIFF
--- a/packages/pro/transfer/style/index.less
+++ b/packages/pro/transfer/style/index.less
@@ -72,8 +72,27 @@
         }
       }
     }
-    .@{tree-node-prefix} {
+    &.@{tree-prefix}-blocked .@{tree-node-prefix} {
       transition: none;
+      background-color: @pro-transfer-list-background-color;
+      &:hover {
+        background-color: @pro-transfer-list-item-hover-color;
+        &-content {
+          background-color: @pro-transfer-list-item-hover-color;
+        }
+      }
+      &-content {
+        background-color: @pro-transfer-list-background-color;
+        transition: none;
+      }
+
+      &-active:not(&-disabled),
+      &-selected:not(&-disabled) {
+        background-color: @pro-transfer-list-background-color;
+        &:hover {
+          background-color: @pro-transfer-list-item-hover-color;
+        }
+      }
     }
     &-close-icon {
       padding: @pro-transfer-tree-close-icon-padding;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树穿梭框的节点选中之后（不是勾选，是点击）背景颜色不正常

![image](https://user-images.githubusercontent.com/28892824/212051516-1439079e-9594-4d23-b87e-18e098005b80.png)



## What is the new behavior?
内部覆盖掉选中样式解决以上问题

## Other information
右边的删除图标背景是必须的，在存在横向滚动时删除图标固定在右边，需要背景颜色遮挡下方文字