### PR TITLE
feat(pro:search): `select` and `treeSelect` support `onSearch` now

### DIFF
--- a/packages/pro/search/demo/RemoteSearch.md
+++ b/packages/pro/search/demo/RemoteSearch.md
@@ -1,0 +1,14 @@
+---
+order: 42
+title:
+  zh: 服务端搜索
+  en: Server-side searching
+---
+
+## zh
+
+`'select'`，`'treeSelect'` 类型搜索项支持服务端搜索。
+
+## en
+
+Server-side searching is supported under field type of `'select'`, `'treeSelect'`.

--- a/packages/pro/search/demo/RemoteSearch.vue
+++ b/packages/pro/search/demo/RemoteSearch.vue
@@ -1,0 +1,126 @@
+<template>
+  <IxProSearch
+    v-model:value="value"
+    style="width: 100%"
+    :searchFields="searchFields"
+    :onChange="onChange"
+    :onSearch="onSearch"
+  ></IxProSearch>
+</template>
+
+<script setup lang="ts">
+import type { SearchField, SearchValue } from '@idux/pro/search'
+
+import { computed, ref } from 'vue'
+
+import { filterTree } from '@idux/cdk/utils'
+
+interface SelectData {
+  key: number
+  label: string
+}
+interface TreeSelectData {
+  key: string
+  label: string
+  children?: TreeSelectData[]
+}
+
+const labels = ['Archer', 'Berserker', 'Lancer', 'Rider', 'Saber', 'Caster', 'Assassin']
+const baseSelectData: SelectData[] = Array.from(new Array(50)).map((_, idx) => {
+  const label = `${labels[idx % labels.length]}-${Math.ceil(idx / labels.length)}`
+
+  return {
+    key: idx,
+    label,
+  }
+})
+const baseTreeSelectData: TreeSelectData[] = Array.from(new Array(20)).map((_, idx) => {
+  const label = labels[idx % labels.length]
+
+  return {
+    key: `${idx}`,
+    label: `${label} ${idx}`,
+    children: [
+      {
+        label: `${label} ${idx}-0`,
+        key: `${idx}-0`,
+        children: [
+          {
+            label: `${label} ${idx}-0-0`,
+            key: `${idx}-0-0`,
+          },
+          {
+            label: `${label} ${idx}-0-1`,
+            key: `${idx}-0-1`,
+          },
+        ],
+      },
+      {
+        label: `${label} ${idx}-1`,
+        key: `${idx}-1`,
+        children: [
+          { label: `${label} ${idx}-1-0`, key: `${idx}-1-0` },
+          { label: `${label} ${idx}-1-1`, key: `${idx}-1-1` },
+        ],
+      },
+    ],
+  }
+})
+const createSelectData = (searchValue: string) => {
+  return baseSelectData.filter(item => new RegExp(searchValue.toLowerCase()).test(item.label.toLowerCase()))
+}
+const createTreeSelectData = (searchValue: string) => {
+  return filterTree(baseTreeSelectData, 'children', item =>
+    new RegExp(searchValue.toLowerCase()).test(item.label.toLowerCase()),
+  )
+}
+
+const value = ref<SearchValue[]>()
+const selectData = ref<SelectData[]>(createSelectData(''))
+const treeSelectData = ref<TreeSelectData[]>(createTreeSelectData(''))
+
+const selectOnSearch = (searchValue: string) => {
+  selectData.value = createSelectData(searchValue)
+}
+const treeSelectOnSearch = (searchValue: string) => {
+  treeSelectData.value = createTreeSelectData(searchValue)
+}
+
+const searchFields = computed<SearchField[]>(() => [
+  {
+    type: 'select',
+    label: 'Select Data',
+    key: 'Select Data',
+    fieldConfig: {
+      multiple: true,
+      searchable: true,
+      dataSource: selectData.value,
+      searchFn: () => true,
+      onSearch: selectOnSearch,
+    },
+  },
+  {
+    type: 'treeSelect',
+    label: 'Tree Data',
+    key: 'tree_data',
+    fieldConfig: {
+      multiple: true,
+      searchable: true,
+      checkable: true,
+      cascaderStrategy: 'all',
+      dataSource: treeSelectData.value,
+      searchFn: () => true,
+      onSearch: treeSelectOnSearch,
+    },
+  },
+])
+
+const onChange = (value: SearchValue[] | undefined, oldValue: SearchValue[] | undefined) => {
+  console.log(value, oldValue)
+}
+const onSearch = () => {
+  console.log('onSearch')
+}
+</script>
+
+<style scoped lang="less"></style>

