### PR TITLE
fix(comp:textarea): boxsizing data parse error in firefox

### DIFF
--- a/packages/components/textarea/src/utils/getBoxSizingData.ts
+++ b/packages/components/textarea/src/utils/getBoxSizingData.ts
@@ -18,10 +18,10 @@ export interface BoxSizingData {
 export function getBoxSizingData(node: HTMLElement): BoxSizingData {
   const { boxSizing, paddingBottom, paddingTop, borderBottom, borderTop } = window.getComputedStyle(node)
 
-  const _paddingTop = parseFloat(paddingTop)
-  const _paddingBottom = parseFloat(paddingBottom)
-  const _borderTop = parseFloat(borderTop)
-  const _borderBottom = parseFloat(borderBottom)
+  const _paddingTop = parseSize(paddingTop)
+  const _paddingBottom = parseSize(paddingBottom)
+  const _borderTop = parseSize(borderTop)
+  const _borderBottom = parseSize(borderBottom)
 
   return {
     boxSizing,
@@ -32,4 +32,10 @@ export function getBoxSizingData(node: HTMLElement): BoxSizingData {
     borderTop: _borderTop,
     borderBottom: _borderBottom,
   }
+}
+
+function parseSize(size: string): number {
+  const parsedSize = parseFloat(size)
+
+  return Number.isNaN(parsedSize) ? 0 : parsedSize
 }


### PR DESCRIPTION
boxsizing data got from computed style is empty string in firefox, causing paseFloat to return NaN

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
火狐浏览器下，没有提供样式的属性，getComputedStyle计算出来的是空字符串，导致计算结果为NaN

## What is the new behavior?
修复以上问题

## Other information
