### PR TITLE
fix(pro:table): the checkbox logic in the layout tool tree is incorrect

### DIFF
--- a/packages/pro/table/src/contents/LayoutToolContent.tsx
+++ b/packages/pro/table/src/contents/LayoutToolContent.tsx
@@ -15,6 +15,7 @@ import { IxCheckbox } from '@idux/components/checkbox'
 import LayoutToolTree from './LayoutToolTree'
 import { proTableToken } from '../token'
 import { type ProTableColumn, proTableLayoutToolContentProps } from '../types'
+import { loopColumns } from '../utils'
 
 export default defineComponent({
   props: proTableLayoutToolContentProps,
@@ -42,8 +43,8 @@ export default defineComponent({
 
     const handleCheckAll = (checked: boolean) => {
       loopColumns(mergedColumns.value, column => {
-        // undefined or true
-        if (column.changeVisible !== false) {
+        // use child cascaderStrategy，undefined or true
+        if (!column.children && column.changeVisible !== false) {
           column.visible = checked
         }
       })
@@ -168,16 +169,4 @@ function groupColumns(mergedColumns: ProTableColumn[]) {
   })
 
   return { startColumns, endColumns, centerColumns }
-}
-
-function loopColumns(columns: ProTableColumn[] | undefined, cb: (column: ProTableColumn) => void) {
-  if (!columns || columns.length === 0) {
-    return
-  }
-  columns.forEach(column => {
-    cb(column)
-    if ('children' in column) {
-      loopColumns(column.children!, cb)
-    }
-  })
 }

--- a/packages/pro/table/src/contents/LayoutToolTree.tsx
+++ b/packages/pro/table/src/contents/LayoutToolTree.tsx
@@ -26,25 +26,19 @@ export default defineComponent({
   },
   setup(props) {
     const key = useKey()
-    const { locale, mergedPrefixCls, mergedColumnMap } = inject(proTableToken)!
+    const { locale, mergedPrefixCls } = inject(proTableToken)!
 
     const checkedKeys = computed(() => getCheckedKeys(props.columns))
 
     const onCheck = (checked: boolean, column: ProTableColumn) => {
-      column.visible = checked
-      loopColumns(column.children, child => {
-        child.visible = checked
-      })
-      if (checked) {
-        const map = mergedColumnMap.value
-        let currColumn = column
-        while (currColumn?.parentKey) {
-          const parent = map.get(currColumn.parentKey)
-          if (parent && parent.visible === false) {
-            parent.visible = undefined
+      if (!column.children) {
+        column.visible = checked
+      } else {
+        loopColumns(column.children, child => {
+          if (!child.children && child.changeVisible !== false) {
+            child.visible = checked
           }
-          currColumn = parent
-        }
+        })
       }
       props.onVisibleChange()
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
布局设置中的树勾选逻辑错误，对于禁用的列是不允许通过父级修改的
![GIF 2023-7-4 11-05-50](https://github.com/IDuxFE/idux/assets/26105153/8597f8b3-12c0-46c0-a28c-2f8e55e89eff)



## What is the new behavior?
![GIF 2023-7-4 11-08-11](https://github.com/IDuxFE/idux/assets/26105153/bac7f13b-42bf-4694-ace5-aea675335510)

将树的勾选策略改为child，只需要收集子节点勾选项即可，具体禁用和勾选的联动通过tree内部去实现

## Other information
