### PR TITLE
fix(pro:search): segment with default value shouldn't be set active

### DIFF
--- a/packages/pro/search/src/components/NameSelectOverlay.tsx
+++ b/packages/pro/search/src/components/NameSelectOverlay.tsx
@@ -7,7 +7,7 @@
 
 import { type ComputedRef, type VNodeChild, computed, defineComponent, inject, onMounted, ref, watch } from 'vue'
 
-import { isString } from 'lodash-es'
+import { isNil, isString } from 'lodash-es'
 
 import { type VKey, callEmit, convertArray, useState } from '@idux/cdk/utils'
 import { ɵOverlay, type ɵOverlayInstance, type ɵOverlayProps } from '@idux/components/_private/overlay'
@@ -81,10 +81,12 @@ export default defineComponent({
         return
       }
 
+      const segmentStates = searchState.segmentStates
+
       updateSearchValues()
       setActiveSegment({
         itemKey: searchState.key,
-        name: searchState.segmentStates[0].name,
+        name: segmentStates.find(state => isNil(state.value))?.name ?? segmentStates[segmentStates.length - 1].name,
       })
 
       callEmit(proSearchProps.onItemCreate, {

--- a/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectShortcut.tsx
@@ -7,6 +7,8 @@
 
 import { type Slot, computed, defineComponent, inject } from 'vue'
 
+import { isNil } from 'lodash-es'
+
 import { callEmit, isEmptyNode } from '@idux/cdk/utils'
 import { IxIcon } from '@idux/components/icon'
 
@@ -43,9 +45,11 @@ export default defineComponent({
           ...convertStateToValue(state.key),
           nameInput: searchField.value?.label,
         })
+
+        const segmentStates = state.segmentStates
         setActiveSegment({
           itemKey: state.key,
-          name: state.segmentStates[0]?.name,
+          name: segmentStates.find(state => isNil(state.value))?.name ?? segmentStates[segmentStates.length - 1].name,
         })
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
创建搜索项时，默认将第一个输入段置为激活状态

## What is the new behavior?
应当将第一个无默认值，即非空的输入段置为激活状态

## Other information
