### PR TITLE
fix(comp:*): overlay options update should watch deep

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -182,9 +182,8 @@ function usePopperOptions(
     setOptions({ allowEnter, autoAdjust, delay, disabled, offset: _offset, placement, trigger })
   }
 
-  onMounted(() => {
-    watch([props, arrowRef], updateOptions, { immediate: true })
-  })
+  watch(props, updateOptions, { immediate: true, deep: true })
+  watch(arrowRef, updateOptions)
 
   return {
     options,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
overlay的props更新，popper的options有概率不更新

## What is the new behavior?
props的监听应当watch deep

## Other information
