### PR TITLE
fix(comp:carousel): when scaled, the component layout error

### DIFF
--- a/packages/components/carousel/src/composables/useStrategy.ts
+++ b/packages/components/carousel/src/composables/useStrategy.ts
@@ -7,7 +7,7 @@
 
 import type { CarouselProps } from '../types'
 
-import { type ComputedRef, onMounted, ref, watch } from 'vue'
+import { type ComputedRef, type Ref, onMounted, ref, watch } from 'vue'
 
 import { useResizeObserver } from '@idux/cdk/resize'
 import { callEmit, convertElement, useState } from '@idux/cdk/utils'
@@ -46,7 +46,9 @@ export function useStrategy(
     if (!carouselElement) {
       return
     }
-    const { width, height } = carouselElement.getBoundingClientRect()
+
+    const width = carouselElement.offsetWidth
+    const height = carouselElement.offsetHeight
 
     setUnitWidth(width)
     setUnitHeight(height)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
当组件scale（大于1 或者 小于1）后，组件布局错误
```
<template>
  <IxCarousel class="wrapper">
    <div class="card-item">远看泰山黑糊糊</div>
    <div class="card-item">上头细来下头粗</div>
    <div class="card-item">如把泰山倒过来</div>
    <div class="card-item">下头细来上头粗</div>
  </IxCarousel>
</template>

<style lang="less" scoped>
.wrapper {
  transform: scale(1.5);
}
.card-item {
  height: 160px;
  line-height: 160px;
  background-color: #364d79;
  text-align: center;
  font-size: 16px;
  color: #fff;
}
</style>
```


## What is the new behavior?

组件可以正常显示

## Other information
