### PR TITLE
fix(pro:search): input searchField trim not working

### DIFF
--- a/packages/pro/search/src/segments/createInputSegment.ts
+++ b/packages/pro/search/src/segments/createInputSegment.ts
@@ -17,7 +17,7 @@ export function createInputSegment(prefixCls: string, searchField: InputSearchFi
     name: 'input',
     inputClassName: [inputClassName, `${prefixCls}-input-segment-input`],
     placeholder: searchField.placeholder,
-    parse: input => (input ? input : undefined),
+    parse: input => (input ? (trim ? input.trim() : input) : undefined),
     format: value => (trim ? value?.trim() : value) ?? '',
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
input 类型的搜索项，trim在输入的时候不起作用


## What is the new behavior?
修复以上问题

## Other information
