### PR TITLE
fix(comp:upload): upload list card status text isn't centered

### DIFF
--- a/packages/components/upload/demo/Dragable.vue
+++ b/packages/components/upload/demo/Dragable.vue
@@ -28,5 +28,10 @@ const files = ref([])
   &-icon {
     font-size: 24px;
   }
+
+  p {
+    font-size: 14px;
+    margin: 8px 0 0 0;
+  }
 }
 </style>

--- a/packages/components/upload/style/list.less
+++ b/packages/components/upload/style/list.less
@@ -179,11 +179,13 @@
 
       .@{upload-prefix}-status {
         color: @color-graphite-base;
+        text-align: center;
+        padding: @spacing-xs;
         min-width: @upload-list-image-card-status-min-width;
 
         .@{idux-prefix}-progress {
           display: flex;
-          margin-top: @upload-list-image-card-status-progress-margin;
+          margin: @upload-list-image-card-status-progress-margin;
         }
       }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 上传列表卡片的文字不居中
2. 上传列表卡片的进度条margin关键字错误
3. 拖拽上传的demo不符合规范

## What is the new behavior?
修复以上问题

## Other information
