### PR TITLE
fix(comp:tooltip): visible is not work when destroyOnHide is true

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -67,16 +67,18 @@ export default defineComponent({
     onMounted(() => initialize())
     onBeforeUnmount(() => destroy())
 
-    watch(visibility, value => callEmit(props['onUpdate:visible'], value))
+    watch(visibility, value => {
+      if (value && props.destroyOnHide) {
+        initialize()
+      }
+      callEmit(props['onUpdate:visible'], value)
+    })
     watch(placement, value => callEmit(props['onUpdate:placement'], value))
     watch(popperOptions, options => update(options))
     watch(
       () => props.visible,
       visible => {
         visible ? show() : hide()
-        if (visible && props.destroyOnHide) {
-          initialize()
-        }
       },
       { flush: 'post' },
     )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
```
<template>
    <IxTooltip title="prompt text" trigger="manual" :visible="visible" destroyOnHide>
      <IxButton @click="visible = !visible">Manual</IxButton>
    </IxTooltip>
</template>

<script lang="ts">
import { defineComponent, ref } from 'vue'

export default defineComponent({
  setup() {
    const visible = ref(false)
    return { visible }
  },
})
</script>
```
点击button，无法显示tooltip
## What is the new behavior?
正常显示

## Other information
