### PR TITLE
fix(comp:table): gap between expand trigger and text not working

### DIFF
--- a/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
+++ b/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
@@ -36,8 +36,9 @@ exports[`Table > basic work > render work 1`] = `
         <tbody class=\\"ix-table-tbody\\">
           <!---->
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><a>expandable</a></td>
+            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -45,28 +46,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 0
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->18
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 0
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 0</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -74,28 +81,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 1
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->19
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 1
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 1</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -103,26 +116,32 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 2
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->20
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 2
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 2</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><a>expandable</a></td>
+            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -130,28 +149,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 3
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->21
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 3
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 3</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -159,28 +184,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 4
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->22
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 4
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 4</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -188,26 +219,32 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 5
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->23
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 5
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 5</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><a>expandable</a></td>
+            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -215,28 +252,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 6
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->24
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 6
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 6</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -244,28 +287,34 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 7
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->25
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 7
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 7</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
             <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\">
                 <!---->
-              </button><a>expandable</a></td>
+              </button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -273,26 +322,32 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 8
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->26
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 8
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 8</a><a>Delete</a>
             </td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><a>expandable</a></td>
+            <td class=\\"ix-table-cell\\"><button class=\\"ix-table-expandable-trigger\\" type=\\"button\\"><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(0deg);\\" role=\\"img\\" aria-label=\\"right\\"></i></button><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
@@ -300,20 +355,25 @@ exports[`Table > basic work > render work 1`] = `
               </label>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->Edrward 9
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->27
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!---->London Park no. 9
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><span class=\\"ix-tag ix-tag-normal ix-tag-success\\"><!----><!----><span class=\\"ix-tag-content\\">NICE</span>
               <!----></span><span class=\\"ix-tag ix-tag-normal ix-tag-warning\\"><!----><!----><span class=\\"ix-tag-content\\">DEVELOPER</span>
               <!----></span>
             </td>
             <td class=\\"ix-table-cell\\">
+              <!---->
               <!----><a style=\\"margin-right: 8px;\\">Invite Edrward 9</a><a>Delete</a>
             </td>
           </tr>

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -9,7 +9,7 @@ import { type ComputedRef, type Slots, type VNodeChild, computed, defineComponen
 
 import { isFunction, isNil, isString } from 'lodash-es'
 
-import { Logger, convertArray, convertCssPixel } from '@idux/cdk/utils'
+import { Logger, convertArray, convertCssPixel, isEmptyNode } from '@idux/cdk/utils'
 import { IxCheckbox } from '@idux/components/checkbox'
 import { TableConfig } from '@idux/components/config'
 import { IxIcon } from '@idux/components/icon'
@@ -137,6 +137,9 @@ export default defineComponent({
       return (
         <Tag class={classes.value} style={style.value} title={title} {...customAdditional}>
           {type === 'expandable' && renderExpandableChildren(props, slots, expandable, mergedPrefixCls.value)}
+          {type === 'expandable' && !isEmptyNode(children) && (
+            <span class={`${mergedPrefixCls.value}-expandable-trigger-gap`}></span>
+          )}
           {children}
         </Tag>
       )

--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -171,7 +171,7 @@
       cursor: unset;
     }
 
-    & + * {
+    &-gap {
       margin-left: @spacing-xs;
     }
   }

--- a/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
+++ b/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
@@ -208,6 +208,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         <label
                           aria-checked="false"
                           aria-disabled="false"
@@ -240,11 +241,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option4
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         4
                       </td>
@@ -253,6 +256,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -264,6 +268,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -297,11 +302,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option5
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         5
                       </td>
@@ -310,6 +317,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -321,6 +329,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -355,11 +364,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option6
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         6
                       </td>
@@ -368,6 +379,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -379,6 +391,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -412,11 +425,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option7
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         7
                       </td>
@@ -425,6 +440,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -436,6 +452,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -469,11 +486,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option8
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         8
                       </td>
@@ -482,6 +501,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -493,6 +513,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -526,11 +547,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option9
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         9
                       </td>
@@ -539,6 +562,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -550,6 +574,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -583,11 +608,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option10
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         10
                       </td>
@@ -596,6 +623,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -607,6 +635,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -640,11 +669,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option11
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         11
                       </td>
@@ -653,6 +684,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -664,6 +696,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -698,11 +731,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option12
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         12
                       </td>
@@ -711,6 +746,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -722,6 +758,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -755,11 +792,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option13
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         13
                       </td>
@@ -768,6 +807,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -779,6 +819,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -812,11 +853,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option14
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         14
                       </td>
@@ -825,6 +868,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -836,6 +880,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -869,17 +914,20 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option15
                       </td>
                       <td
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         15
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <!---->
                       </td>
@@ -893,6 +941,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -927,11 +976,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option16
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         16
                       </td>
@@ -940,6 +991,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -951,6 +1003,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -984,11 +1037,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option17
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         17
                       </td>
@@ -997,6 +1052,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -1008,6 +1064,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -1041,11 +1098,13 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option18
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         18
                       </td>
@@ -1054,6 +1113,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       >
                         <!---->
                         <!---->
+                        <!---->
                       </td>
                       
                     </tr>
@@ -1065,6 +1125,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -1098,17 +1159,20 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option19
                       </td>
                       <td
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         19
                       </td>
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <!---->
                       </td>
@@ -1353,6 +1417,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         <label
                           aria-checked="false"
                           aria-disabled="false"
@@ -1385,6 +1450,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option0
                       </td>
                       
@@ -1397,6 +1463,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -1431,6 +1498,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         Option1
                       </td>
                       
@@ -1443,6 +1511,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         <label
                           aria-checked="false"
@@ -1475,6 +1544,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         Option2
                       </td>
@@ -1489,6 +1559,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                         class="ix-table-cell"
                       >
                         <!---->
+                        <!---->
                         <label
                           aria-checked="false"
                           aria-disabled="false"
@@ -1520,6 +1591,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       <td
                         class="ix-table-cell"
                       >
+                        <!---->
                         <!---->
                         Option3
                       </td>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当展开图标右侧只有文字内容而非html元素时，间距失效
## What is the new behavior?
修复以上问题

## Other information
