### PR TITLE
refactor(pro:search): add searchState watcher logic

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -19,6 +19,7 @@ import { useControl } from './composables/useControl'
 import { useFocusedState } from './composables/useFocusedState'
 import { useSearchItems } from './composables/useSearchItem'
 import { useSearchItemErrors } from './composables/useSearchItemErrors'
+import { useSearchStateWatcher } from './composables/useSearchStateWatcher'
 import { tempSearchStateKey, useSearchStates } from './composables/useSearchStates'
 import { useSearchTrigger } from './composables/useSearchTrigger'
 import { useSearchValues } from './composables/useSearchValues'
@@ -39,8 +40,10 @@ export default defineComponent({
     const dateConfig = useDateConfig()
     const mergedPrefixCls = computed(() => `${common.prefixCls}-search`)
 
-    const { searchValues, searchValueEmpty, setSearchValues } = useSearchValues(props)
-    const searchStateContext = useSearchStates(props, dateConfig, searchValues, setSearchValues)
+    const searchValueContext = useSearchValues(props)
+    const { searchValues, searchValueEmpty } = searchValueContext
+    const searchStateWatcherContext = useSearchStateWatcher()
+    const searchStateContext = useSearchStates(props, dateConfig, searchValueContext, searchStateWatcherContext)
     const errors = useSearchItemErrors(props, searchValues)
     const searchItems = useSearchItems(
       props,
@@ -138,6 +141,7 @@ export default defineComponent({
       focused,
 
       ...searchStateContext,
+      ...searchStateWatcherContext,
       ...activeSegmentContext,
       ...searchTriggerContext,
     })

--- a/packages/pro/search/src/composables/useSearchStateWatcher.ts
+++ b/packages/pro/search/src/composables/useSearchStateWatcher.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { SearchState, SegmentValue } from './useSearchStates'
+import type { VKey } from '@idux/cdk/utils'
+
+export enum SEARCH_STATE_ACTION {
+  REMOVED,
+  CREATED,
+  UPDATED,
+}
+
+export type UpdatedSegmentValue = SegmentValue & { oldValue: unknown }
+export type SearchStateWatcherPayload<Action extends SEARCH_STATE_ACTION> = Action extends SEARCH_STATE_ACTION.REMOVED
+  ? { searchState: SearchState }
+  : Action extends SEARCH_STATE_ACTION.CREATED
+  ? { searchState: SearchState }
+  : Action extends SEARCH_STATE_ACTION.UPDATED
+  ? { searchState: SearchState; updatedSegments: UpdatedSegmentValue[] }
+  : never
+export type SearchStateWatchHandler = <Action extends SEARCH_STATE_ACTION>(
+  action: Action,
+  payload: SearchStateWatcherPayload<Action>,
+) => void
+export type SearchStateWatcher = (key: VKey, handler: SearchStateWatchHandler) => () => void
+export type SearchStateNotifier = <Action extends SEARCH_STATE_ACTION>(
+  key: VKey,
+  action: Action,
+  payload: SearchStateWatcherPayload<Action>,
+) => void
+
+export interface SearchStateWatcherContext {
+  notifySearchStateChange: SearchStateNotifier
+  watchSearchState: SearchStateWatcher
+  compareSegmentValues: (
+    currentSegmentValues: SegmentValue[],
+    oldSegmentValues: SegmentValue[],
+  ) => UpdatedSegmentValue[]
+  compareSearchStates: (searchStates: SearchState[], oldSearchStates: SearchState[]) => void
+}
+
+export function useSearchStateWatcher(): SearchStateWatcherContext {
+  const handlersMap = new Map<VKey, Set<SearchStateWatchHandler>>()
+
+  const watchSearchState: SearchStateWatcher = (key, handler) => {
+    const handlers = handlersMap.get(key) ?? new Set<SearchStateWatchHandler>()
+    handlers.add(handler)
+    handlersMap.set(key, handlers)
+
+    return () => {
+      const handlers = handlersMap.get(key)
+      handlers?.delete(handler)
+
+      if (!handlers?.size) {
+        handlersMap.delete(key)
+      }
+    }
+  }
+  const notifySearchStateChange: SearchStateNotifier = (key, action, payload) => {
+    const handlers = handlersMap.get(key)
+
+    if (!handlers) {
+      return
+    }
+
+    handlers.forEach(handler => {
+      handler(action, payload)
+    })
+  }
+
+  const compareSegmentValues = (currentSegmentValues: SegmentValue[], oldSegmentValues: SegmentValue[]) => {
+    const updatedSegments: (SegmentValue & { oldValue: unknown })[] = []
+
+    // find updated or removed segments
+    oldSegmentValues.forEach(segmentValue => {
+      const name = segmentValue.name
+      const newSegmentValue = currentSegmentValues.find(sv => sv.name === name)
+
+      if (segmentValue.value !== newSegmentValue?.value) {
+        updatedSegments.push({ name, value: newSegmentValue, oldValue: segmentValue.value })
+      }
+    })
+    // find newly created segments
+    currentSegmentValues.forEach(currentSegmentValue => {
+      const name = currentSegmentValue.name
+
+      if (oldSegmentValues.findIndex(sv => sv.name === name) < 0) {
+        updatedSegments.push({ name, value: currentSegmentValue, oldValue: undefined })
+      }
+    })
+
+    return updatedSegments
+  }
+
+  const compareSearchStates = (currentSearchStates: SearchState[], oldSearchStates: SearchState[]) => {
+    oldSearchStates.forEach(searchState => {
+      const key = searchState.key
+      const newSearchState = currentSearchStates.find(ns => ns.key === key)
+
+      // notify searchState removed
+      if (!newSearchState) {
+        notifySearchStateChange(key, SEARCH_STATE_ACTION.REMOVED, { searchState })
+        return
+      }
+
+      const updatedSegments = compareSegmentValues(newSearchState.segmentValues, searchState.segmentValues)
+
+      // notify searchState update
+      if (updatedSegments.length > 0) {
+        notifySearchStateChange(key, SEARCH_STATE_ACTION.UPDATED, { searchState, updatedSegments })
+      }
+    })
+
+    // find newly created searchStates
+    currentSearchStates.forEach(newSearchState => {
+      const key = newSearchState.key
+      if (oldSearchStates.findIndex(searchState => searchState.key === newSearchState.key) < 0) {
+        notifySearchStateChange(key, SEARCH_STATE_ACTION.CREATED, { searchState: newSearchState })
+      }
+    })
+  }
+
+  return {
+    watchSearchState,
+    notifySearchStateChange,
+    compareSegmentValues,
+    compareSearchStates,
+  }
+}

--- a/packages/pro/search/src/searchItem/Segment.tsx
+++ b/packages/pro/search/src/searchItem/Segment.tsx
@@ -311,7 +311,7 @@ function useInputEvents(
     switch (evt.key) {
       case 'Enter':
         evt.preventDefault()
-        if (!props.segment.panelRenderer || overlayOpened.value || props.value) {
+        if (props.input || overlayOpened.value || !props.segment.panelRenderer) {
           confirm()
         } else {
           setCurrentAsActive(true)

--- a/packages/pro/search/src/token.ts
+++ b/packages/pro/search/src/token.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ActiveSegmentContext } from './composables/useActiveSegment'
+import type { SearchStateWatcherContext } from './composables/useSearchStateWatcher'
 import type { SearchStateContext } from './composables/useSearchStates'
 import type { SearchTriggerContext } from './composables/useSearchTrigger'
 import type { SegmentOverlayUpdateContext } from './composables/useSegmentOverlayUpdate'
@@ -15,7 +16,11 @@ import type { ɵOverlayProps } from '@idux/components/_private/overlay'
 import type { ProSearchLocale } from '@idux/pro/locales'
 import type { ComputedRef, InjectionKey, Slots } from 'vue'
 
-export interface ProSearchContext extends SearchStateContext, ActiveSegmentContext, SearchTriggerContext {
+export interface ProSearchContext
+  extends SearchStateContext,
+    SearchStateWatcherContext,
+    ActiveSegmentContext,
+    SearchTriggerContext {
   props: ProSearchProps
   slots: Slots
   locale: ProSearchLocale


### PR DESCRIPTION
add watcher logics to watch inner searchStates changes more percisely

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当前的逻辑并不能准确监听数据 `searchStates` 的变化以及变化内容，搜索项的状态也不能精确响应变化

## What is the new behavior?
增加 `useSearchStateWatcher` 逻辑，在searchState变化后通知变更，更精确得处理组件状态变化

## Other information
