### PR TITLE
fix(comp:select): responsive maxLabel size calculation error

### DIFF
--- a/packages/cdk/utils/src/dom.ts
+++ b/packages/cdk/utils/src/dom.ts
@@ -13,6 +13,18 @@ export type EventTarget = HTMLElement | Document | Window | null | undefined
 
 export type Dimensions = { [key in 'width' | 'height']: number }
 
+export interface BoxSizingData {
+  boxSizing: 'border-box' | 'padding-box' | 'content-box'
+  paddingTop: number
+  paddingBottom: number
+  paddingLeft: number
+  paddingRight: number
+  borderTop: number
+  borderBottom: number
+  borderLeft: number
+  borderRight: number
+}
+
 export function on<K extends keyof HTMLElementEventMap>(
   el: EventTarget,
   type: K | undefined,
@@ -155,10 +167,16 @@ export function getMouseClientXY(evt: MouseEvent | TouchEvent): { clientX: numbe
   return { clientX, clientY }
 }
 
+function parseSize(size: string): number {
+  const parsedSize = parseFloat(size)
+
+  return Number.isNaN(parsedSize) ? 0 : parsedSize
+}
+
 export function getCssDimensions(element: HTMLElement): Dimensions & { fallback: boolean } {
   const css = getComputedStyle(element)
-  let width = parseFloat(css.width)
-  let height = parseFloat(css.height)
+  let width = parseSize(css.width)
+  let height = parseSize(css.height)
   const offsetWidth = element.offsetWidth
   const offsetHeight = element.offsetHeight
   const shouldFallback = Math.round(width) !== offsetWidth || Math.round(height) !== offsetHeight
@@ -173,4 +191,28 @@ export function getCssDimensions(element: HTMLElement): Dimensions & { fallback:
     height,
     fallback: shouldFallback,
   }
+}
+
+export function getBoxSizingData(node: HTMLElement): BoxSizingData {
+  const css = window.getComputedStyle(node)
+
+  return (
+    [
+      'paddingTop',
+      'paddingBottom',
+      'paddingLeft',
+      'paddingRight',
+      'borderTop',
+      'borderBottom',
+      'borderLeft',
+      'borderRight',
+    ] as const
+  ).reduce(
+    (data, key) => {
+      data[key] = parseSize(css[key])
+
+      return data
+    },
+    { boxSizing: css.boxSizing } as BoxSizingData,
+  )
 }

--- a/packages/components/_private/overflow/src/Item.tsx
+++ b/packages/components/_private/overflow/src/Item.tsx
@@ -17,7 +17,7 @@ export default defineComponent({
   props: overflowItemProps,
   setup(props, { slots }) {
     const itemElRef = ref<HTMLElement | undefined>()
-    const handleResize = (entry: ResizeObserverEntry) => callEmit(props.onSizeChange, entry.target, props.itemKey ?? '')
+    const handleResize = (entry: ResizeObserverEntry) => callEmit(props.onSizeChange, entry, props.itemKey ?? '')
     useResizeObserver(itemElRef, handleResize)
 
     return () => {

--- a/packages/components/_private/overflow/src/types.ts
+++ b/packages/components/_private/overflow/src/types.ts
@@ -29,7 +29,7 @@ export const overflowItemProps = {
     required: true,
   },
   data: Object as PropType<ItemData>,
-  onSizeChange: Function as PropType<(itemEl: Element, key?: VKey) => void>,
+  onSizeChange: Function as PropType<(entry: ResizeObserverEntry, key?: VKey) => void>,
 } as const
 
 export const overflowProps = {

--- a/packages/components/textarea/src/composables/useAutoRows.ts
+++ b/packages/components/textarea/src/composables/useAutoRows.ts
@@ -55,7 +55,7 @@ export function useAutoRows(
   const cachedLineHeight = useLineHeight(textareaRef)
   const boxSizingData = computed(() => {
     if (!textareaRef.value) {
-      return { paddingSize: 0, borderSize: 0, boxSizing: '' } as BoxSizingData
+      return { paddingSize: 0, borderSize: 0, boxSizing: '' } as unknown as BoxSizingData
     }
 
     return getBoxSizingData(textareaRef.value)

--- a/packages/components/textarea/src/utils/getBoxSizingData.ts
+++ b/packages/components/textarea/src/utils/getBoxSizingData.ts
@@ -5,37 +5,20 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-export interface BoxSizingData {
-  boxSizing: string
+import { type BoxSizingData as IBoxSizingData, getBoxSizingData as _getBoxSizingData } from '@idux/cdk/utils'
+
+export interface BoxSizingData extends IBoxSizingData {
   paddingSize: number
   borderSize: number
-  paddingTop: number
-  paddingBottom: number
-  borderTop: number
-  borderBottom: number
 }
 
 export function getBoxSizingData(node: HTMLElement): BoxSizingData {
-  const { boxSizing, paddingBottom, paddingTop, borderBottom, borderTop } = window.getComputedStyle(node)
-
-  const _paddingTop = parseSize(paddingTop)
-  const _paddingBottom = parseSize(paddingBottom)
-  const _borderTop = parseSize(borderTop)
-  const _borderBottom = parseSize(borderBottom)
+  const data = _getBoxSizingData(node)
+  const { paddingBottom, paddingTop, borderBottom, borderTop } = data
 
   return {
-    boxSizing,
-    paddingSize: _paddingTop + _paddingBottom,
-    borderSize: _borderTop + _borderBottom,
-    paddingTop: _paddingTop,
-    paddingBottom: _paddingBottom,
-    borderTop: _borderTop,
-    borderBottom: _borderBottom,
+    ...data,
+    paddingSize: paddingTop + paddingBottom,
+    borderSize: borderTop + borderBottom,
   }
-}
-
-function parseSize(size: string): number {
-  const parsedSize = parseFloat(size)
-
-  return Number.isNaN(parsedSize) ? 0 : parsedSize
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
select组件的maxlabel配置responsive时，由于容器尺寸没有减去内边距以及使用了clientWidth，而clientWidth会省略掉小数，导致实际计算结果不准确，可能出现换行的情况

## What is the new behavior?
修复以上问题

## Other information
