### PR TITLE
fix(comp:carousel): when items is dynamically reduced to 1, layout error

### DIFF
--- a/packages/cdk/utils/src/dom.ts
+++ b/packages/cdk/utils/src/dom.ts
@@ -11,6 +11,8 @@ import { isString } from 'lodash-es'
 
 export type EventTarget = HTMLElement | Document | Window | null | undefined
 
+export type Dimensions = { [key in 'width' | 'height']: number }
+
 export function on<K extends keyof HTMLElementEventMap>(
   el: EventTarget,
   type: K | undefined,
@@ -151,4 +153,24 @@ export function getMouseEvent(evt: MouseEvent | TouchEvent): MouseEvent | Touch 
 export function getMouseClientXY(evt: MouseEvent | TouchEvent): { clientX: number; clientY: number } {
   const { clientX, clientY } = getMouseEvent(evt)
   return { clientX, clientY }
+}
+
+export function getCssDimensions(element: HTMLElement): Dimensions & { fallback: boolean } {
+  const css = getComputedStyle(element)
+  let width = parseFloat(css.width)
+  let height = parseFloat(css.height)
+  const offsetWidth = element.offsetWidth
+  const offsetHeight = element.offsetHeight
+  const shouldFallback = Math.round(width) !== offsetWidth || Math.round(height) !== offsetHeight
+
+  if (shouldFallback) {
+    width = offsetWidth
+    height = offsetHeight
+  }
+
+  return {
+    width,
+    height,
+    fallback: shouldFallback,
+  }
 }

--- a/packages/components/carousel/__tests__/carousel.spec.ts
+++ b/packages/components/carousel/__tests__/carousel.spec.ts
@@ -130,4 +130,24 @@ describe('Carousel', () => {
     await wrapper.find('.ix-carousel-slider-track').trigger('transitionend')
     expect(onChange).toHaveBeenCalledTimes(1)
   })
+
+  test('goTo, next, prev work', async () => {
+    const wrapper = CarouselMount()
+
+    expect(wrapper.findAll('.ix-carousel-dot')[0].classes()).toContain('ix-carousel-dot-active')
+
+    await wrapper.vm.goTo(1)
+
+    expect(wrapper.findAll('.ix-carousel-dot')[1].classes()).toContain('ix-carousel-dot-active')
+
+    await wrapper.find('.ix-carousel-slider-track').trigger('transitionend')
+    await wrapper.vm.next()
+
+    expect(wrapper.findAll('.ix-carousel-dot')[2].classes()).toContain('ix-carousel-dot-active')
+
+    await wrapper.find('.ix-carousel-slider-track').trigger('transitionend')
+    await wrapper.vm.prev()
+
+    expect(wrapper.findAll('.ix-carousel-dot')[1].classes()).toContain('ix-carousel-dot-active')
+  })
 })

--- a/packages/components/carousel/src/composables/useStrategy.ts
+++ b/packages/components/carousel/src/composables/useStrategy.ts
@@ -10,7 +10,7 @@ import type { CarouselProps } from '../types'
 import { type ComputedRef, type Ref, onMounted, ref, watch } from 'vue'
 
 import { useResizeObserver } from '@idux/cdk/resize'
-import { callEmit, convertElement, useState } from '@idux/cdk/utils'
+import { callEmit, convertElement, getCssDimensions, useState } from '@idux/cdk/utils'
 
 export interface StrategyContext {
   activeIndex: Ref<number>
@@ -47,8 +47,7 @@ export function useStrategy(
       return
     }
 
-    const width = carouselElement.offsetWidth
-    const height = carouselElement.offsetHeight
+    const { width, height } = getCssDimensions(carouselElement)
 
     setUnitWidth(width)
     setUnitHeight(height)
@@ -78,7 +77,7 @@ export function useStrategy(
     const lastSliderElement = convertElement(sliderRefs.value[length - 1])
 
     if (
-      length <= 1 ||
+      length < 1 ||
       runningIndex.value !== -1 ||
       index === activeIndex.value ||
       !sliderTrackElement ||


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
```
<template>
  <IxCarousel>
    <div v-for="page in pageSizes">
      <div class="card-item">远看泰山黑糊糊</div>
    </div>
  </IxCarousel>
  <IxButton @click="pageSizes = 1">减少数量</IxButton>
</template>

<script lang="ts" setup>
import { ref } from 'vue'

const pageSizes = ref(3)

</script>

<style lang="less" scoped>
.card-item {
  height: 160px;
  line-height: 160px;
  background-color: #364d79;
  text-align: center;
  font-size: 16px;
  color: #fff;
}
</style>
```
![GIF 2023-2-16 16-42-50](https://user-images.githubusercontent.com/26105153/219313165-c96459d1-cbf0-4e24-aafd-f46f0581e3d5.gif)


## What is the new behavior?

![GIF 2023-2-16 16-44-09](https://user-images.githubusercontent.com/26105153/219313450-bb783b18-803c-452d-936b-93dedd8b9764.gif)

## Other information
新增`getCssDimensions`精确获取元素宽高

