### PR TITLE
feat(pro:table): the layout tool support visible, changeSize, resetable

### DIFF
--- a/packages/pro/config/src/defaultConfig.ts
+++ b/packages/pro/config/src/defaultConfig.ts
@@ -30,6 +30,8 @@ export const defaultConfig: ProGlobalConfig = {
   },
   table: {
     layoutTool: {
+      changeSize: false,
+      resetable: false,
       searchable: false,
     },
   },

--- a/packages/pro/config/src/types.ts
+++ b/packages/pro/config/src/types.ts
@@ -73,6 +73,8 @@ export interface ProTableConfig {
   // @deprecated please use `columnIndexable` of TableConfig instead'
   columnIndexable?: Omit<ProTableColumnIndexable, 'type'>
   layoutTool: {
+    changeSize: boolean
+    resetable: boolean
     searchable: boolean
   }
 }

--- a/packages/pro/table/docs/Api.zh.md
+++ b/packages/pro/table/docs/Api.zh.md
@@ -75,5 +75,10 @@ export type ProTableColumn<T = any, V = any, CT = 'input'> =
 | 名称 | 说明 | 类型  | 默认值 | 全局配置 | 备注 |
 | --- | --- | --- | --- | --- | --- |
 | `v-model:searchValue` | 搜索的文本 | `string` | - | - | - |
-| `placeholder` | 搜索框的占位符 | `string` | ✅ | - | 通过 locale 全局配置 |
-| `searchable` | 是否开启搜索功能 | `boolean` | ✅ | - | - |
+| `v-model:visible` | 浮层的显示隐藏 | `boolean` | - | - | - |
+| `changeSize` | 是否支持修改表格的尺寸 | `boolean` | `true` | ✅ |- |
+| `className` | 自定义浮层的 `class` | `string` | - | - |- |
+| `placeholder` | 搜索框的占位符 | `string` | `搜索关键字` | ✅ | 通过 locale 全局配置 |
+| `resetable` | 是否支持重置布局设置 | `boolean` | `true` | ✅ |- |
+| `searchable` | 是否开启搜索功能 | `boolean` | `false` | ✅ | - |
+| `onReset` | 点击重置按钮后的回调 | `(evt: MouseEvent) => boolean \| void` | - | - | 返回 `false` 会阻止组件内部的重置操作 |

--- a/packages/pro/table/src/ProTable.tsx
+++ b/packages/pro/table/src/ProTable.tsx
@@ -9,7 +9,7 @@
 
 import { computed, defineComponent, provide, ref, watch } from 'vue'
 
-import { isString } from 'lodash-es'
+import { isObject, isString } from 'lodash-es'
 
 import { type VirtualScrollToOptions } from '@idux/cdk/scroll'
 import { useState } from '@idux/cdk/utils'
