### PR TITLE
fix(pro:search): change proSearch overlay vertical offset to 8px

### DIFF
--- a/packages/pro/search/src/composables/useCommonOverlayProps.ts
+++ b/packages/pro/search/src/composables/useCommonOverlayProps.ts
@@ -21,6 +21,6 @@ export function useCommonOverlayProps(
     container: props.overlayContainer ?? config.overlayContainer,
     containerFallback: `.${mergedPrefixCls.value}-overlay-container`,
     placement: 'bottomStart',
-    offset: [0, 4],
+    offset: [0, 8],
   }))
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?

## What is the new behavior?
修改浮层垂直offset为 8px， 使最下方的浮层会落在输入框的下面，不覆盖

## Other information
视觉检视问题