### PR TITLE
fix(comp:date-picker): panel header font-size not right

### DIFF
--- a/packages/components/date-picker/style/panel.less
+++ b/packages/components/date-picker/style/panel.less
@@ -50,10 +50,13 @@
       &-content {
         flex: auto;
 
-        button:not(:first-child) {
-          margin-left: @date-panel-header-content-spacing;
+        button {
           font-size: @date-panel-header-content-font-size;
           font-weight: @date-panel-header-content-font-weight;
+
+          &:not(:first-child) {
+            margin-left: @date-panel-header-content-spacing;
+          }
         }
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
日期面板中年月选择的font-size不生效

## What is the new behavior?
修复以上问题

## Other information