@@ -44,7 +44,6 @@ export default defineComponent({
 
     provide(proTableToken, {
       props,
-      slots,
       config,
       locale,
       mergedPrefixCls,
@@ -59,10 +58,12 @@ export default defineComponent({
     })
 
     const renderLayoutTool = () => {
-      if (!props.layoutTool) {
+      const { layoutTool } = props
+      if (!layoutTool) {
         return null
       }
-      return <ProTableLayoutTool />
+      const toolProps = isObject(layoutTool) ? layoutTool : undefined
+      return <ProTableLayoutTool {...toolProps} />
     }
 
     const renderToolbar = () => {

--- a/packages/pro/table/src/ProTableLayoutTool.tsx
+++ b/packages/pro/table/src/ProTableLayoutTool.tsx
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { defineComponent, inject, normalizeClass } from 'vue'
+import { computed, defineComponent, inject, normalizeClass } from 'vue'
 
 import { IxIcon } from '@idux/components/icon'
 import { IxPopover } from '@idux/components/popover'
@@ -27,7 +27,11 @@ export default defineComponent({
   name: 'IxProTableLayoutTool',
   props: proTableLayoutToolProps,
   setup(props, { slots }) {
-    const { locale, mergedPrefixCls, mergedSize, setMergedSize } = inject(proTableToken)!
+    const { config, locale, mergedPrefixCls, mergedSize, setMergedSize } = inject(proTableToken)!
+
+    const mergedChangeSize = computed(() => props.changeSize ?? config.layoutTool.changeSize)
+    const mergedResetable = computed(() => props.resetable ?? config.layoutTool.resetable)
+    const mergedSearchable = computed(() => props.searchable ?? config.layoutTool.searchable)
 
     return () => {
       const prefixCls = `${mergedPrefixCls.value}-layout-tool`
@@ -49,14 +53,32 @@ export default defineComponent({
           />
         )
       }
-      const suffixNode = (
+      const suffixNode = mergedChangeSize.value ? (
         <IxSpace>
           {renderIcon('sm')}
           {renderIcon('md')}
           {renderIcon('lg')}
         </IxSpace>
-      )
-      const popoverHeader = { title: layoutLocale.title, suffix: suffixNode }
+      ) : undefined
+
+      const contentProps = {
+        placeholder: props.placeholder,
+        resetable: mergedResetable.value,
+        searchable: mergedSearchable.value,
+        searchValue: props.searchValue,
+        'onUpdate:searchValue': props['onUpdate:searchValue'],
+        onReset: props.onReset,
+      }
+      const popoverProps = {
+        class: normalizeClass([prefixCls, props.className]),
+        header: { title: layoutLocale.title, suffix: suffixNode },
+        offset: defaultOffset,
+        placement: 'bottomEnd',
+        showArrow: false,
+        trigger: 'click',
+        visible: props.visible,
+        'onUpdate:visible': props['onUpdate:visible'],
+      } as const
 
       return (
         <IxPopover
@@ -68,15 +90,10 @@ export default defineComponent({
                   <IxIcon name="ellipsis" />
                 </span>
               )),
-            content: () => <LayoutToolContent {...props} />,
+            content: () => <LayoutToolContent {...contentProps} />,
           }}
-          class={prefixCls}
-          header={popoverHeader}
-          offset={defaultOffset}
-          placement="bottomEnd"
-          showArrow={false}
-          trigger="click"
-        ></IxPopover>
+          {...popoverProps}
+        />
       )
     }
   },

--- a/packages/pro/table/src/token.ts
+++ b/packages/pro/table/src/token.ts
@@ -9,11 +9,10 @@ import type { ColumnsContext } from './composables/useColumns'
 import type { ProTableProps } from './types'
 import type { ProTableConfig } from '@idux/pro/config'
 import type { ProLocale } from '@idux/pro/locales'
-import type { ComputedRef, InjectionKey, Slots } from 'vue'
+import type { ComputedRef, InjectionKey } from 'vue'
 
 export interface ProTableContext extends ColumnsContext {
   props: ProTableProps
-  slots: Slots
   config: ProTableConfig
   locale: ProLocale
   mergedPrefixCls: ComputedRef<string>

--- a/packages/pro/table/src/types.ts
+++ b/packages/pro/table/src/types.ts
@@ -42,11 +42,17 @@ export type ProTableComponent = DefineComponent<
 export type ProTableInstance = InstanceType<DefineComponent<ProTableProps, ProTableBindings>>
 
 export const proTableLayoutToolProps = {
+  changeSize: { type: Boolean, default: undefined },
+  className: { type: String, default: undefined },
   placeholder: { type: String, default: undefined },
+  resetable: { type: Boolean, default: undefined },
   searchable: { type: Boolean, default: undefined },
   searchValue: { type: String, default: undefined },
+  visible: { type: Boolean, default: undefined },
 
   'onUpdate:searchValue': [Function, Array] as PropType<MaybeArray<(searchValue: string) => void>>,
+  'onUpdate:visible': [Function, Array] as PropType<MaybeArray<(visible: boolean) => void>>,
+  onReset: [Function, Array] as PropType<MaybeArray<(evt: MouseEvent) => boolean | void>>,
 } as const
 
 export type ProTableLayoutToolProps = ExtractInnerPropTypes<typeof proTableLayoutToolProps>
@@ -101,3 +107,14 @@ export type ProTableColumnResizable = {
   minWidth?: number | string
   resizable?: boolean
 }
+
+// private
+export const proTableLayoutToolContentProps = {
+  placeholder: { type: String, default: undefined },
+  resetable: { type: Boolean, required: true },
+  searchable: { type: Boolean, required: true },
+  searchValue: { type: String, default: undefined },
+
+  'onUpdate:searchValue': [Function, Array] as PropType<MaybeArray<(searchValue: string) => void>>,
+  onReset: [Function, Array] as PropType<MaybeArray<(evt: MouseEvent) => boolean | void>>,
+} as const


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

布局设置面板新增功能

- 双向绑定 visible
- 隐藏修改大小的图标: changeSize
- 自定义面板样式: className
- 隐藏重置按钮: resetable
- 重置按钮被点击后的回调: onReset


## Other information
