### PR TITLE
fix(comp:tree): searchKeys is affected by the side effects of other v…

### DIFF
--- a/packages/components/tree/src/composables/useSearchable.ts
+++ b/packages/components/tree/src/composables/useSearchable.ts
@@ -5,9 +5,9 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { type ComputedRef, computed } from 'vue'
+import { type ComputedRef, computed, watch } from 'vue'
 
-import { NoopArray, type VKey } from '@idux/cdk/utils'
+import { type VKey, useState } from '@idux/cdk/utils'
 
 import { type MergedNode } from './useDataSource'
 import { type TreeNode, type TreeProps } from '../types'
@@ -23,21 +23,26 @@ export function useSearchable(
 ): SearchableContext {
   const mergedSearchFn = useSearchFn(props, mergedLabelKey)
 
-  const searchedKeys = computed(() => {
-    const { searchValue } = props
-    if (!searchValue) {
-      return NoopArray as unknown as VKey[]
-    }
-    const searchFn = mergedSearchFn.value
-    const keys: VKey[] = []
-    mergedNodeMap.value.forEach(node => {
-      if (searchFn(node.rawNode, searchValue)) {
-        keys.push(node.key)
-      }
-    })
+  const [searchedKeys, setSearchedKeys] = useState<VKey[]>([])
 
-    return keys
-  })
+  watch(
+    () => props.searchValue,
+    searchValue => {
+      const searchFn = mergedSearchFn.value
+      const keys: VKey[] = []
+      if (searchValue) {
+        mergedNodeMap.value.forEach(node => {
+          if (searchFn(node.rawNode, searchValue)) {
+            keys.push(node.key)
+          }
+        })
+      }
+      setSearchedKeys(keys)
+    },
+    {
+      immediate: true,
+    },
+  )
 
   return { searchedKeys }
 }


### PR DESCRIPTION
…ariables

fix #1462

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
此issue中的demo由于设置了动态disabled，导致修改到了`mergedNodeMap.value`值，而`searchKeys`在`computed`中被`mergedNodeMap.value`收集到了依赖，从而从新更新了`searchKeys`，进而影响到了`expandedKeys`； 所以把`computed`改为`watch`，使得`searchKeys`仅被`props.searchValue`影响

## Other information
