### PR TITLE
fix(pro:search): onItemConfirm value is empty when item is removed

### DIFF
--- a/packages/pro/search/src/composables/useSegmentStates.ts
+++ b/packages/pro/search/src/composables/useSegmentStates.ts
@@ -120,20 +120,21 @@ export function useSegmentStates(
     const key = props.searchItem!.key
     const validateRes = validateSearchState(key)
 
+    const valueName = searchDataTypes.find(name => !!segmentStates.value[name])
+    const searchValue = convertStateToValue(key)
+    const _segmentStates = segmentStates.value
+
     if (!validateRes) {
       removeSearchState(key)
     } else {
       updateSearchValues()
     }
 
-    const valueName = searchDataTypes.find(name => !!segmentStates.value[name])
-    const searchValue = convertStateToValue(key)
-
     callEmit(proSearchProps.onItemConfirm, {
       ...(searchValue ?? {}),
       nameInput: searchValue?.name ?? '',
-      operatorInput: segmentStates.value.operator?.input,
-      valueInput: valueName && segmentStates.value[valueName]?.input,
+      operatorInput: _segmentStates.operator?.input,
+      valueInput: valueName && _segmentStates[valueName]?.input,
       removed: !validateRes,
     })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，由于搜索项非法而在确认时被删除，onItemConfirm的参数为空

## What is the new behavior?
修复以上问题

## Other information
