### PR TITLE
fix(pro:search): segmentState should init only when item key changes

### DIFF
--- a/packages/pro/search/src/composables/useSegmentStates.ts
+++ b/packages/pro/search/src/composables/useSegmentStates.ts
@@ -83,7 +83,11 @@ export function useSegmentStates(
   let searchStateWatchStop: () => void
   watch(
     () => props.searchItem,
-    searchItem => {
+    (searchItem, oldSearchItem) => {
+      if (searchItem?.key === oldSearchItem?.key) {
+        return
+      }
+
       searchStateWatchStop?.()
       initSegmentStates()
       if (searchItem?.key) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
searchItem的内容变化后，输入状态内容被初始化

## What is the new behavior?
仅当searchItem的key变化后才初始化输入状态，并建立对该key对应的searchState的监听

## Other information
