### PR TITLE
fix(comp:transfer): select all status error

### DIFF
--- a/packages/components/transfer/src/composables/useTransferSelectState.ts
+++ b/packages/components/transfer/src/composables/useTransferSelectState.ts
@@ -59,29 +59,35 @@ export function useTransferSelectState(
     getKey,
   } = transferDataContext
 
-  const sourceDataCount = computed(() =>
-    props.mode === 'immediate' ? dataKeyMap.value.size : sourceDataKeys.value.size,
-  )
-  const targetDataCount = computed(() => targetDataKeys.value.size)
   const sourceCheckableDataCount = computed(() => {
+    const sourceDataCount = props.mode === 'immediate' ? dataKeyMap.value.size : sourceDataKeys.value.size
     const disabledCount = props.mode === 'immediate' ? disabledKeys.value.size : disabledSourceKeys.value.size
 
-    return sourceDataCount.value - disabledCount
+    return sourceDataCount - disabledCount
   })
   const targetCheckableDataCount = computed(() => targetDataKeys.value.size - disabledTargetKeys.value.size)
 
-  const sourceSelectAllStatus = computed(() => {
+  const getAllSelectedStatus = (isSource: boolean) => {
+    const allSelectedKeys = transferDataStrategy.value.getAllSelectedKeys(
+      true,
+      isSource ? (props.mode === 'immediate' ? dataSource.value : sourceData.value) : targetData.value,
+      new Set(),
+      new Set(),
+      getKey.value,
+    )
+    const selectedkeyCount = (isSource ? sourceSelectedKeys : targetSelectedKeys).value.length
+    const selectedKeySet = isSource ? sourceSelectedKeySet.value : targetSelectedKeySet.value
+
     return {
-      checked: sourceDataCount.value >= sourceSelectedKeys.value.length && sourceSelectedKeys.value.length > 0,
-      indeterminate: sourceDataCount.value > sourceSelectedKeys.value.length && sourceSelectedKeys.value.length > 0,
+      checked: selectedkeyCount > 0,
+      indeterminate:
+        (allSelectedKeys.length !== selectedkeyCount || allSelectedKeys.some(key => !selectedKeySet.has(key))) &&
+        selectedkeyCount > 0,
     }
-  })
-  const targetSelectAllStatus = computed(() => {
-    return {
-      checked: targetDataCount.value >= targetSelectedKeys.value.length && targetSelectedKeys.value.length > 0,
-      indeterminate: targetDataCount.value > targetSelectedKeys.value.length && targetSelectedKeys.value.length > 0,
-    }
-  })
+  }
+
+  const sourceSelectAllStatus = computed(() => getAllSelectedStatus(true))
+  const targetSelectAllStatus = computed(() => getAllSelectedStatus(false))
 
   let transferBySelectionChangeLocked = false
   watch(sourceSelectedKeySet, (currentCheckedKeys, originalCheckedKeys) => {


### PR DESCRIPTION
`getAllSelectedKeys` in dataStrategy should be used to calculate select all status

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
级联策略为 `'children'` 时，全选之后勾选状态还是半选

## What is the new behavior?
修复以上问题

## Other information
