### PR TITLE
fix(pro:table): triggers of last column is covered by layout tool

### DIFF
--- a/packages/pro/table/style/index.less
+++ b/packages/pro/table/style/index.less
@@ -105,11 +105,21 @@
       }
     }
 
-    .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-content {
-      table > thead > tr:first-child {
-        th:last-child {
-          .@{table-prefix}-sortable-trigger {
-            margin-right: 40px;
+    &.@{table-prefix}-scroll-vertical {
+      .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-fixed-holder {
+        table > thead > tr:first-child {
+          th:nth-last-of-type(2) .@{table-prefix}-cell-triggers {
+            padding-right: 30px;
+          }
+        }
+      }
+    }
+
+    &:not(.@{table-prefix}-scroll-vertical) {
+      .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-content {
+        table > thead > tr:first-child {
+          th:last-child > .@{table-prefix}-cell-triggers {
+            padding-right: 38px;
           }
         }
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
出现滚动的时候，最后一列的头部按钮（筛选，排序等）被布局按钮遮挡

## What is the new behavior?
修改以上问题

修改样式实现为，在最后一列的 triggers 容器中补充右边距

## Other information
