### PR TITLE
fix(pro:tree): tree content horizontal padding

### DIFF
--- a/packages/pro/tree/style/index.less
+++ b/packages/pro/tree/style/index.less
@@ -53,6 +53,7 @@
   .@{tree-prefix} {
     flex: 1;
     height: 0;
+    padding: @pro-tree-content-vertical-spacing @pro-tree-content-horizontal-spacing;
 
     &.@{tree-prefix}-blocked {
       .@{tree-prefix}-node {

--- a/packages/pro/tree/style/themes/default.variable.less
+++ b/packages/pro/tree/style/themes/default.variable.less
@@ -8,6 +8,9 @@
 @pro-tree-header-wrapper-icon-font-size: @font-size-lg;
 @pro-tree-header-wrapper-icon-hover-color: @color-primary;
 @pro-tree-header-wrapper-height: 38px;
+@pro-tree-content-horizontal-spacing: 12px;
+@pro-tree-content-vertical-spacing: 0;
+
 @pro-tree-divider-horizontal-spacing: @pro-tree-header-search-wrapper-horizontal-spacing;
 @pro-tree-divider-vertical-spacing: 8px;
 @pro-tree-node-padding: 0 0 0 8px;


### PR DESCRIPTION
tree content horizontal padding should be consistent with header and customizable

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
ProTree的内容区域padding和头部不一致，导致后缀和悬浮背景边界没有和头部文字对齐


## What is the new behavior?
添加内容区域padding样式

## Other information
