### PR TITLE
fix(pro:search): shortcut compont should provide comp name

### DIFF
--- a/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
@@ -14,6 +14,7 @@ import { proSearchContext } from '../../token'
 import { type SearchField, quickSelectPanelShortcutProps } from '../../types'
 
 export default defineComponent({
+  name: 'IxProSearchShortcut',
   props: quickSelectPanelShortcutProps,
   setup(props, { slots }) {
     const {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
IxProSearchShortcut 没有 name


## What is the new behavior?
修复以上问题


## Other information
