### PR TITLE
fix(comp:date-picker): start and end cell calculation error

### DIFF
--- a/packages/components/_private/date-panel/src/panel-body/PanelCell.tsx
+++ b/packages/components/_private/date-panel/src/panel-body/PanelCell.tsx
@@ -61,8 +61,12 @@ export default defineComponent({
     const cellTooltip = computed(() =>
       panelProps.cellTooltip?.({ value: cellDate.value, disabled: !!isDisabled.value }),
     )
-    const isStart = computed(() => startDate.value && dateConfig.isSame(startDate.value, cellDate.value, 'date'))
-    const isEnd = computed(() => endDate.value && dateConfig.isSame(endDate.value, cellDate.value, 'date'))
+    const isStart = computed(
+      () => startDate.value && dateConfig.isSame(startDate.value, cellDate.value, getPanelCellType(activeType.value)),
+    )
+    const isEnd = computed(
+      () => endDate.value && dateConfig.isSame(endDate.value, cellDate.value, getPanelCellType(activeType.value)),
+    )
     const isCurrent = computed(() =>
       dateConfig.isSame(cellDate.value, dateConfig.now(), getPanelCellType(activeType.value)),
     )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
时间日期范围的开始和结束cell，计算时使用的判断基准类型不正确，导致年、月面板中计算错误

## What is the new behavior?
修复以上问题，根据不同的面板类型使用不同的比对基准

## Other information
