### PR TITLE
fix(comp:tag): tag content not aligned center

### DIFF
--- a/packages/components/tag/style/index.less
+++ b/packages/components/tag/style/index.less
@@ -29,6 +29,11 @@
     padding-left: 4px;
   }
 
+  &-content {
+    flex: auto;
+    text-align: center;
+  }
+
   &-bordered {
     border-color: @tag-border-color;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在内容宽度小于最小宽度时，tag标签内容未居中

## What is the new behavior?
修复以上问题

## Other information
