### PR TITLE
fix(pro:transfer): tree transfer count error under `children` strategy

### DIFF
--- a/packages/cdk/utils/src/tree.ts
+++ b/packages/cdk/utils/src/tree.ts
@@ -63,7 +63,7 @@ export function mapTree<V extends TreeTypeData<V, C>, R extends object, C extend
 export function filterTree<V extends TreeTypeData<V, C>, C extends keyof V>(
   data: V[],
   childrenKey: C,
-  filterFn: (item: V, parents: V[]) => boolean,
+  filterFn: (item: V, parents: V[], filteredChildren: V[] | undefined) => boolean,
   filterStrategy: 'and' | 'or' = 'or',
 ): V[] {
   const filter = (_data: V[], parents: V[]): V[] => {
@@ -76,7 +76,7 @@ export function filterTree<V extends TreeTypeData<V, C>, C extends keyof V>(
         children = filter(item[childrenKey]!, [item, ...parents])
       }
 
-      let itemValid = filterFn(item, parents)
+      let itemValid = filterFn(item, parents, children)
       const childrenValid = (children && children.length > 0) || (!item[childrenKey]?.length && itemValid)
 
       itemValid = filterStrategy === 'and' ? childrenValid && itemValid : childrenValid || itemValid


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树穿梭框在级联策略 `'children'` 下，由于选中的数量只计算了叶子节点，全选之后待选数量仍然不为0，计算不正确
 
## What is the new behavior?
修复以上问题

## Other information