--- a/packages/pro/search/docs/Api.zh.md
+++ b/packages/pro/search/docs/Api.zh.md
@@ -99,6 +99,7 @@ SelectSearchFieldConfig
 | `showSelectAll` | 是否支持全选 | `boolean` | `true` | - | - |
 | `virtual` | 是否支持虚拟滚动 | `boolean` | `false` | - | 默认不支持 |
 | `overlayItemWidth` | 选项宽度 | `number` | - | - | - |
+| `onSearch` | 搜索回调函数 | `(searchValue: string) => void | ((searchValue: string) => void)[]` | - | - | 在触发搜索值改变时执行 |
 
 > 注：使用 `Ctrl + Enter` 在多选下切换面板中选项选中状态
 
@@ -140,6 +141,7 @@ TreeSelectSearchFieldConfig
 | `onDrop` | `drop` 触发时调用 | `(options: TreeDragDropOptions<any>) => void | ((options: TreeDragDropOptions<any>) => void)[]` | - | - | 详情参考[Tree](/components/tree/zh) |
 | `onExpand` | 点击展开图标时触发 | `(expanded: boolean, node: TreeSelectPanelData) => void | ((expanded: boolean, node: TreeSelectPanelData) => void)[]` | - | - | 详情参考[Tree](/components/tree/zh) |
 | `onSelect` | 选中状态发生变化时触发 | `(selected: boolean, node: TreeSelectPanelData) => void | ((selected: boolean, node: TreeSelectPanelData) => void)[]` | - | - | 详情参考[Tree](/components/tree/zh) |
