### PR TITLE
style(pro:search): shortcuts in quickselect use margin-right instead

### DIFF
--- a/packages/pro/search/style/quick-select.less
+++ b/packages/pro/search/style/quick-select.less
@@ -39,8 +39,8 @@
     align-items: center;
     background-color: @color-graphite-l40;
     border-radius: 2px;
-    &:not(&:first-child) {
-      margin-left: 8px;
+    &:not(&:last-child) {
+      margin-right: 8px;
     }
 
     cursor: pointer;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
间距使用了margin-left，导致换行后左边会不对齐

## What is the new behavior?
改用margin-right

## Other information
