### PR TITLE
fix: lock @idux dependencies' version to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lessvariable:update": "ts-node scripts/gen/style-variable/update.ts",
     "prepare": "husky install",
     "preinstall": "npx only-allow pnpm",
-    "version": "lerna version --conventional-commits --no-push",
+    "version": "lerna version --conventional-commits --no-push --exact",
     "test": "vitest",
     "lint": "npm-run-all -p ls-lint eslint stylelint markdownlint",
     "lint:fix": "npm-run-all -p ls-lint eslint:fix stylelint:fix markdownlint:fix",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
发布的npm包，@idux/* 相关依赖没有固定而使用 `'^'` ，导致依赖树中存在多个不同版本时实际依赖版本错误

## What is the new behavior?
lerna version 命令中 增加 --exact 参数，固定相关依赖版本

## Other information
