### PR TITLE
fix(cdk:popper): popper shouldn't update if reference is display none

### DIFF
--- a/packages/cdk/popper/src/middlewares/arrow.ts
+++ b/packages/cdk/popper/src/middlewares/arrow.ts
@@ -14,11 +14,17 @@ export function arrow(arrowElement: HTMLElement): Middleware {
     ...rest,
     name: 'IDUX_arrow',
     async fn(middlewareArguments) {
+      const { reference } = middlewareArguments.elements
+
+      if (!(reference instanceof HTMLElement) || getComputedStyle(reference).display === 'none') {
+        return middlewareArguments
+      }
+
       const res = (await arrowFn(middlewareArguments)) as { data: { x: number; y: number; centerOffset: number } }
+
       const {
         data: { x, y },
       } = res
-
       Object.assign(arrowElement.style, {
         left: x != null ? `${x}px` : '',
         top: y != null ? `${y}px` : '',

--- a/packages/cdk/popper/src/middlewares/refenceHidden.ts
+++ b/packages/cdk/popper/src/middlewares/refenceHidden.ts
@@ -68,7 +68,7 @@ function checkParentsVisible(el: ReferenceElement): boolean {
 
   let parent = el.parentElement
   while (parent) {
-    if (!isVisibleElement(parent)) {
+    if (getComputedStyle(parent).display !== 'contents' && !isVisibleElement(parent)) {
       return false
     }
 

--- a/packages/cdk/popper/src/middlewares/updatePlacement.ts
+++ b/packages/cdk/popper/src/middlewares/updatePlacement.ts
@@ -16,11 +16,14 @@ export function updatePlacement(updatePlacement: (value: PopperPlacement) => voi
     fn(middlewareArguments) {
       const {
         placement,
-        elements: { floating },
+        elements: { floating, reference },
       } = middlewareArguments
-      updatePlacement(camelCase(placement) as PopperPlacement)
 
-      floating.setAttribute('data-popper-placement', placement)
+      if (reference instanceof HTMLElement && getComputedStyle(reference).display !== 'none') {
+        updatePlacement(camelCase(placement) as PopperPlacement)
+        floating.setAttribute('data-popper-placement', placement)
+      }
+
       return middlewareArguments
     },
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior
当 reference 为dispaly:none 隐藏时，虽然位置不会更新，但箭头位置和placement还是会更新，导致隐藏场景下显示不正常

## What is the new behavior?
在reference 为 display:none时，不再更新Placement以及arrow位置

## Other information
隐藏时不更新是为了解决例如reference是hover才显示的场景