### PR TITLE
feat(pro:search): bluring segment with no panel triggers update now

### DIFF
--- a/packages/pro/search/src/components/SearchItem.tsx
+++ b/packages/pro/search/src/components/SearchItem.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
       segmentsRef.value?.scrollTo(0, 0)
     })
 
-    const segmentStateContext = useSegmentStates(props, proSearchProps, context, isActive)
+    const segmentStateContext = useSegmentStates(props, proSearchProps, context)
     const segmentOverlayUpdateContext = useSegmentOverlayUpdate()
     const { searchState, segmentStates } = segmentStateContext
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
所有的搜索项必须回车确认或者点击面板的确认按钮才会触发value的更新，对于没有面板的搜索项，体验不友好

## What is the new behavior?
修改为，如果某个搜索项正在操作的输入段不存在面板，且在输入之后搜索项合法可更新，则在blur的时候更新value

## Other information
修改之后回车确认会同时触发blur，导致重复更新，因此在updateSearchValue的原基础上加上执行队列并在宏任务的粒度上串行执行，保证单词操作不会重复触发更新