### PR TITLE
fix(pro:search): empty state should be determined by search states

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -64,11 +64,14 @@ export default defineComponent({
     const tempSegmentInputRef = ref<HTMLInputElement>()
 
     const searchValueContext = useSearchValues(props)
-    const { searchValues, searchValueEmpty } = searchValueContext
+    const { searchValues } = searchValueContext
     const resolvedSearchFieldsContext = useResolvedSearchFields(props, mergedPrefixCls, dateConfig)
     const { fieldKeyMap } = resolvedSearchFieldsContext
     const searchStateContext = useSearchStates(props, fieldKeyMap, searchValueContext)
-    const { initSearchStates, clearSearchState, updateSearchValues, isSegmentVisible } = searchStateContext
+    const { searchStates, initSearchStates, clearSearchState, updateSearchValues, isSegmentVisible } =
+      searchStateContext
+
+    const searchStateEmpty = computed(() => !searchStates.value || searchStates.value.length <= 0)
 
     const errors = useSearchItemErrors(props, searchValues)
     const searchItems = useSearchItems(fieldKeyMap, searchStateContext.searchStates, errors)
@@ -196,11 +199,11 @@ export default defineComponent({
                 getKey={item => item.key ?? 'name-select'}
                 maxLabel={focused.value ? Number.MAX_SAFE_INTEGER : props.maxLabel}
               />
-              {searchValueEmpty.value && !isActive.value && (
+              {searchStateEmpty.value && !isActive.value && (
                 <span class={`${prefixCls}-placeholder`}>{placeholder.value}</span>
               )}
             </div>
-            {!searchValueEmpty.value && clearable.value && !props.disabled && (
+            {!searchStateEmpty.value && clearable.value && !props.disabled && (
               <div
                 class={`${prefixCls}-clear-icon`}
                 onMousedown={handleClearBtnMouseDown}

--- a/packages/pro/search/src/composables/useSearchValues.ts
+++ b/packages/pro/search/src/composables/useSearchValues.ts
@@ -6,14 +6,12 @@
  */
 
 import type { ProSearchProps, SearchValue } from '../types'
-
-import { type ComputedRef, computed } from 'vue'
+import type { ComputedRef } from 'vue'
 
 import { useControlledProp } from '@idux/cdk/utils'
 
 export interface SearchValueContext {
   searchValues: ComputedRef<SearchValue[] | undefined>
-  searchValueEmpty: ComputedRef<boolean>
   setSearchValues: (values: SearchValue[]) => void
 }
 
@@ -21,11 +19,9 @@ export const tempSearchStateKey = 'temp'
 
 export function useSearchValues(props: ProSearchProps): SearchValueContext {
   const [searchValues, setSearchValues] = useControlledProp(props, 'value')
-  const searchValueEmpty = computed(() => !searchValues.value || searchValues.value.length <= 0)
 
   return {
     searchValues,
-    searchValueEmpty,
     setSearchValues,
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
存在临时标签但value是空的时候，placeholder异常显示

## What is the new behavior?
高级搜索的标签渲染直接与searchStates数据相关，空状态也应当根据searchStates判断

## Other information
