### PR TITLE
fix(pro:search): item created by shortcut shoule be set active

### DIFF
--- a/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
@@ -9,7 +9,7 @@ import type { SearchState } from '../../composables/useSearchStates'
 
 import { computed, defineComponent, inject, normalizeClass, ref, watch } from 'vue'
 
-import { useState } from '@idux/cdk/utils'
+import { callEmit, useState } from '@idux/cdk/utils'
 import { type IconInstance, IxIcon } from '@idux/components/icon'
 import { IxInput } from '@idux/components/input'
 
@@ -20,7 +20,9 @@ export default defineComponent({
   props: quickSelectPanelItemProps,
   setup(props, { slots }) {
     const {
+      props: proSearchProps,
       mergedPrefixCls,
+      convertStateToValue,
       createSearchState,
       getSearchStatesByFieldKey,
       updateSegmentValue,
@@ -67,6 +69,10 @@ export default defineComponent({
         searchStateKey = createSearchState(props.searchField.key, {
           value,
         })!.key
+        callEmit(proSearchProps.onItemCreate, {
+          ...convertStateToValue(searchStateKey),
+          nameInput: props.searchField.label,
+        })
       } else if (searchDataSegment.value?.name) {
         updateSegmentValue(value, searchDataSegment.value.name, searchState.value.key)
       }

--- a/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
@@ -7,6 +7,7 @@
 
 import { defineComponent, inject } from 'vue'
 
+import { callEmit } from '@idux/cdk/utils'
 import { IxIcon } from '@idux/components/icon'
 
 import { proSearchContext } from '../../token'
@@ -15,14 +16,34 @@ import { quickSelectPanelShortcutProps } from '../../types'
 export default defineComponent({
   props: quickSelectPanelShortcutProps,
   setup(props) {
-    const { mergedPrefixCls, createSearchState, updateSearchState, getSearchStatesByFieldKey } =
-      inject(proSearchContext)!
+    const {
+      props: proSearchProps,
+      mergedPrefixCls,
+      convertStateToValue,
+      createSearchState,
+      updateSearchState,
+      getSearchStatesByFieldKey,
+      setActiveSegment,
+    } = inject(proSearchContext)!
 
     const handleClick = () => {
       const fieldKey = props.searchField.key
-      if (!!props.searchField.multiple || !getSearchStatesByFieldKey(fieldKey).length) {
-        const state = createSearchState(props.searchField.key)
-        state && updateSearchState(state.key)
+      if (!props.searchField.multiple && getSearchStatesByFieldKey(fieldKey).length) {
+        return
+      }
+
+      const state = createSearchState(props.searchField.key)
+
+      if (state) {
+        updateSearchState(state.key)
+        callEmit(proSearchProps.onItemCreate, {
+          ...convertStateToValue(state.key),
+          nameInput: props.searchField.label,
+        })
+        setActiveSegment({
+          itemKey: state.key,
+          name: state.segmentValues[0]?.name,
+        })
       }
     }
 


### PR DESCRIPTION
 item created by shortcut shoule be set active after created and onItemCreate should be called

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
通过快捷选择面板的shortcut创建标签后没有将焦点移动到新创建的标签上

## What is the new behavior?
应当在创建后立即设置新标签为激活状态，并展开对应的面板

## Other information
