### PR TITLE
fix(cdk:popper): reference hidden popper are no longer updated

### DIFF
--- a/packages/cdk/popper/__tests__/__snapshots__/popper.spec.ts.snap
+++ b/packages/cdk/popper/__tests__/__snapshots__/popper.spec.ts.snap
@@ -12,70 +12,70 @@ exports[`usePopper > options > autoAdjust work 2`] = `
 
 exports[`usePopper > options > offset work 1`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 4px; top: -4px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"top\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 4px; top: -4px;\\" data-popper-placement=\\"top\\">Popper</div>"
 `;
 
 exports[`usePopper > options > offset work 2`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 8px; top: -8px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"top\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 8px; top: -8px;\\" data-popper-placement=\\"top\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 1`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 2`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 3`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 4`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 5`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 6`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 7`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 8`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 9`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 10`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 11`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 12`] = `
 "<div id=\\"trigger\\">Trigger</div>
-<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-reference-hidden=\\"\\" data-popper-placement=\\"left-end\\">Popper</div>"
+<div id=\\"overlay\\" style=\\"position: absolute; left: 0px; top: 0px;\\" data-popper-placement=\\"left-end\\">Popper</div>"
 `;

--- a/packages/cdk/popper/src/middlewares/refenceHidden.ts
+++ b/packages/cdk/popper/src/middlewares/refenceHidden.ts
@@ -5,31 +5,49 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { type Middleware, hide } from '@floating-ui/dom'
+import { type Middleware, type Side, type SideObject, hide } from '@floating-ui/dom'
+
+export const referenceHiddenMiddlewareName = 'IDUX_referenceHidden'
+export interface ReferenceHiddenData {
+  referenceHidden: boolean
+  referenceHiddenOffsets: SideObject
+}
+
+const sides: Side[] = ['top', 'bottom', 'left', 'right']
 
 export function referenceHidden(): Middleware {
-  const { fn: hideFn, ...rest } = hide()
+  const { fn: hideFn, ...rest } = hide({ elementContext: 'reference' })
 
   return {
     ...rest,
-    name: 'IDUX_referenceHidden',
+    name: referenceHiddenMiddlewareName,
     async fn(middlewareArguments) {
       const {
         elements: { floating },
       } = middlewareArguments
 
-      const res = (await hideFn(middlewareArguments)) as { data: { referenceHidden: boolean } }
+      const res = (await hideFn(middlewareArguments)) as {
+        data: ReferenceHiddenData
+      }
       const {
-        data: { referenceHidden },
+        data: { referenceHiddenOffsets },
       } = res
 
-      if (referenceHidden) {
+      const referenceHidden = sides.some(side => referenceHiddenOffsets[side] > 0)
+
+      if (sides.some(side => referenceHiddenOffsets[side] > 0)) {
         floating.setAttribute('data-popper-reference-hidden', '')
       } else {
         floating.removeAttribute('data-popper-reference-hidden')
       }
 
-      return res
+      return {
+        ...res,
+        data: {
+          ...res.data,
+          referenceHidden,
+        },
+      }
     },
   }
 }

--- a/packages/cdk/popper/src/usePopper.ts
+++ b/packages/cdk/popper/src/usePopper.ts
@@ -76,7 +76,7 @@ export function usePopper<TE extends PopperElement = PopperElement, PE extends P
 
   function initialize() {
     destroy()
-    popperInstance = useInstance(triggerRef, popperRef, convertedOptions)
+    popperInstance = useInstance(triggerRef, popperRef, visibility, convertedOptions)
   }
 
   function destroy(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
reference hidden 的 popper，位置依然会被计算，此时会把浮层的位置计算到左上角

## What is the new behavior?
1. reference hidden 的 popper，位置不会再更新
2. reference hidden 的规则，严格限定为 溢出大于0，等于0不当作被隐藏，排除了 reference display: none 的情况
3. reference display: none 的时候，浮层不再会自动隐藏

## Other information
