### PR TITLE
style(comp:tree): change drop target node box-shadow to inset

### DIFF
--- a/packages/components/tree/style/index.less
+++ b/packages/components/tree/style/index.less
@@ -293,15 +293,15 @@
 
     &-drop-parent,
     &-drop-inside {
-      box-shadow: 0 0 0 @tree-box-shadow-size @tree-box-shadow-color;
+      box-shadow: 0 0 0 @tree-box-shadow-size @tree-box-shadow-color inset;
     }
 
     &-drop-before .@{tree-node-prefix}-content {
-      box-shadow: 0 -@tree-box-shadow-size 0 0 @tree-box-shadow-color;
+      box-shadow: 0 @tree-box-shadow-size 0 0 @tree-box-shadow-color inset;
     }
 
     &-drop-after .@{tree-node-prefix}-content {
-      box-shadow: 0 @tree-box-shadow-size 0 0 @tree-box-shadow-color;
+      box-shadow: 0 -@tree-box-shadow-size 0 0 @tree-box-shadow-color inset;
     }
   }
 }


### PR DESCRIPTION
change drop target node box-shadow to inset to prevent overflow

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
第一个和最后一个节点作为拖动目标的时候，box-shadow不会显示，因为容器配置了 overflow: auto
## What is the new behavior?
修改box-shadow为inset，调整样式

如果是inside，则由原先的两条线变成完整的线框

## Other information
