### PR TITLE
fix(comp:date-picker): prevent elements with class name `ix-overlay`'s `box-sizing` set to `content-box`

### DIFF
--- a/packages/components/_private/overlay/style/index.less
+++ b/packages/components/_private/overlay/style/index.less
@@ -1,4 +1,5 @@
 .@{overlay-prefix} {
+  box-sizing: border-box;
 
   &-arrow {
     position: absolute;

--- a/packages/components/_private/overlay/style/index.less
+++ b/packages/components/_private/overlay/style/index.less
@@ -1,5 +1,7 @@
+@import "../../../style/mixins/reset.less";
+
 .@{overlay-prefix} {
-  box-sizing: border-box;
+  .reset-component();
 
   &-arrow {
     position: absolute;

--- a/packages/components/_private/overlay/style/index.less
+++ b/packages/components/_private/overlay/style/index.less
@@ -1,7 +1,7 @@
 @import "../../../style/mixins/reset.less";
 
 .@{overlay-prefix} {
-  .reset-component();
+  .reset-component-new();
 
   &-arrow {
     position: absolute;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://user-images.githubusercontent.com/82451257/227506275-8ab64556-23be-4cf0-aeac-1667306342d4.png)


## What is the new behavior?


## Other information
