### PR TITLE
fix(pro:transfer): optimize tree expanded keys sync logic

### DIFF
--- a/packages/pro/transfer/src/composables/useTreeExpandedKeys.ts
+++ b/packages/pro/transfer/src/composables/useTreeExpandedKeys.ts
@@ -41,7 +41,9 @@ export function useTreeExpandedKeys<V extends TreeTransferData<V, C>, C extends 
   ) => {
     const processExpandedKey = (key: VKey) => {
       if (expandedKeysSource.has(key)) {
-        !expandedKeysTarget.has(key) && expandedKeysTarget.add(key)
+        expandedKeysTarget.add(key)
+      } else if (remove) {
+        expandedKeysTarget.delete(key)
       }
     }
 
@@ -57,8 +59,6 @@ export function useTreeExpandedKeys<V extends TreeTransferData<V, C>, C extends 
         processExpandedKey(getKey.value(item))
       })
     }
-
-    remove && expandedKeysSource.delete(key)
   }
 
   watch(targetKeySet, (keys, oldKeys) => {
@@ -77,10 +77,10 @@ export function useTreeExpandedKeys<V extends TreeTransferData<V, C>, C extends 
     const newSourceExpandedKeySet = new Set<VKey>(sourceExpandedKeySet.value)
 
     deletedKeySet?.forEach(key => {
-      syncSelectedExpandedState(key, newTargetExpandedKeySet, newSourceExpandedKeySet, true)
+      syncSelectedExpandedState(key, newTargetExpandedKeySet, newSourceExpandedKeySet, false)
     })
     newKeySet?.forEach(key => {
-      syncSelectedExpandedState(key, newSourceExpandedKeySet, newTargetExpandedKeySet, props.mode !== 'immediate')
+      syncSelectedExpandedState(key, newSourceExpandedKeySet, newTargetExpandedKeySet, true)
     })
 
     setTargetExpandedKeys(Array.from(newTargetExpandedKeySet))


### PR DESCRIPTION
removed targert expaneded keys shouldn't be synced to source

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树穿梭框，收起目标列表的某个节点之后，删除该节点， 源列表对应的节点也被收起来

## What is the new behavior?
expandedKeys 从目标列表到源列表的同步仅仅同步添加的key, 删除的key不同步

## Other information
