### PR TITLE
fix(comp:drawer): translate transition error when container is set

### DIFF
--- a/packages/components/drawer/__tests__/drawer.spec.ts
+++ b/packages/components/drawer/__tests__/drawer.spec.ts
@@ -1,5 +1,5 @@
 import { MountingOptions, VueWrapper, flushPromises, mount } from '@vue/test-utils'
-import { h } from 'vue'
+import { h, nextTick } from 'vue'
 
 import { isElementVisible, renderWork } from '@tests'
 
@@ -40,6 +40,8 @@ describe('Drawer', () => {
     expect(isElementVisible(document.querySelector('.ix-drawer-wrapper'))).toBe(false)
 
     await wrapper.setProps({ visible: true })
+    await nextTick()
+    await flushPromises()
 
     const drawerWrapper = wrapper.getComponent(DrawerWrapper)
 
@@ -195,17 +197,17 @@ describe('Drawer', () => {
   test('height work', async () => {
     const wrapper = DrawerMount({ props: { height: 400 } })
     const drawerWrapper = wrapper.getComponent(DrawerWrapper)
-    const contentDom = drawerWrapper.find('.ix-drawer').element as HTMLElement
+    const getDom = () => drawerWrapper.find('.ix-drawer').element as HTMLElement
 
-    expect(contentDom.style.height).toBe('400px')
+    expect(getDom().style.height).toBe('400px')
 
     await wrapper.setProps({ height: '200px' })
 
-    expect(contentDom.style.height).toBe('200px')
+    expect(getDom().style.height).toBe('200px')
 
     await wrapper.setProps({ height: '20%' })
 
-    expect(contentDom.style.height).toBe('20%')
+    expect(getDom().style.height).toBe('20%')
   })
 
   test('mask work', async () => {
@@ -237,13 +239,13 @@ describe('Drawer', () => {
     const wrapper = DrawerMount({ props: { offset: 256 } })
     const drawerWrapper = wrapper.getComponent(DrawerWrapper)
 
-    const contentDom = drawerWrapper.find('.ix-drawer').element as HTMLElement
+    const getDom = () => drawerWrapper.find('.ix-drawer').element as HTMLElement
 
-    expect(contentDom.style.top).toBe('256px')
+    expect(getDom().style.top).toBe('256px')
 
     await wrapper.setProps({ offset: '30%' })
 
-    expect(contentDom.style.top).toBe('30%')
+    expect(getDom().style.top).toBe('30%')
   })
 
   test('placement work', async () => {
@@ -274,17 +276,17 @@ describe('Drawer', () => {
   test('width work', async () => {
     const wrapper = DrawerMount({ props: { width: 400 } })
     const drawerWrapper = wrapper.getComponent(DrawerWrapper)
-    const contentDom = drawerWrapper.find('.ix-drawer').element as HTMLElement
+    const getDom = () => drawerWrapper.find('.ix-drawer').element as HTMLElement
 
-    expect(contentDom.style.width).toBe('400px')
+    expect(getDom().style.width).toBe('400px')
 
     await wrapper.setProps({ width: '200px' })
 
-    expect(contentDom.style.width).toBe('200px')
+    expect(getDom().style.width).toBe('200px')
 
     await wrapper.setProps({ width: '20%' })
 
-    expect(contentDom.style.width).toBe('20%')
+    expect(getDom().style.width).toBe('20%')
   })
 
   test('zIndex work', async () => {

--- a/packages/components/drawer/src/token.ts
+++ b/packages/components/drawer/src/token.ts
@@ -15,7 +15,7 @@ export interface DrawerContext {
   common: CommonConfig
   config: DrawerConfig
   mergedPrefixCls: ComputedRef<string>
-  visible: ComputedRef<boolean>
+  visible: Ref<boolean>
   animatedVisible: Ref<boolean | undefined>
   mergedVisible: ComputedRef<boolean>
   currentZIndex: ComputedRef<number>

--- a/packages/components/drawer/style/index.less
+++ b/packages/components/drawer/style/index.less
@@ -19,13 +19,14 @@
     }
   }
 
-  &-opened&-push {
-    transition: transform var(--ix-transition-duration-medium) var(--ix-ease-out);
-    transition-delay: var(--ix-transition-duration-fast);
-  }
-
-  &-opened&-pull {
-    transition: transform var(--ix-transition-duration-medium) var(--ix-ease-in);
+  &-opened {
+    &.@{drawer-prefix}-push {
+      transition: transform var(--ix-transition-duration-medium) var(--ix-ease-out);
+      transition-delay: var(--ix-transition-duration-fast);
+    }
+    &.@{drawer-prefix}-pull {
+      transition: transform var(--ix-transition-duration-medium) var(--ix-ease-in);
+    }
   }
 
   &-sentinel {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当配置了自定义container，首次渲染的时候，由于cdkPortal加载是懒加载，wrapper和内容的渲染和动画同时进行，导致translate动画效果不正常

## What is the new behavior?
修复以上问题，在首次visible改变为true的时候，等待nextTick之后再显示，即等待渲染完成

## Other information
