### PR TITLE
fix(pro:search): remove transition for overlay

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -58,7 +58,7 @@ export default defineComponent({
       searchItems,
       searchStateContext.tempSearchStateAvailable,
     )
-    const commonOverlayProps = useCommonOverlayProps(props, config, componentCommon, mergedPrefixCls)
+    const commonOverlayProps = useCommonOverlayProps(props, config, mergedPrefixCls)
     const { focused, focus, blur } = useFocusedState(
       props,
       elementRef,

--- a/packages/pro/search/src/composables/useCommonOverlayProps.ts
+++ b/packages/pro/search/src/composables/useCommonOverlayProps.ts
@@ -8,7 +8,6 @@
 import { type ComputedRef, computed } from 'vue'
 
 import { type ɵOverlayProps } from '@idux/components/_private/overlay'
-import { type CommonConfig } from '@idux/components/config'
 import { type ProSearchConfig } from '@idux/pro/config'
 
 import { type ProSearchProps } from '../types'
@@ -16,14 +15,12 @@ import { type ProSearchProps } from '../types'
 export function useCommonOverlayProps(
   props: ProSearchProps,
   config: ProSearchConfig,
-  componentCommonConfig: CommonConfig,
   mergedPrefixCls: ComputedRef<string>,
 ): ComputedRef<ɵOverlayProps> {
   return computed(() => ({
     container: props.overlayContainer ?? config.overlayContainer,
     containerFallback: `.${mergedPrefixCls.value}-overlay-container`,
     placement: 'bottomStart',
-    transitionName: `${componentCommonConfig.prefixCls}-slide-auto`,
     offset: [0, 4],
   }))
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
由于复合搜索的某一个输入框在非激活状态时会隐藏，转换为标签显示，浮层对应的trigger位置会有改变，这时浮层收起的动画显示位置会不正确


## What is the new behavior?
暂时去掉复合搜索的浮层动画

## Other information
