### PR TITLE
fix(pro:search): segment states should be reset after blur

### DIFF
--- a/packages/pro/search/src/composables/useSegmentStates.ts
+++ b/packages/pro/search/src/composables/useSegmentStates.ts
@@ -191,6 +191,10 @@ export function useSegmentStates(
     const validateRes = validateSearchState(key)
     const searchValue = convertStateToValue(key)
 
+    Object.entries(segmentStates.value).forEach(([name, state]) => {
+      updateSegmentValue(state.value, name, key)
+    })
+
     if (!validateRes) {
       removeSearchState(key)
     } else {
@@ -216,8 +220,7 @@ export function useSegmentStates(
     if (!segmentState) {
       return
     }
-    const { value, index } = segmentState
-    updateSegmentValue(value, name, props.searchItem!.key)
+    const { index } = segmentState
 
     // only confirm searchItem when the last segment is confirmed
     // if the last segment is searchItem name, confirm the searchItem only when no searchField is selected


### PR DESCRIPTION
segment states need to be reset after blur when its not confirmed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
修改搜索项标签内容不回车确认，在失焦后搜索项标签内容不会重置

## What is the new behavior?
在搜索项没有确认的情况下失焦，即激活状态改变为非激活，标签内容应当重置

## Other information
