### PR TITLE
fix(comp:cascader): group height should be same as panel height

### DIFF
--- a/packages/components/cascader/style/index.less
+++ b/packages/components/cascader/style/index.less
@@ -92,7 +92,7 @@
 
     display: flex;
     flex-wrap: nowrap;
-    align-items: flex-start;
+    align-items: stretch;
     font-size: @cascader-option-font-size;
     overflow: auto;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
子面板group数据量比较多，撑开整体面板高度时，父级面板高度没有占满整体面板高度，导致右border高度不对
![image](https://user-images.githubusercontent.com/28892824/224599040-f31b6e0f-23a6-4957-b0a5-ec2c7da06133.png)



## What is the new behavior?
修复以上问题

## Other information
