### PR TITLE
fix(pro:search): empty input segment should be invalid

### DIFF
--- a/packages/pro/search/src/segments/createInputSegment.ts
+++ b/packages/pro/search/src/segments/createInputSegment.ts
@@ -7,7 +7,7 @@
 
 import type { InputSearchField, Segment } from '../types'
 
-export function createInputSegment(prefixCls: string, searchField: InputSearchField): Segment<string> {
+export function createInputSegment(prefixCls: string, searchField: InputSearchField): Segment<string | undefined> {
   const {
     fieldConfig: { trim },
     defaultValue,
@@ -19,7 +19,7 @@ export function createInputSegment(prefixCls: string, searchField: InputSearchFi
     inputClassName: [inputClassName, `${prefixCls}-input-segment-input`],
     placeholder: searchField.placeholder,
     defaultValue,
-    parse: input => input,
+    parse: input => (input ? input : undefined),
     format: value => (trim ? value?.trim() : value) ?? '',
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
input类型搜索项，先输入，再退格清除，此时空的输入会被校验为合法

## What is the new behavior?
修复以上问题，空字符串一律返回 undefined

## Other information
