### PR TITLE
fix(cdk:drag-drop): the shard context was not initalized correctly

### DIFF
--- a/packages/cdk/drag-drop/src/utils.ts
+++ b/packages/cdk/drag-drop/src/utils.ts
@@ -19,15 +19,12 @@ const useDnDContext = createSharedComposable(useDragDropContext)
  * @param targetContext
  */
 export const initContext = (targetContext?: DnDContext): DnDContext => {
-  let context = {} as DnDContext
   // default context is window
   if (!targetContext) {
     const root = document as unknown as HTMLElement
+    const context = useDnDContext(root)
     if (!_dnDContextMap.has(root)) {
-      context = useDnDContext(root)
       _dnDContextMap.set(root, context)
-    } else {
-      context = _dnDContextMap.get(root)!
     }
     return context
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 挂载在 document 的 context 初始化的逻辑不正确
- 导致了 #1436 的 bug

## What is the new behavior?

- 正确使用 createSharedComposable， 保证全局共享的 context 的唯一性


## Other information
