### PR TITLE
fix(comp:tour): active step incorrect when async

### DIFF
--- a/packages/components/tour/__tests__/tour.spec.ts
+++ b/packages/components/tour/__tests__/tour.spec.ts
@@ -117,6 +117,7 @@ describe('Tour', () => {
     )
 
     await wrapper.setProps({ activeIndex: 1 })
+    await wait(50)
     await flushPromises()
 
     expect(document.querySelector('.active-index-test .ix-tour-panel .ix-header .ix-header-title')?.textContent).toBe(

--- a/packages/components/tour/src/Tour.tsx
+++ b/packages/components/tour/src/Tour.tsx
@@ -29,8 +29,9 @@ import { tourProps } from './types'
 
 export default defineComponent({
   name: 'IxTour',
+  inheritAttrs: false,
   props: tourProps,
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const common = useGlobalConfig('common')
     const config = useGlobalConfig('tour')
     const locale = useGlobalConfig('locale')
@@ -52,7 +53,7 @@ export default defineComponent({
 
     useCloseTrigger(mergedProps, positionInfo, visible, setVisible)
     const stepChangeContext = useStepChange(mergedProps, activeIndex, activeStep, visible, onAnimateEnd)
-    const { isStepChanging } = stepChangeContext
+    const { isStepChanging, onStepChange } = stepChangeContext
 
     const mergedContainerFallback = computed(() => `.${mergedPrefixCls.value}-overlay-container`)
     const mergedContainer = computed(() => mergedProps.value.overlayContainer ?? mergedContainerFallback.value)
@@ -65,6 +66,7 @@ export default defineComponent({
       isStepChanging,
       visible,
       currentZIndex,
+      onStepChange,
     )
 
     const placeholderStyle = computed(() => {
@@ -108,7 +110,7 @@ export default defineComponent({
               <Mask v-show={visible.value && !!activeStep.value?.mask} />
             </Transition>
           </CdkPortal>
-          <ɵOverlay class={`${prefixCls}-overlay`} {...overlayProps.value} v-slots={overlaySlots} />
+          <ɵOverlay class={`${prefixCls}-overlay`} {...overlayProps.value} {...attrs} v-slots={overlaySlots} />
         </>
       )
     }

--- a/packages/components/tour/src/composables/useActiveStep.ts
+++ b/packages/components/tour/src/composables/useActiveStep.ts
@@ -5,8 +5,8 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { MergedTourProps } from './useMergedProps'
 import type { ResolvedTourStep } from '../types'
+import type { MergedTourProps } from './useMergedProps'
 import type { ButtonMode, ButtonSize } from '@idux/components/button'
 import type { TourLocale } from '@idux/components/locales'
 
@@ -97,6 +97,11 @@ export function useActiveStep(
   }
 
   const pushCurrentUpdate = async (index: number) => {
+    if (index < 0) {
+      setActiveStep(undefined)
+      return
+    }
+
     const promise = getActiveStep(index)
 
     destructions.push(async () => {
@@ -113,15 +118,15 @@ export function useActiveStep(
 
   watch(
     activeIndex,
-    async (current, pre) => {
-      if (current === pre) {
+    async current => {
+      if (current === activeStep.value?.index) {
         return
       }
 
       destroySteps()
       pushCurrentUpdate(current)
     },
-    { immediate: true },
+    { immediate: true, flush: 'post' },
   )
 
   return activeStep

--- a/packages/components/tour/src/composables/useOverlayProps.ts
+++ b/packages/components/tour/src/composables/useOverlayProps.ts
@@ -5,12 +5,12 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { MergedTourProps } from './useMergedProps'
 import type { ResolvedTourStep } from '../types'
+import type { MergedTourProps } from './useMergedProps'
 import type { ɵOverlayProps } from '@idux/components/_private/overlay'
 import type { CommonConfig } from '@idux/components/config'
 
-import { type ComputedRef, computed } from 'vue'
+import { type ComputedRef, computed, ref } from 'vue'
 
 export function useOverlayProps(
   componentCommonConfig: CommonConfig,
@@ -20,13 +20,20 @@ export function useOverlayProps(
   isStepChanging: ComputedRef<boolean>,
   visible: ComputedRef<boolean>,
   currentZIndex: ComputedRef<number>,
+  onStepChange: (cb: () => void) => void,
 ): ComputedRef<ɵOverlayProps> {
+  const currentActiveStep = ref(activeStep.value)
+
+  onStepChange(() => {
+    currentActiveStep.value = activeStep.value
+  })
+
   return computed(() => {
     const { animatable, overlayContainer, offset } = mergedProps.value
-    const { placement = 'bottomStart', showArrow } = activeStep.value ?? {}
+    const { placement = 'bottomStart', showArrow } = currentActiveStep.value ?? {}
 
     return {
-      visible: visible.value && !!activeStep.value && !isStepChanging.value,
+      visible: visible.value && !!currentActiveStep.value && !isStepChanging.value,
       container: overlayContainer,
       containerFallback: containerFallback.value,
       trigger: 'manual',

--- a/packages/components/tour/src/types.ts
+++ b/packages/components/tour/src/types.ts
@@ -12,6 +12,8 @@ import type { DefineComponent, HTMLAttributes, PropType } from 'vue'
 
 import { ɵOverlayPlacementDef } from '@idux/components/_private/overlay'
 
+export type TargetPositionOrigin = 'resize' | 'scroll' | 'index' | 'visible'
+
 export interface TargetPositionInfo {
   windowWidth: number
   windowHeight: number
@@ -20,6 +22,7 @@ export interface TargetPositionInfo {
   width: number
   height: number
   radius: number
+  origin: TargetPositionOrigin
 }
 
 export interface TargetGap {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在asnyc模式下，即是用了beforeEnter，在进入下一步之前滚动鼠标，会导致当前的step计算不正确

## What is the new behavior?
修复以上问题

## Other information
