### PR TITLE
fix(pro:tree): the header don't render when it is empty

### DIFF
--- a/packages/pro/tree/__tests__/__snapshots__/proTree.spec.ts.snap
+++ b/packages/pro/tree/__tests__/__snapshots__/proTree.spec.ts.snap
@@ -3,7 +3,17 @@
 exports[`ProTree > render work 1`] = `
 "<div class=\\"ix-pro-tree\\">
   <div class=\\"ix-pro-tree-header-wrapper\\">
-    <!---->
+    <div class=\\"ix-header ix-header-md\\">
+      <!---->
+      <!---->
+      <div class=\\"ix-header-content\\">
+        <div class=\\"ix-header-title-wrapper\\"><span class=\\"ix-header-title\\">header</span>
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <!---->
+    </div>
     <!---->
   </div>
   <div class=\\"ix-pro-tree-search-wrapper\\"><button class=\\"ix-button ix-button-icon-only ix-button-default ix-button-square ix-button-xs\\" type=\\"button\\" title=\\"收起全部\\"><i class=\\"ix-icon ix-icon-tree-unexpand\\" role=\\"img\\" aria-label=\\"tree-unexpand\\"></i>

--- a/packages/pro/tree/__tests__/proTree.spec.ts
+++ b/packages/pro/tree/__tests__/proTree.spec.ts
@@ -41,7 +41,7 @@ describe('ProTree', () => {
   }
 
   renderWork<ProTreeProps>(ProTree, {
-    props: { dataSource: defaultDataSource },
+    props: { dataSource: defaultDataSource, header: 'header' },
   })
 
   test('checkable work', async () => {
@@ -349,6 +349,11 @@ describe('ProTree', () => {
 
     expect(wrapper.find('.ix-header-title').text()).toBe('tmp')
     expect(wrapper.find('.ix-header-suffix .ix-icon-setting').exists()).toBe(true)
+
+    // 为空时，不显示 header
+    await wrapper.setProps({ header: undefined })
+
+    expect(wrapper.find('.ix-header-wrapper').exists()).toBe(false)
   })
 
   test('header slot work', async () => {

--- a/packages/pro/tree/src/ProTree.tsx
+++ b/packages/pro/tree/src/ProTree.tsx
@@ -187,18 +187,22 @@ export default defineComponent({
         empty: slots.empty,
         expandIcon: slots.expandIcon,
       }
+      const showHeaderIcon = !isNil(collapsed.value)
+      const showHeader = props.header || slots.header || showHeaderIcon
       return (
         <div class={classes.value} style={style.value}>
-          <div class={`${prefixCls}-header-wrapper`}>
-            <ɵHeader v-slots={slots} header={props.header} />
-            {!isNil(collapsed.value) && (
-              <IxIcon
-                class={`${prefixCls}-collapsed-icon`}
-                name={collapsed.value ? mergedCollapseIcon.value[1] : mergedCollapseIcon.value[0]}
-                onClick={handleCollapsed}
-              />
-            )}
-          </div>
+          {showHeader && (
+            <div class={`${prefixCls}-header-wrapper`}>
+              <ɵHeader v-slots={slots} header={props.header} />
+              {showHeaderIcon && (
+                <IxIcon
+                  class={`${prefixCls}-collapsed-icon`}
+                  name={collapsed.value ? mergedCollapseIcon.value[1] : mergedCollapseIcon.value[0]}
+                  onClick={handleCollapsed}
+                />
+              )}
+            </div>
+          )}
           {props.searchable ? (
             <div class={`${prefixCls}-search-wrapper`}>
               <IxButton


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

header 为空时不渲染

## What is the new behavior?


## Other information
