### PR TITLE
fix(pro:search): empty value set by quick select should be removed

### DIFF
--- a/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
@@ -25,6 +25,7 @@ export default defineComponent({
       convertStateToValue,
       createSearchState,
       getSearchStatesByFieldKey,
+      removeSearchState,
       updateSegmentValue,
       updateSearchValues,
       tempSegmentInputRef,
@@ -65,6 +66,12 @@ export default defineComponent({
 
     const confirmValue = (value: unknown) => {
       let searchStateKey = searchState.value?.key
+
+      if (!value && searchStateKey) {
+        removeSearchState(searchStateKey)
+        return
+      }
+
       if (!searchState.value) {
         searchStateKey = createSearchState(props.searchField.key, {
           value,

--- a/packages/pro/search/src/components/segment/SegmentInput.tsx
+++ b/packages/pro/search/src/components/segment/SegmentInput.tsx
@@ -184,9 +184,9 @@ function useSegmentScroll(
 ): ComputedRef<SegmentScroll> {
   const [segmentScroll, setSegmentScroll] = useState<SegmentScroll>({ left: 0, right: 0 }, true)
 
-  let listenerStops: (() => void)[]
+  let listenerStops: (() => void)[] | undefined
   const stopListen = () => {
-    listenerStops.forEach(stop => stop())
+    listenerStops?.forEach(stop => stop())
   }
 
   const getScrolls = (): SegmentScroll => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，多选在快捷面板中触发取消选择使值为空，没有反应

## What is the new behavior?
为空的值应当被移除

## Other information
