### PR TITLE
fix(comp:cascader): searchValue not working after CascaderPanel added

### DIFF
--- a/packages/components/cascader/src/Cascader.tsx
+++ b/packages/components/cascader/src/Cascader.tsx
@@ -146,7 +146,7 @@ export default defineComponent({
       />
     )
 
-    const panelProps = usePanelProps(props, setOverlayOpened)
+    const panelProps = usePanelProps(props, inputValue, setOverlayOpened)
     const handleSearchInput = (evt: Event) => {
       const { value } = evt.target as HTMLInputElement
       setInputValue(value)

--- a/packages/components/cascader/src/composables/usePanelProps.ts
+++ b/packages/components/cascader/src/composables/usePanelProps.ts
@@ -13,6 +13,7 @@ import { useControlledProp } from '@idux/cdk/utils'
 
 export function usePanelProps(
   props: CascaderProps,
+  searchValue: ComputedRef<string>,
   setOverlayOpened: (opened: boolean) => void,
 ): ComputedRef<Partial<CascaderPanelProps>> {
   const [expandedKeys, setExpandedKeys] = useControlledProp(props, 'expandedKeys')
@@ -43,6 +44,7 @@ export function usePanelProps(
 
     searchable: props.searchable,
     searchFn: props.searchFn,
+    searchValue: searchValue.value,
     strategy: props.strategy,
     virtual: props.virtual,
 

--- a/packages/components/cascader/src/types.ts
+++ b/packages/components/cascader/src/types.ts
@@ -54,7 +54,6 @@ export const cascaderPanelProps = {
   onExpandedChange: [Function, Array] as PropType<MaybeArray<(expendedKeys: any[], data: CascaderData[]) => void>>,
   onLoaded: [Function, Array] as PropType<MaybeArray<(loadedKeys: any[], data: CascaderData) => void>>,
   onSelect: [Function, Array] as PropType<MaybeArray<(option: CascaderData, isSelected: boolean) => void>>,
-  onSearch: [Function, Array] as PropType<MaybeArray<(value: string) => void>>,
 
   // private
   _virtualScrollHeight: { type: Number, default: 256 },


### PR DESCRIPTION
after adding `IxCascaderPanel`, searching isn't working

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
新增 `IxCascaderPanel` 之后，搜索不起作用了

## What is the new behavior?
修复以上问题

## Other information
