### PR TITLE
fix(comp:select): the placeholder in overlay can't setting

### DIFF
--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -193,6 +193,7 @@ export default defineComponent({
               clearable
               clearIcon={clearIcon}
               clearVisible={!!value}
+              placeholder={props.searchPlaceholder}
               size="sm"
               suffix="search"
               value={value}

--- a/packages/components/select/src/types.ts
+++ b/packages/components/select/src/types.ts
@@ -80,6 +80,7 @@ export const selectProps = {
   readonly: { type: Boolean, default: false },
   searchable: { type: [Boolean, String] as PropType<boolean | 'overlay'>, default: false },
   searchFn: { type: [Boolean, Function] as PropType<boolean | SelectSearchFn>, default: true },
+  searchPlaceholder: { type: String, default: undefined },
   size: { type: String as PropType<FormSize>, default: undefined },
   status: String as PropType<ValidateStatus>,
   suffix: { type: String, default: undefined },

--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -192,7 +192,8 @@
   // --------- Selectable ---------
   &-selectable-trigger {
     margin-left: @spacing-xs;
-    color: @table-head-icon-color;
+    color: @table-head-color;
+    font-size: var(--ix-font-size-lg);
     cursor: pointer;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 设置 searchable=‘false’ 的时候，不能设置面板中搜索框的 placeholder 

## What is the new behavior?


## Other information
