### PR TITLE
fix(pro:search): segment should init only when it's set inactive

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -5,18 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import {
-  computed,
-  defineComponent,
-  nextTick,
-  normalizeClass,
-  normalizeStyle,
-  onMounted,
-  provide,
-  ref,
-  toRef,
-  watch,
-} from 'vue'
+import { computed, defineComponent, normalizeClass, normalizeStyle, onMounted, provide, ref, toRef, watch } from 'vue'
 
 import { callEmit, convertCssPixel } from '@idux/cdk/utils'
 import { ɵOverflow } from '@idux/components/_private/overflow'
@@ -107,7 +96,7 @@ export default defineComponent({
     watch(
       () => props.value,
       () => {
-        nextTick(initSearchStates)
+        initSearchStates()
       },
       { immediate: true, deep: true },
     )

--- a/packages/pro/search/src/composables/useSearchStates.ts
+++ b/packages/pro/search/src/composables/useSearchStates.ts
@@ -263,7 +263,7 @@ export function useSearchStates(
     const segmentStates = generateSegmentStates(searchField, searchValue)
 
     if (!segmentName) {
-      searchState.segmentStates = generateSegmentStates(searchField, searchValue)
+      searchState.segmentStates = segmentStates
     } else {
       const idx = searchState.segmentStates.findIndex(state => state.name === segmentName)
       searchState.segmentStates[idx] = segmentStates[idx]

--- a/packages/pro/search/src/composables/useSegmentStates.ts
+++ b/packages/pro/search/src/composables/useSegmentStates.ts
@@ -175,7 +175,7 @@ export function useSegmentStates(
   watch(
     [activeSegment, () => props.searchItem?.resolvedSearchField],
     ([activeSegment, searchField], [preActiveSegment]) => {
-      if (activeSegment?.itemKey === props.searchItem?.key) {
+      if (activeSegment?.itemKey === props.searchItem?.key || preActiveSegment?.itemKey !== props.searchItem?.key) {
         return
       }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，当激活的segment发生变化时，所有的segment都会被初始化一遍

## What is the new behavior?
仅当激活状态的segment被置于非激活状态，类似于blur的时候，才对其进行单独初始化。

## Other information
