### PR TITLE
fix(pro:table): width calculation problem after resize

### DIFF
--- a/packages/components/table/src/utils/index.ts
+++ b/packages/components/table/src/utils/index.ts
@@ -37,19 +37,16 @@ export function getColTitle(
 }
 
 export function getColumnKey(column: TableColumn): VKey {
-  if (column.key) {
-    return column.key
+  if ('key' in column) {
+    return column.key!
   }
-  // @ts-ignore
-  if (column.dataKey) {
-    // @ts-ignore
+  if ('dataKey' in column) {
     return convertArray(column.dataKey).join('-')
   }
-  // @ts-ignore
-  if (column.type) {
-    // @ts-ignore
+  if ('type' in column) {
     return `__IDUX_table_column_key_${column.type}`
   }
+
   __DEV__ &&
     Logger.warn(
       'components/table',

--- a/packages/pro/table/demo/Resizable.md
+++ b/packages/pro/table/demo/Resizable.md
@@ -7,11 +7,10 @@ title:
 
 ## zh
 
-可以通过配置 `resizable`，开启拖拽调整列宽，还可以配置 `maxWidth` `minWidth` 来限制列宽的范围。  
+可以通过配置 `resizable`，开启拖拽调整列宽，请尽可能的给一个非百分比初始的宽度(`column.width`)，还可以配置 `maxWidth` `minWidth` 来限制列宽的范围。  
 如果发现设置 `scroll.width` 后无法出现横向滚动条，拖拽一列后导致其他列变得过窄，请对未设置 `width` 的列设置一个 `minWidth`.
 
 ## en
 
-Column width can be adjusted by configuring `resizable`, enabling drag and drop, and column width can be limited by configuring `maxWidth` and `minWidth`.
-
+You can enable drag and drop to adjust column width by setting `resizable`, giving a non-percentage initial column width as much as possible . You can also setting `maxWidth` and `minWidth` to limit the range of column width.  
 If you find that setting `scroll.width` does not allow horizontal scrollbar to appear, and dragging one column causes the other columns to become too narrow, set a `minWidth` for the column that is not set `width`.

--- a/packages/pro/table/demo/Resizable.vue
+++ b/packages/pro/table/demo/Resizable.vue
@@ -50,7 +50,7 @@ const columns: ProTableColumn<Data>[] = [
     dataKey: 'name',
     changeFixed: false,
     customCell: 'name',
-    width: 150,
+    width: 100,
     minWidth: 100,
     maxWidth: 300,
     resizable: true,
@@ -69,14 +69,14 @@ const columns: ProTableColumn<Data>[] = [
     title: 'Address',
     dataKey: 'address',
     changeFixed: false,
-    width: 400,
-    minWidth: 200,
+    width: 200,
+    minWidth: 100,
     resizable: true,
   },
   {
     title: 'Tags',
     dataKey: 'tags',
-    minWidth: 200,
+    width: 200,
     customCell: ({ value }) =>
       value.map((tag: string) => {
         let color = tag.length > 5 ? 'warning' : 'success'

--- a/packages/pro/table/docs/Api.zh.md
+++ b/packages/pro/table/docs/Api.zh.md
@@ -44,7 +44,7 @@ export type ProTableColumn<T = any, V = any, CT = 'input'> =
 | --- | --- | --- | --- | --- | --- |
 | `maxWidth` | 列的最大宽度 | `number` | - | - | - |
 | `minWidth` | 列的最小宽度 | `number` | - | - | - |
-| `resizable` | 是否开启列宽调整 | `boolean` | `false` | - | - |
+| `resizable` | 是否开启列宽调整 | `boolean` | `false` | - | 如果设为 `true`, 请同时设置一个非百分比的 `column.width` |
 
 ##### ProTableColumnBase
 

--- a/packages/pro/table/src/composables/useResizable.ts
+++ b/packages/pro/table/src/composables/useResizable.ts
@@ -7,22 +7,51 @@
 
 import { type ComputedRef, computed } from 'vue'
 
-import { type VKey } from '@idux/cdk/utils'
+import { isString } from 'lodash-es'
+
+import { type VKey, convertNumber } from '@idux/cdk/utils'
 
 import { type ColumnsContext } from './useColumns'
 
 export interface ResizableContext {
   hasResizable: ComputedRef<boolean>
-  onResizeEnd: (key: VKey, width: number) => void
+  onResizeEnd: (key: VKey, width: number, offsetWidth: number) => void
 }
 
 export function useResizable({ mergedColumns, setMergedColumns, mergedColumnMap }: ColumnsContext): ResizableContext {
   const hasResizable = computed(() => mergedColumns.value.some(column => column.resizable))
 
-  const onResizeEnd = (key: VKey, width: number) => {
+  const onResizeEnd = (key: VKey, width: number, offsetWidth: number) => {
     const targetColumn = mergedColumnMap.value.get(key)
-    if (targetColumn) {
+    if (!targetColumn) {
+      return
+    }
+    /**
+     * 拖拽宽度计算规则
+     *
+     * * 如果不存在原始的 column.width, 则直接将拖拽后的宽度赋值给 column.width
+     * * 如果存在原始的 column.width, 则需要按比例进行计算: (原始宽度 * 拖拽后段都) / 当前真实渲染的宽度
+     * * * 同时需要判断是否存在 minWidth, maxWidth，应满足 minWidth < 计算后的宽度 < maxWidth
+     */
+    const originalWidth = targetColumn.width
+    const originalWidthNumber = isString(originalWidth) ? convertNumber(originalWidth.replace('px', '')) : originalWidth
+    if (!originalWidthNumber) {
       targetColumn.width = width
+    } else {
+      const renderWidth = width - offsetWidth
+      const newWidth = Math.floor(((originalWidthNumber * width) / renderWidth) * 1000) / 1000
+      const { minWidth, maxWidth } = targetColumn
+      const minWidthNumber = isString(minWidth) ? convertNumber(minWidth.replace('px', '')) : minWidth
+      const maxWidthNumber = isString(maxWidth)
+        ? convertNumber(maxWidth.replace('px', ''), Number.MAX_SAFE_INTEGER)
+        : maxWidth
+      if (minWidthNumber && newWidth < minWidthNumber) {
+        targetColumn.width = minWidthNumber
+      } else if (maxWidthNumber && newWidth > maxWidthNumber) {
+        targetColumn.width = maxWidthNumber
+      } else {
+        targetColumn.width = newWidth
+      }
     }
     setMergedColumns([...mergedColumns.value])
   }

--- a/packages/pro/table/src/contents/ResizableHeadCell.tsx
+++ b/packages/pro/table/src/contents/ResizableHeadCell.tsx
@@ -16,7 +16,7 @@ export default defineComponent({
   setup(props, { slots }) {
     const elementRef = ref<HTMLDivElement>()
     const onResizeEnd: ResizableEvent = position => {
-      callEmit(props.onResizeEnd, props.column.key, position.width)
+      callEmit(props.onResizeEnd, props.column.key, position.width, position.offsetWidth)
     }
     const resizableOptions = reactive<ResizableOptions>({
       maxWidth: props.column.maxWidth,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 在表格实际渲染宽度超过了 scroll.width 的时候，每一列都会被放大
  - 例如本身设置的宽度是 80 ，实际渲染成了 200，缩放了 2.5 倍
  - 如果此时通过拖拽拉到了 150px, 经过缩放后实际渲染成了 350px
  - 就会出现用户拖拽缩小宽度，但是反而增大了的宽度的异常情况。

## What is the new behavior?


    /**
     * 拖拽宽度计算规则
     *
     * * 如果不存在原始的 column.width, 则直接将拖拽后的宽度赋值给 column.width
     * * 如果存在原始的 column.width, 则需要按比例进行计算: (原始宽度 * 拖拽后段都) / 当前真实渲染的宽度
     * * * 同时需要判断是否存在 minWidth, maxWidth，应满足 minWidth < 计算后的宽度 < maxWidth
     */

## Other information
