### PR TITLE
fix(pro:tree): expandAll button state is wrong

### DIFF
--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -146,6 +146,10 @@ export default defineComponent({
       return mergedNodeMap.value.get(key)?.rawNode
     }
 
+    const _getFlattedNodes = () => {
+      return flattedNodes.value
+    }
+
     expose({
       focus,
       blur,
@@ -153,6 +157,9 @@ export default defineComponent({
       collapseAll: expandableContext.collapseAll,
       scrollTo,
       getNode,
+
+      // private
+      _getFlattedNodes,
     })
 
     const handleScrolledChange = (startIndex: number, endIndex: number, visibleNodes: MergedNode[]) => {

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -127,6 +127,9 @@ export interface TreeBindings<K = VKey> {
    * @returns node
    */
   getNode: (key: K) => TreeNode<K> | undefined
+
+  //private
+  _getFlattedNodes: () => MergedNode[]
 }
 export type TreeComponent = DefineComponent<Omit<HTMLAttributes, keyof TreePublicProps> & TreePublicProps, TreeBindings>
 export type TreeInstance = InstanceType<DefineComponent<TreeProps, TreeBindings>>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
展开/收起按钮的状态内部是写死的，没有根据当前节点的展开状态实时变化

## What is the new behavior?
只要当存在一个展开节点时，按钮的状态为收起全部

![GIF 2023-1-18 15-54-09](https://user-images.githubusercontent.com/26105153/213114636-47c94773-2677-4821-99d1-acdc603487a6.gif)


## Other information
