### PR TITLE
fix(comp:modal): the size of button should be 'md'

### DIFF
--- a/packages/components/modal/src/ModalWrapper.tsx
+++ b/packages/components/modal/src/ModalWrapper.tsx
@@ -147,6 +147,8 @@ export default defineComponent({
 
     return () => {
       const prefixCls = mergedPrefixCls.value
+      const okButton = { size: 'md', ...props.okButton } as const
+      const cancelButton = { size: 'md', ...props.cancelButton } as const
 
       return (
         <div
@@ -191,13 +193,13 @@ export default defineComponent({
                   v-slots={slots}
                   class={`${prefixCls}-footer`}
                   cancel={handleCancel}
-                  cancelButton={props.cancelButton}
+                  cancelButton={cancelButton}
                   cancelLoading={cancelLoading.value}
                   cancelText={cancelText.value}
                   cancelVisible={cancelVisible.value}
                   footer={props.footer}
                   ok={handleOk}
-                  okButton={props.okButton}
+                  okButton={okButton}
                   okLoading={okLoading.value}
                   okText={okText.value}
                 ></ɵFooter>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Seer 主题下，Modal 的按钮默认为 ’sm‘

## What is the new behavior?

- 改为 `md`


## Other information
