### PR TITLE
fix(cdk:scroll): content is blank when re-activated in keepalive mode

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useScrollPlacement.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useScrollPlacement.ts
@@ -8,7 +8,7 @@
 import type { VirtualScrollProps } from '../types'
 import type { Ref } from 'vue'
 
-import { computed } from 'vue'
+import { computed, onActivated } from 'vue'
 
 import { isFunction } from 'lodash-es'
 
@@ -63,6 +63,13 @@ export function useScrollPlacement(
       callEmit(props.onScrolledBottom)
     }
   }
+
+  const initScrollTop = () => {
+    if (holderRef.value) {
+      syncScrollTop(scrollTop.value, true)
+    }
+  }
+  onActivated(initScrollTop)
 
   return { syncScrollTop, handleScroll }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
keepAlive 模式下，再切回到有虚拟滚动的页面，由于页面滚动的位置被重置而储存的滚动位置没有变，导致虚拟滚动内容是空的

## What is the new behavior?
activated钩子中，重置holder的scrollTop

## Other information
