### PR TITLE
fix(comp:modal): header size should be sm when header has no content

### DIFF
--- a/packages/components/modal/src/ModalWrapper.tsx
+++ b/packages/components/modal/src/ModalWrapper.tsx
@@ -150,6 +150,11 @@ export default defineComponent({
       const okButton = { size: 'md', ...props.okButton } as const
       const cancelButton = { size: 'md', ...props.cancelButton } as const
 
+      const headerSlots = {
+        header: slots.header,
+        closeIcon: slots.closeIcon,
+      }
+
       return (
         <div
           v-show={mergedVisible.value}
@@ -181,11 +186,11 @@ export default defineComponent({
               <div ref={contentRef} class={`${prefixCls}-content`}>
                 <ɵHeader
                   ref={headerRef}
-                  v-slots={slots}
+                  v-slots={headerSlots}
                   closable={closable.value}
                   closeIcon={closeIcon.value}
                   header={props.header}
-                  size={props.type === 'default' ? 'md' : 'sm'}
+                  size={props.header ? 'md' : 'sm'}
                   onClose={close}
                 />
                 <ModalBody></ModalBody>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
对话框header的尺寸不符合设计规范

## What is the new behavior?
在header有内容的时候尺寸为md，无内容时尺寸为sm

## Other information
