### PR TITLE
style(comp:menu): modify menu item height for seer

### DIFF
--- a/packages/components/menu/style/themes/seer.variable.less
+++ b/packages/components/menu/style/themes/seer.variable.less
@@ -1,7 +1,6 @@
 @import './default.variable.less';
 
-@menu-height: 36px;
-@menu-height-level-1: 44px;
+@menu-height-level-1: 40px;
 @menu-border-radius: 0;
 @menu-font-size: var(--ix-font-size-sm);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
seer主题的menu item高度不符合设计

## What is the new behavior?
普通高度和default一样是32px，1级高度为40

## Other information
