### PR TITLE
fix(comp:alert): alert icon should always be aligned top

### DIFF
--- a/packages/components/alert/style/index.less
+++ b/packages/components/alert/style/index.less
@@ -3,12 +3,13 @@
 
 .@{alert-prefix} {
   .reset-component-new();
-  .reset-font-size();
 
+  @line-height: calc(var(--ix-font-size) + var(--ix-line-height-gutter));
+
+  font-size: var(--ix-font-size);
+  line-height: @line-height;
   display: flex;
-  align-items: center;
-  min-height: @alert-height;
-  padding: 0 8px;
+  padding: calc((@alert-height - @line-height - 2px) / 2) 8px;
   border: 1px solid transparent;
   border-radius: @alert-border-radius;
 
@@ -19,7 +20,7 @@
   .alert-status-color(offline, @alert-offline-color, @alert-offline-background-color);
 
   &-banner {
-    padding: 0 16px;
+    padding: calc((@alert-height - @line-height - 2px) / 2) 16px;
     border-bottom-color: @alert-banner-border-color;
   }
 
@@ -52,16 +53,10 @@
     .reset-font-size();
   }
 
-  &-with-description {
+  &-with-description &-title {
     .reset-font-size(calc(var(--ix-font-size) + 2px));
 
-    align-items: baseline;
-    padding-top: 6px;
-    padding-bottom: 6px;
-
-    .@{alert-prefix}-title {
-      margin-bottom: 4px;
-    }
+    margin-bottom: 4px;
   }
 
   &-pagination {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
alert 的 title 超长换行之后，icon垂直居中展示

## What is the new behavior?
icon应当始终在顶部

## Other information
取消min-height，并且调整组件的上下padding始终为4px，此时单行文字高度为32px