### PR TITLE
fix(pro:search): clicking search button should trigger value change

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -143,9 +143,11 @@ export default defineComponent({
     }
     const handleSearchBtnMouseDown = (evt: MouseEvent) => {
       evt.preventDefault()
+      evt.stopImmediatePropagation()
     }
     const handleClearBtnMouseDown = (evt: MouseEvent) => {
       evt.preventDefault()
+      evt.stopImmediatePropagation()
     }
 
     provide(proSearchContext, {

--- a/packages/pro/search/src/composables/useSegmentStates.ts
+++ b/packages/pro/search/src/composables/useSegmentStates.ts
@@ -188,12 +188,13 @@ export function useSegmentStates(
   }
   const confirmSearchItem = () => {
     const key = props.searchItem!.key
-    const validateRes = validateSearchState(key)
-    const searchValue = convertStateToValue(key)
 
     Object.entries(segmentStates.value).forEach(([name, state]) => {
       updateSegmentValue(state.value, name, key)
     })
+
+    const validateRes = validateSearchState(key)
+    const searchValue = convertStateToValue(key)
 
     if (!validateRes) {
       removeSearchState(key)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
点击搜索按钮会重置正在编辑的标签

## What is the new behavior?
不应当重置，应当保存当前状态并触发值的修改

## Other information
问题在于按钮的mousedown没有阻止冒泡，导致触发了useControl中的全局mousedown，导致了激活状态的变化