### PR TITLE
fix(comp:alert): alert content not aligined with pagination

### DIFF
--- a/packages/components/alert/style/index.less
+++ b/packages/components/alert/style/index.less
@@ -77,6 +77,10 @@
       .@{pagination-prefix}-item {
         padding: 0;
       }
+      .@{pagination-prefix}-item-content {
+        height: @line-height;
+        line-height: @line-height;
+      }
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
pagnination的高度和line-height比alert的内容高，导致其于内容不对齐

## What is the new behavior?
修复以上问题

## Other information
