### PR TITLE
fix(comp:select):  compositionEnd can't trigger

### DIFF
--- a/packages/components/_private/selector/src/Selector.tsx
+++ b/packages/components/_private/selector/src/Selector.tsx
@@ -57,6 +57,7 @@ export default defineComponent({
       handleCompositionEnd,
       handleInput,
       clearInput,
+      handleEnterDown,
     } = useInputState(props, mergedSearchable)
 
     const getBoundingClientRect = () => elementRef.value?.getBoundingClientRect()
@@ -137,6 +138,7 @@ export default defineComponent({
       handleCompositionStart,
       handleCompositionEnd,
       handleInput,
+      handleEnterDown,
     })
 
     const elementRef = ref<HTMLDivElement>()

--- a/packages/components/_private/selector/src/composables/useInputState.ts
+++ b/packages/components/_private/selector/src/composables/useInputState.ts
@@ -26,6 +26,7 @@ export interface InputStateContext {
   handleCompositionEnd: (evt: CompositionEvent) => void
   handleInput: (evt: Event) => void
   clearInput: () => void
+  handleEnterDown: (evt: KeyboardEvent) => void
 }
 
 export function useInputState(props: SelectorProps, mergedSearchable: ComputedRef<boolean>): InputStateContext {
@@ -68,6 +69,13 @@ export function useInputState(props: SelectorProps, mergedSearchable: ComputedRe
     if (isComposing.value) {
       isComposing.value = false
       handleInput(evt, false)
+    }
+  }
+
+  // 处理中文输入法下的回车无法触发 compositionEnd 事件的问题
+  const handleEnterDown = (evt: KeyboardEvent) => {
+    if (evt.code === 'Enter' && isComposing.value) {
+      handleCompositionEnd(evt as any)
     }
   }
 
@@ -116,5 +124,6 @@ export function useInputState(props: SelectorProps, mergedSearchable: ComputedRe
     handleCompositionEnd,
     handleInput,
     clearInput,
+    handleEnterDown,
   }
 }

--- a/packages/components/_private/selector/src/contents/Input.tsx
+++ b/packages/components/_private/selector/src/contents/Input.tsx
@@ -22,6 +22,7 @@ export default defineComponent({
       handleCompositionStart,
       handleCompositionEnd,
       handleInput,
+      handleEnterDown,
     } = inject(selectorToken)!
 
     const inputReadonly = computed(
@@ -47,6 +48,7 @@ export default defineComponent({
             value={inputValue.value}
             onCompositionstart={handleCompositionStart}
             onCompositionend={handleCompositionEnd}
+            onKeydown={handleEnterDown}
             onInput={handleInput}
           />
           {multiple && <span ref={mirrorRef} class={`${prefixCls}-mirror`} aria-hidden></span>}

--- a/packages/components/_private/selector/src/token.ts
+++ b/packages/components/_private/selector/src/token.ts
@@ -22,6 +22,7 @@ export interface SelectorContext {
   handleCompositionStart: (evt: CompositionEvent) => void
   handleCompositionEnd: (evt: CompositionEvent) => void
   handleInput: (evt: Event) => void
+  handleEnterDown: (evt: KeyboardEvent) => void
 }
 
 export const selectorToken: InjectionKey<SelectorContext> = Symbol('selectorToken')


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
fix #1474 
input 添加了 compostionStart 事件和 compositionEnd 事件，但是由于中文输入法的原因 compositionEnd 事件不能被正常触发
![image](https://user-images.githubusercontent.com/82451257/227596463-6e00bc83-ddde-47b9-880e-9bc2f30ac2a1.png)
就会导致 isComposing 一直为 true，从而下面的 inputValue change 等一系列事件不会运行。

## What is the new behavior?


## Other information
