### PR TITLE
fix(comp:select): blur event make span render bad

### DIFF
--- a/packages/components/_private/selector/src/composables/useInputState.ts
+++ b/packages/components/_private/selector/src/composables/useInputState.ts
@@ -40,10 +40,6 @@ export function useInputState(props: SelectorProps, mergedSearchable: ComputedRe
   }
 
   const handleBlur = (evt: FocusEvent) => {
-    if (props.allowInput && !props.multiple) {
-      props.value[0] = inputValue.value
-      inputValue.value = ''
-    }
     isFocused.value = false
     callEmit(props.onBlur, evt)
   }

--- a/packages/components/_private/selector/src/composables/useInputState.ts
+++ b/packages/components/_private/selector/src/composables/useInputState.ts
@@ -40,6 +40,10 @@ export function useInputState(props: SelectorProps, mergedSearchable: ComputedRe
   }
 
   const handleBlur = (evt: FocusEvent) => {
+    if (props.allowInput && !props.multiple) {
+      props.value[0] = inputValue.value
+      inputValue.value = ''
+    }
     isFocused.value = false
     callEmit(props.onBlur, evt)
   }

--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -107,7 +107,13 @@ export default defineComponent({
       }
     }
 
-    const handleBlur = () => accessor.markAsBlurred()
+    const handleBlur = () => {
+      if (props.allowInput && inputValue.value) {
+        changeSelected(inputValue.value)
+        clearInput()
+      }
+      accessor.markAsBlurred()
+    }
     const handleItemRemove = (value: VKey) => {
       focus()
       handleRemove(value)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?

## What is the new behavior?

## Other information
fix #1431

正常显示：
![image](https://user-images.githubusercontent.com/82451257/214636136-8bb42cb2-01c2-476f-86f7-1423124209d0.png)

错误显示：
![image](https://user-images.githubusercontent.com/82451257/214636397-347d247d-49cb-41ea-8126-5288218a61af.png)

可以发现，错误显示的原因就是没有渲染 ix-selector-item 这个盒子

![image](https://user-images.githubusercontent.com/82451257/214636761-eef0f1b5-e4b6-4ad1-8dfd-729b4c90fa69.png)

错误情况下丢失焦点，inputValue.value 是有的，所以 !inputValue.value 就为 false，导致 item 没有渲染
