### PR TITLE
style(comp:collapse): modify expand icon size

### DIFF
--- a/packages/components/collapse/docs/Theme.zh.md
+++ b/packages/components/collapse/docs/Theme.zh.md
@@ -2,6 +2,8 @@
 | --- | --- | --- | --- |
 | `@collapse-font-size-sm` | `var(--ix-font-size-sm)` | - | - |
 | `@collapse-font-size-md` | `var(--ix-font-size-md)` | `var(--ix-font-size-sm)` | - |
+| `@collapse-expand-icon-font-size-sm` | `var(--ix-font-size-xl)` | - | - |
+| `@collapse-expand-icon-font-size-md` | `var(--ix-font-size-2xl)` | - | - |
 | `@collapse-padding-horizontal-sm` | `var(--ix-spacing-md)` | - | - |
 | `@collapse-padding-horizontal-md` | `var(--ix-spacing-lg)` | - | - |
 | `@collapse-border` | `1px solid var(--ix-border-color)` | - | - |

--- a/packages/components/collapse/src/CollapsePanel.tsx
+++ b/packages/components/collapse/src/CollapsePanel.tsx
@@ -51,8 +51,19 @@ export default defineComponent({
 
     return () => {
       const expanded = isExpanded.value
-      const headerNode = renderHeader(props, slots, collapseSlots, key, mergedSize, expanded, expandIcon, handleClick)
       const prefixCls = mergedPrefixCls.value
+      const headerNode = renderHeader(
+        props,
+        slots,
+        prefixCls,
+        collapseSlots,
+        key,
+        mergedSize,
+        expanded,
+        expandIcon,
+        handleClick,
+      )
+
       return (
         <div class={classes.value}>
           {headerNode}
@@ -70,6 +81,7 @@ export default defineComponent({
 function renderHeader(
   props: CollapsePanelProps,
   slots: Slots,
+  prefixCls: string,
   collapseSlots: Slots,
   key: VKey,
   mergedSize: ComputedRef<CollapseSize>,
@@ -88,7 +100,9 @@ function renderHeader(
     }
   } else {
     const iconName = expandIcon.value
-    iconNode = iconName ? <IxIcon name={iconName} rotate={expanded ? 90 : 0} /> : undefined
+    iconNode = iconName ? (
+      <IxIcon class={`${prefixCls}-expand-icon`} name={iconName} rotate={expanded ? 90 : 0} />
+    ) : undefined
   }
   const headerSlots = iconNode ? { prefix: () => iconNode } : undefined
   const { header, disabled } = props

--- a/packages/components/collapse/style/index.less
+++ b/packages/components/collapse/style/index.less
@@ -5,7 +5,7 @@
   .reset-color();
 
   &-sm {
-    .collapse-size(@collapse-font-size-sm, @collapse-padding-horizontal-sm);
+    .collapse-size(@collapse-font-size-sm, @collapse-expand-icon-font-size-sm, @collapse-padding-horizontal-sm);
 
     .@{collapse-prefix}-panel {
       border-bottom: none;
@@ -22,7 +22,7 @@
   }
 
   &-md {
-    .collapse-size(@collapse-font-size-md, @collapse-padding-horizontal-md);
+    .collapse-size(@collapse-font-size-md, @collapse-expand-icon-font-size-md, @collapse-padding-horizontal-md);
 
     .@{collapse-prefix}-panel + .@{collapse-prefix}-panel {
       margin-top: var(--ix-spacing-sm);
@@ -51,6 +51,10 @@
       .@{header-prefix} {
         cursor: not-allowed;
       }
+    }
+
+    & &-expand-icon {
+      display: block;
     }
   }
 
@@ -88,12 +92,16 @@
   }
 }
 
-.collapse-size(@font-size, @padding-horizontal) {
+.collapse-size(@font-size, @expand-icon-font-size, @padding-horizontal) {
   .reset-font-size(@font-size);
 
   .@{header-prefix} {
     padding-left: @padding-horizontal;
     padding-right: @padding-horizontal;
+  }
+
+  .@{header-prefix} .@{collapse-prefix}-panel-expand-icon {
+    font-size: @expand-icon-font-size;
   }
 
   .@{collapse-prefix}-panel-content-box {

--- a/packages/components/collapse/style/themes/default.variable.less
+++ b/packages/components/collapse/style/themes/default.variable.less
@@ -1,6 +1,9 @@
 @collapse-font-size-sm: var(--ix-font-size-sm);
 @collapse-font-size-md: var(--ix-font-size-md);
 
+@collapse-expand-icon-font-size-sm: var(--ix-font-size-xl);
+@collapse-expand-icon-font-size-md: var(--ix-font-size-2xl);
+
 @collapse-padding-horizontal-sm: var(--ix-spacing-md);
 @collapse-padding-horizontal-md: var(--ix-spacing-lg);
 


### PR DESCRIPTION
add class to expand icon and modify its font-size for all sizes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
折叠面板展开收起按钮大小同header的前后缀大小一致为16px

## What is the new behavior?
修改为：
md: 24px
sm: 20px

## Other information
展开收起按钮图标新添加 class，修改为display：fix，解决居中问题