### PR TITLE
fix(comp:button): fix icon not vertically centered

### DIFF
--- a/packages/components/button/style/index.less
+++ b/packages/components/button/style/index.less
@@ -6,8 +6,9 @@
   .reset-color(@button-color, @button-background-color);
 
   position: relative;
-  display: inline-block;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   white-space: nowrap;
   cursor: pointer;
   user-select: none;

--- a/packages/components/button/style/mixin.less
+++ b/packages/components/button/style/mixin.less
@@ -3,7 +3,7 @@
 
   height: @height;
   min-width: @min-width;
-  padding: calc((@height - @font-size - var(--ix-line-height-gutter) - 2px) / 2) @padding-horizontal;
+  padding: 0 @padding-horizontal;
 
   &.@{button-prefix}-circle,
   &.@{button-prefix}-square {

--- a/packages/components/drawer/style/index.less
+++ b/packages/components/drawer/style/index.less
@@ -59,6 +59,7 @@
   }
 
   &-footer {
+    display: flex;
     padding: 12px 16px;
 
     .@{button-prefix} + .@{button-prefix} {

--- a/packages/components/modal/style/index.less
+++ b/packages/components/modal/style/index.less
@@ -124,7 +124,8 @@
   }
 
   &-footer {
-    text-align: end;
+    display: flex;
+    justify-content: flex-end;
     padding: 12px 16px;
 
     .@{button-prefix} + .@{button-prefix} {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
按钮中的图标没办法居中对齐
![Snipaste_2023-04-24_19-28-13](https://user-images.githubusercontent.com/26105153/233987495-1be37883-4f1e-4ce5-b06b-9c85be74ddd0.png)

## What is the new behavior?
使用flex居中对齐
![Snipaste_2023-04-24_19-30-29](https://user-images.githubusercontent.com/26105153/233987531-5638020f-f763-4263-8362-f58b04f66a3e.png)


## Other information
此修改会影响到：带图标和没带图标按钮同时存在时的垂直对齐，请使用`IxButtonGroup` 或者 `IxSpace` ，或者`flex`样式包裹即可
![image](https://user-images.githubusercontent.com/26105153/233988292-8228e446-9481-4bcd-919f-2457b88c9de0.png)
