### PR TITLE
fix(comp:*): overlay animating cls should be set only at leaving

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -91,7 +91,7 @@ export default defineComponent({
     )
 
     const [isAnimating, setIsAnimating] = useState(false)
-    const onBeforeEnter = () => {
+    const onBeforeLeave = () => {
       setIsAnimating(true)
     }
     const onAfterLeave = () => {
@@ -152,7 +152,7 @@ export default defineComponent({
         <>
           {trigger}
           <CdkPortal target={mergedContainer.value} load={visibility.value}>
-            <Transition appear name={props.transitionName} onBeforeEnter={onBeforeEnter} onAfterLeave={onAfterLeave}>
+            <Transition appear name={props.transitionName} onBeforeLeave={onBeforeLeave} onAfterLeave={onAfterLeave}>
               {content}
             </Transition>
           </CdkPortal>

--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -27,7 +27,7 @@ import { isFunction } from 'lodash-es'
 import { vClickOutside } from '@idux/cdk/click-outside'
 import { type PopperElement, type PopperEvents, type PopperOptions, usePopper } from '@idux/cdk/popper'
 import { CdkPortal } from '@idux/cdk/portal'
-import { Logger, callEmit, convertElement, getFirstValidNode, useState } from '@idux/cdk/utils'
+import { Logger, callEmit, convertElement, getFirstValidNode } from '@idux/cdk/utils'
 import { useGlobalConfig } from '@idux/components/config'
 import { useZIndex } from '@idux/components/utils'
 
@@ -90,12 +90,7 @@ export default defineComponent({
       { immediate: true },
     )
 
-    const [isAnimating, setIsAnimating] = useState(false)
-    const onBeforeLeave = () => {
-      setIsAnimating(true)
-    }
     const onAfterLeave = () => {
-      setIsAnimating(false)
       if (props.destroyOnHide) {
         destroy()
       }
@@ -139,7 +134,6 @@ export default defineComponent({
         props,
         mergedPrefixCls,
         visibility,
-        isAnimating,
         currentZIndex,
         contentNode!,
         contentArrowRef,
@@ -152,7 +146,7 @@ export default defineComponent({
         <>
           {trigger}
           <CdkPortal target={mergedContainer.value} load={visibility.value}>
-            <Transition appear name={props.transitionName} onBeforeLeave={onBeforeLeave} onAfterLeave={onAfterLeave}>
+            <Transition appear name={props.transitionName} onAfterLeave={onAfterLeave}>
               {content}
             </Transition>
           </CdkPortal>
@@ -182,7 +176,6 @@ function renderContent(
   props: OverlayProps,
   mergedPrefixCls: ComputedRef<string>,
   visibility: ComputedRef<boolean>,
-  isAnimating: ComputedRef<boolean>,
   currentZIndex: ComputedRef<number>,
   contentNode: VNode[],
   arrowRef: Ref<PopperElement | undefined>,
@@ -195,16 +188,12 @@ function renderContent(
   }
 
   const prefixCls = mergedPrefixCls.value
-  const classes = {
-    [prefixCls]: true,
-    [`${prefixCls}-animating`]: isAnimating.value,
-  }
 
   const { triggerId } = props
   const overlayId = triggerId != null ? `__IDUX_OVERLAY-${triggerId}` : undefined
   const style = `z-index: ${currentZIndex.value}`
   const overlay = (
-    <div ref={popperRef} id={overlayId} class={classes} style={style} {...popperEvents.value} {...attrs}>
+    <div ref={popperRef} id={overlayId} class={prefixCls} style={style} {...popperEvents.value} {...attrs}>
       {contentNode}
       {props.showArrow && <div ref={arrowRef} class={`${prefixCls}-arrow`}></div>}
     </div>

--- a/packages/components/_private/overlay/style/index.less
+++ b/packages/components/_private/overlay/style/index.less
@@ -66,7 +66,7 @@
     }
   }
 
-  &[data-popper-reference-hidden]:not(&-animating) {
+  &[data-popper-reference-hidden] {
     visibility: hidden;
     opacity: 0;
     pointer-events: none;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
trigger隐藏的情况下，正在进行动画过渡的浮层还会显示

## What is the new behavior?
修复以上问题

## Other information
最初是为了解决高级搜索中失焦之后输入框隐藏导致动画不生效的问题，现在由于修改了实现方式输入框不会隐藏，直接去掉动画的判断会更符合逻辑