### PR TITLE
fix(pro:search): `treeSelect` panel height is unset

### DIFF
--- a/packages/pro/search/src/panel/TreeSelectPanel.tsx
+++ b/packages/pro/search/src/panel/TreeSelectPanel.tsx
@@ -118,7 +118,7 @@ export default defineComponent({
         expandedKeys: expandedKeys.value,
         expandIcon: expandIcon,
         getKey: 'key',
-        autoHeight: true,
+        height: 256,
         loadChildren,
         leafLineIcon,
         virtual,


### PR DESCRIPTION
add `height` prop and fix it to `256` so that `treeSelect` panel wont be too high

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
`treeSelect` 类型面板没有设置高度，会导致超长


## What is the new behavior?
暂时固定高度为 `256px`，和目前的 `select` 面板一致，后续考虑是否要增加可配置

## Other information
