### PR TITLE
fix(comp:card): add css class to footer button

### DIFF
--- a/packages/components/card/src/Card.tsx
+++ b/packages/components/card/src/Card.tsx
@@ -144,7 +144,7 @@ const renderFooter = (props: CardProps, slots: Slots, prefixCls: string) => {
       } else {
         const { text, ...rest } = item
         itemChild = (
-          <IxButton waveless={true} {...rest}>
+          <IxButton class={`${prefixCls}-footer-button`} waveless={true} {...rest}>
             {text}
           </IxButton>
         )

--- a/packages/components/card/style/index.less
+++ b/packages/components/card/style/index.less
@@ -68,7 +68,7 @@
     > li {
       flex: 1;
 
-      > .@{idux-prefix}-button {
+      > .@{card-prefix}-footer-button {
         border: none;
         width: 100%;
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
card的footer样式是特殊处理的，并且是直接引用的button的样式，导致自己写的button样式被影响

## What is the new behavior?
给footer中的button加上class，不影响用户自定义的button

## Other information
