### PR TITLE
fix(pro:search): add min-height to select panel in quickselect

### DIFF
--- a/packages/pro/search/style/quick-select.less
+++ b/packages/pro/search/style/quick-select.less
@@ -119,6 +119,7 @@
       min-width: 252px;
     }
     .@{pro-search-prefix}-select-panel {
+      min-height: 230px;
       .@{select-option-prefix} {
         padding: 8px;
         &-selected:not(&-disabled) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
select面板在快捷搜索面板中没有最小高度，导致只有select时会没有高度

## What is the new behavior?
设置最小高度 230px

## Other information
