### PR TITLE
fix(comp:select): the onSearch should be called when the intput is clear

### DIFF
--- a/packages/components/_private/selector/src/Selector.tsx
+++ b/packages/components/_private/selector/src/Selector.tsx
@@ -124,6 +124,7 @@ export default defineComponent({
       }
       evt.stopPropagation()
       callEmit(props.onClear, evt)
+      mergedSearchable.value && callEmit(props.onSearch, '')
     }
 
     provide(selectorToken, {

--- a/packages/components/cascader/src/Cascader.tsx
+++ b/packages/components/cascader/src/Cascader.tsx
@@ -96,7 +96,6 @@ export default defineComponent({
       selectedStateContext.handleSelect(key)
     }
     const handleClear = (evt: MouseEvent) => {
-      evt.stopPropagation()
       setValue([])
       callEmit(props.onClear, evt)
     }
@@ -157,7 +156,10 @@ export default defineComponent({
       setInputValue(value)
       props.searchable && callEmit(props.onSearch, value)
     }
-    const handleSearchClear = () => setInputValue('')
+    const handleSearchClear = () => {
+      setInputValue('')
+      props.searchable && callEmit(props.onSearch, '')
+    }
     const renderContent = () => {
       const { searchable, overlayRender } = props
       const searchValue = inputValue.value

--- a/packages/components/notification/src/types.ts
+++ b/packages/components/notification/src/types.ts
@@ -10,9 +10,6 @@ import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } 
 import type { ButtonProps } from '@idux/components/button'
 import type { DefineComponent, HTMLAttributes, PropType, VNode, VNodeProps } from 'vue'
 
-// 挑出部分必填的属性
-type PickRequire<T, U extends keyof T> = Pick<T, Exclude<keyof T, U>> & Required<Pick<T, U>>
-
 export interface NotificationButtonProps<K = VKey> extends ButtonProps {
   key?: K
   text?: string | VNode
@@ -69,8 +66,8 @@ export type NotificationComponent = DefineComponent<
 export type NotificationInstance = InstanceType<DefineComponent<NotificationProps>>
 
 // 通过useNotification的配置
-export interface NotificationOptions<K = VKey> extends PickRequire<NotificationProps, 'title' | 'content'> {
-  key: K
+export interface NotificationOptions<K = VKey> extends NotificationProps {
+  key?: K
   contentProps?: Record<string, unknown> | VNodeProps
   onDestroy?: (key: K) => void
 }

--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -185,7 +185,10 @@ export default defineComponent({
           setInputValue(value)
           props.searchable && callEmit(props.onSearch, value)
         }
-        const handleSearchClear = () => setInputValue('')
+        const handleSearchClear = () => {
+          setInputValue('')
+          props.searchable && callEmit(props.onSearch, '')
+        }
 
         children.unshift(
           <div class={`${mergedPrefixCls.value}-overlay-search-wrapper`}>

--- a/packages/components/tree-select/src/composables/useSelectedState.ts
+++ b/packages/components/tree-select/src/composables/useSelectedState.ts
@@ -58,7 +58,6 @@ export function useSelectedState(
   }
 
   const handleClear = (evt: MouseEvent) => {
-    evt.stopPropagation()
     setValue([])
     callEmit(props.onClear, evt)
   }

--- a/packages/components/tree-select/src/content/Content.tsx
+++ b/packages/components/tree-select/src/content/Content.tsx
@@ -128,7 +128,10 @@ export default defineComponent({
       setInputValue(value)
       props.searchable && callEmit(props.onSearch, value)
     }
-    const handleClear = () => setInputValue('')
+    const handleClear = () => {
+      setInputValue('')
+      props.searchable && callEmit(props.onSearch, '')
+    }
 
     return () => {
       const {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 设置 searchable = true 时，点击输入框的清除图标，不会触发 onSearch 事件，仅触发 onClear 事件
- 设置 searchable = ’overlay‘ 时，点击浮层中输入框的清除图标，不会触发任何事件

## What is the new behavior?

- 现在都会触发 onSearch 事件，参数为 '' 空字符。
- 受影响的组件有：Cascader， Select, TreeSelect


## Other information
