### PR TITLE
fix(pro:search): panel onkeydown should only be called when opened

### DIFF
--- a/packages/pro/search/src/searchItem/Segment.tsx
+++ b/packages/pro/search/src/searchItem/Segment.tsx
@@ -167,7 +167,7 @@ export default defineComponent({
       handleMouseDown,
       handleKeyDown,
       setPanelOnKeyDown,
-    } = useInputEvents(props, context, handleSegmentInput, setCurrentAsActive, handleConfirm)
+    } = useInputEvents(props, context, overlayOpened, handleSegmentInput, setCurrentAsActive, handleConfirm)
 
     const overlayProps = useOverlayAttrs(props, mergedPrefixCls, commonOverlayProps, overlayOpened)
 
@@ -263,6 +263,7 @@ interface InputEventHandlers {
 function useInputEvents(
   props: SegmentProps,
   context: ProSearchContext,
+  overlayOpened: ComputedRef<boolean>,
   handleSegmentInput: (name: string, input: string) => void,
   setCurrentAsActive: (overlayOpened: boolean) => void,
   confirm: () => void,
@@ -302,15 +303,20 @@ function useInputEvents(
     setCurrentAsActive(true)
   }
   const handleKeyDown = (evt: KeyboardEvent) => {
-    const paneKeyDownRes = panelOnKeyDown.value?.(evt) ?? true
-    if (!paneKeyDownRes) {
+    evt.stopPropagation()
+    if (overlayOpened.value && panelOnKeyDown.value && !panelOnKeyDown.value(evt)) {
       return
     }
 
     switch (evt.key) {
       case 'Enter':
         evt.preventDefault()
-        confirm()
+        if (props.value) {
+          confirm()
+        } else {
+          setCurrentAsActive(true)
+        }
+
         break
       case 'Backspace':
         if (!props.input) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
复合搜索，在面板浮层关闭的时候，面板自身绑定的键盘事件处理函数依然会被触发

## What is the new behavior?
在浮层关闭，即面板隐藏的时候，面板的键盘事件不应该触发，键盘操作应当唤起面板显示

## Other information