+| `onSearch` | 搜索回调函数 | `(searchValue: string) => void | ((searchValue: string) => void)[]` | - | - | 在触发搜索值改变时执行 |
 | `onLoaded` | 子节点加载完毕时触发 | `(loadedKeys: any[], node: TreeSelectPanelData) => void | ((loadedKeys: any[], node: TreeSelectPanelData) => void)[]` | - | - | 详情参考[Tree](/components/tree/zh) |
 
 ```typescript

--- a/packages/pro/search/src/composables/useSearchItem.ts
+++ b/packages/pro/search/src/composables/useSearchItem.ts
@@ -43,6 +43,7 @@ export function useSearchItems(
         key: searchState.key,
         optionKey: searchState.fieldKey,
         error: searchItemErrors.value?.find(error => error.index === searchState.index),
+        searchField,
         segments: searchState.segmentValues
           .map(segmentValue => {
             if (segmentValue.name === 'name') {

--- a/packages/pro/search/src/panel/TreeSelectPanel.tsx
+++ b/packages/pro/search/src/panel/TreeSelectPanel.tsx
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { type ComputedRef, computed, defineComponent, inject } from 'vue'
+import { type ComputedRef, computed, defineComponent, inject, onUnmounted, watch } from 'vue'
 
 import { isFunction } from 'lodash-es'
 
@@ -27,6 +27,18 @@ export default defineComponent({
         return 'off'
       }
       return props.cascaderStrategy
+    })
+
+    watch(
+      () => props.searchValue,
+      searchValue => {
+        callEmit(props.onSearch, searchValue ?? '')
+      },
+    )
+    onUnmounted(() => {
+      if (props.searchValue) {
+        callEmit(props.onSearch, '')
+      }
     })
 
     const { expandedKeys, setExpandedKeys } = useExpandedKeys(props)

--- a/packages/pro/search/src/searchItem/SearchItem.tsx
+++ b/packages/pro/search/src/searchItem/SearchItem.tsx
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { computed, defineComponent, inject, provide, watch } from 'vue'
+import { computed, defineComponent, inject, provide } from 'vue'
 
 import SearchItemTag from './SearchItemTag'
 import Segment from './Segment'
@@ -20,9 +20,13 @@ export default defineComponent({
   setup(props) {
     const context = inject(proSearchContext)!
     const { props: proSearchProps, mergedPrefixCls, activeSegment } = context
-    const segmentStateContext = useSegmentStates(props, proSearchProps, context)
+
+    const isActive = computed(() => activeSegment.value?.itemKey === props.searchItem!.key)
+    const itemVisible = computed(() => isActive.value && !proSearchProps.disabled)
+
+    const segmentStateContext = useSegmentStates(props, proSearchProps, context, isActive)
     const segmentOverlayUpdateContext = useSegmentOverlayUpdate()
-    const { segmentStates, initSegmentStates } = segmentStateContext
+    const { segmentStates } = segmentStateContext
 
     provide(searchItemContext, {
       ...segmentStateContext,
@@ -36,18 +40,10 @@ export default defineComponent({
         const segmentState = segmentStates.value[segment.name]
         return {
           ...segment,
-          input: segmentState.input,
-          value: segmentState.value,
+          input: segmentState?.input,
+          value: segmentState?.value,
         }
       })
-    })
-
-    const isActive = computed(() => activeSegment.value?.itemKey === props.searchItem!.key)
-    const itemVisible = computed(() => isActive.value && !proSearchProps.disabled)
-    watch(isActive, active => {
-      if (!active) {
-        initSegmentStates()
-      }
     })
 
     return () => (

--- a/packages/pro/search/src/segments/CreateNameSegment.tsx
+++ b/packages/pro/search/src/segments/CreateNameSegment.tsx
@@ -10,7 +10,7 @@ import type { PanelRenderContext, SearchField, Segment } from '../types'
 import { type VKey, convertArray } from '@idux/cdk/utils'
 
 import SelectPanel from '../panel/SelectPanel'
-import { filterSelectDataSourceByInput } from '../utils/selectData'
+import { filterDataSource, matchRule } from '../utils/selectData'
 
 export const defaultNameSegmentEndSymbol = ':'
 
@@ -26,7 +26,7 @@ export function createNameSegment(
       setValue(value[0])
       ok()
     }
-    const filteredDataSource = filterSelectDataSourceByInput(names, getRawInput(input))
+    const filteredDataSource = filterDataSource(names, nameOption => matchRule(nameOption.label, getRawInput(input)))
     if (!filteredDataSource?.length) {
       return
     }

--- a/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
@@ -41,6 +41,7 @@ export function createTreeSelectSegment(
       onDrop,
       onExpand,
       onSelect,
+      onSearch,
       onLoaded,
     },
     defaultValue,
@@ -58,11 +59,8 @@ export function createTreeSelectSegment(
   const panelRenderer = (context: PanelRenderContext<VKey | VKey[] | undefined>) => {
     const { input, value, setValue, ok, cancel } = context
     const panelValue = convertArray(value)
-    const lastInputPart = input
-      .trim()
-      .split(separator ?? defaultSeparator)
-      .pop()
-      ?.trim()
+    const inputParts = input.trim().split(separator ?? defaultSeparator)
+    const lastInputPart = inputParts.length > panelValue.length ? inputParts.pop()?.trim() : ''
 
     const handleChange = (value: VKey[]) => {
       if (!multiple) {
@@ -76,7 +74,7 @@ export function createTreeSelectSegment(
     return (
       <TreeSelectPanel
         value={panelValue}
-        searchValue={searchable && lastInputPart && !nodeLabelMap.has(lastInputPart) ? lastInputPart : undefined}
+        searchValue={searchable && lastInputPart ? lastInputPart : undefined}
         dataSource={dataSource}
         draggable={draggable}
         draggableIcon={draggableIcon}
@@ -95,6 +93,7 @@ export function createTreeSelectSegment(
         onDrop={onDrop}
         onExpand={onExpand}
         onSelect={onSelect}
+        onSearch={onSearch}
         onLoaded={onLoaded}
         onChange={handleChange}
         onConfirm={ok}

--- a/packages/pro/search/src/types/panels.ts
+++ b/packages/pro/search/src/types/panels.ts
@@ -27,19 +27,21 @@ export const proSearchSelectPanelProps = {
   multiple: { type: Boolean, default: false },
   showSelectAll: { type: Boolean, default: true },
   allSelected: Boolean,
-  virtual: { type: Boolean, default: false },
+  searchValue: { type: String, default: undefined },
+  searchFn: Function as PropType<(data: SelectPanelData, searchValue?: string) => boolean>,
   setOnKeyDown: Function as PropType<(onKeyDown: ((evt: KeyboardEvent) => boolean) | undefined) => void>,
+  virtual: { type: Boolean, default: false },
 
-  onChange: Function as PropType<(value: VKey[]) => void>,
-  onSelectAllClick: Function as PropType<() => void>,
-  onConfirm: Function as PropType<() => void>,
-  onCancel: Function as PropType<() => void>,
+  onChange: [Function, Array] as PropType<MaybeArray<(value: VKey[]) => void>>,
+  onConfirm: [Function, Array] as PropType<MaybeArray<() => void>>,
+  onCancel: [Function, Array] as PropType<MaybeArray<() => void>>,
+  onSearch: [Function, Array] as PropType<MaybeArray<(searchValue: string) => void>>,
+  onSelectAllClick: [Function, Array] as PropType<MaybeArray<() => void>>,
 } as const
 export type ProSearchSelectPanelProps = ExtractInnerPropTypes<typeof proSearchSelectPanelProps>
 
 export const proSearchTreeSelectPanelProps = {
   value: { type: Array as PropType<VKey[]>, default: undefined },
-  searchValue: { type: String, default: undefined },
   dataSource: { type: Array as PropType<TreeSelectPanelData[]>, default: undefined },
   multiple: { type: Boolean, default: false },
   checkable: { type: Boolean, default: false },
@@ -56,6 +58,7 @@ export const proSearchTreeSelectPanelProps = {
   },
   leafLineIcon: { type: String, default: undefined },
   showLine: { type: Boolean, default: undefined },
+  searchValue: { type: String, default: undefined },
   searchFn: Function as PropType<(node: TreeSelectPanelData, searchValue?: string) => boolean>,
   virtual: { type: Boolean, default: false },
 
@@ -72,6 +75,7 @@ export const proSearchTreeSelectPanelProps = {
   onDrop: [Function, Array] as PropType<MaybeArray<(options: TreeDragDropOptions<any>) => void>>,
   onExpand: [Function, Array] as PropType<MaybeArray<(expanded: boolean, node: TreeSelectPanelData) => void>>,
   onSelect: [Function, Array] as PropType<MaybeArray<(selected: boolean, node: TreeSelectPanelData) => void>>,
+  onSearch: [Function, Array] as PropType<MaybeArray<(searchValue: string) => void>>,
   onLoaded: [Function, Array] as PropType<MaybeArray<(loadedKeys: any[], node: TreeSelectPanelData) => void>>,
 } as const
 export type ProSearchTreeSelectPanelProps = ExtractInnerPropTypes<typeof proSearchTreeSelectPanelProps>

--- a/packages/pro/search/src/types/searchFields.ts
+++ b/packages/pro/search/src/types/searchFields.ts
@@ -39,7 +39,8 @@ export interface SelectSearchField extends SearchFieldBase<VKey | VKey[]> {
     separator?: string
     showSelectAll?: boolean
     virtual?: boolean
-    searchFn?: (data: SelectPanelData, searchText: string) => boolean
+    searchFn?: (data: SelectPanelData, searchText?: string) => boolean
+    onSearch?: MaybeArray<(searchValue: string) => void>
     overlayItemWidth?: number
   }
 }
@@ -68,6 +69,7 @@ export interface TreeSelectSearchField extends SearchFieldBase<VKey | VKey[]> {
     onDrop?: MaybeArray<(options: TreeDragDropOptions<any>) => void>
     onExpand?: MaybeArray<(expanded: boolean, node: TreeSelectPanelData) => void>
     onSelect?: MaybeArray<(selected: boolean, node: TreeSelectPanelData) => void>
+    onSearch?: MaybeArray<(searchValue: string) => void>
     onLoaded?: MaybeArray<(loadedKeys: any[], node: TreeSelectPanelData) => void>
   }
 }

--- a/packages/pro/search/src/types/searchItem.ts
+++ b/packages/pro/search/src/types/searchItem.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
+import type { SearchField } from './searchFields'
 import type { SearchValue } from './searchValue'
 import type { Segment } from './segment'
 import type { ExtractInnerPropTypes, VKey } from '@idux/cdk/utils'
@@ -26,6 +27,7 @@ export interface SearchItem {
   key: VKey
   optionKey?: VKey
   error?: SearchItemError
+  searchField: SearchField
   segments: Segment[]
 }
 

--- a/packages/pro/search/src/utils/selectData.ts
+++ b/packages/pro/search/src/utils/selectData.ts
@@ -8,7 +8,7 @@
 import type { SelectPanelData } from '../types'
 import type { VKey } from '@idux/cdk/utils'
 
-import { isNil } from 'lodash-es'
+import { isNil, toString } from 'lodash-es'
 
 export function getSelectDataSourceKeys(dataSource: SelectPanelData[]): VKey[] {
   const keys = []
@@ -66,22 +66,6 @@ export function filterDataSource(
   return filteredData
 }
 
-export function filterSelectDataSourceByInput(
-  dataSource: SelectPanelData[],
-  input: string | undefined,
-  searchFn?: (data: SelectPanelData, searchText: string) => boolean,
-): SelectPanelData[] {
-  if (!input) {
-    return dataSource
-  }
-
-  const filterFn = searchFn
-    ? (option: SelectPanelData) => searchFn(option, input.trim())
-    : (option: SelectPanelData) => matchRule(option.label, input.trim())
-
-  return filterDataSource(dataSource, filterFn)
-}
-
-function matchRule(srcString: string | number | undefined, targetString: string): boolean {
-  return !isNil(srcString) && String(srcString).toLowerCase().includes(targetString.toLowerCase())
+export function matchRule(srcString: string | number | undefined, targetString: string): boolean {
+  return !isNil(srcString) && toString(srcString).toLowerCase().includes(targetString.toLowerCase())
 }


### PR DESCRIPTION
add `onSearch` for to make server-side searching possible

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当前复合搜索的 `select` 和 `treeSelect` 无法实现服务端搜索

## What is the new behavior?
增加 fieldConfig 中的 `onSearch` 属性，支持搜索值改变后修改dataSource，以支持服务端搜索
增加相关 demo

## Other information
