### PR TITLE
fix(comp:select): pressing enter after chinese input

### DIFF
--- a/packages/components/_private/selector/src/composables/useInputState.ts
+++ b/packages/components/_private/selector/src/composables/useInputState.ts
@@ -75,6 +75,7 @@ export function useInputState(props: SelectorProps, mergedSearchable: ComputedRe
   // 处理中文输入法下的回车无法触发 compositionEnd 事件的问题
   const handleEnterDown = (evt: KeyboardEvent) => {
     if (evt.code === 'Enter' && isComposing.value) {
+      evt.stopImmediatePropagation()
       handleCompositionEnd(evt as any)
     }
   }

--- a/packages/components/select/src/composables/usePanelActiveState.ts
+++ b/packages/components/select/src/composables/usePanelActiveState.ts
@@ -47,10 +47,16 @@ export function usePanelActiveState(
     key !== activeValue.value && setActiveValue(flattenedOptions.value[index]?.key)
   }
 
-  watch([() => props.activeValue, flattenedOptions], ([value, options]) => {
-    const targetIndex = isNil(value) ? -1 : keyIndexMap.value.get(value) ?? -1
-    setActiveIndex(targetIndex !== -1 ? getEnabledActiveIndex(options, targetIndex, 1) : -1)
-  })
+  watch(
+    [() => props.activeValue, flattenedOptions],
+    ([value, options]) => {
+      const targetIndex = isNil(value) ? -1 : keyIndexMap.value.get(value) ?? -1
+      setActiveIndex(targetIndex !== -1 ? getEnabledActiveIndex(options, targetIndex, 1) : -1)
+    },
+    {
+      flush: 'post',
+    },
+  )
 
   const scrollToActivated = () => {
     scrollTo({ index: activeIndex.value })


### PR DESCRIPTION
unexpected selection created after pressing enter key when input is in chinese and allowInput is enabled

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
allowInput开启时， 中文输入法下，直接按回车，有几率直接触发选择项的创建，此时输入的怕拼音字母内容会被保留显示，但实际为空

## What is the new behavior?
修复以上问题

## Other information
