### PR TITLE
fix(comp:select): call blur after 'enter' envent

### DIFF
--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -87,6 +87,7 @@ export default defineComponent({
       handleRemove,
       clearInput,
       setOverlayOpened,
+      blur,
     )
 
     watch(overlayOpened, opened => {

--- a/packages/components/select/src/composables/useKeyboardEvents.ts
+++ b/packages/components/select/src/composables/useKeyboardEvents.ts
@@ -20,6 +20,7 @@ export function useKeyboardEvents(
   handleRemove: (key: VKey) => void,
   clearInput: () => void,
   setOverlayOpened: (opened: boolean) => void,
+  blur: () => void | undefined,
 ): (evt: KeyboardEvent) => void {
   return (evt: KeyboardEvent) => {
     switch (evt.code) {
@@ -36,7 +37,10 @@ export function useKeyboardEvents(
         const key = activeValue.value
         !isNil(key) && changeSelected(key)
         clearInput()
-        !isMultiple.value && setOverlayOpened(false)
+        if (!isMultiple.value) {
+          setOverlayOpened(false)
+          blur()
+        }
         break
       }
       case 'Backspace': {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 在可输入模式下，输入内容后，按下回车键，会保存输入的内容。
- 再一次按下回车键，会把内容重置为第一个选项的值。

![select](https://user-images.githubusercontent.com/25052421/218040914-1479211b-1fef-48ab-b9d6-d47b29084225.gif)

## What is the new behavior?

- 单选模式下，按下回车后，触发 blur 事件，来规避上面的问题。


## Other information
