### PR TITLE
fix(comp:input): addon select should remove box-shadow when invalid

### DIFF
--- a/packages/components/input/style/index.less
+++ b/packages/components/input/style/index.less
@@ -146,7 +146,6 @@
       &-content {
         background-color: inherit;
         border-color: transparent;
-        box-shadow: none;
       }
 
       // TODO: select 那边要去掉这两个样式
@@ -270,7 +269,7 @@
           border-color: transparent;
         }
 
-        &&-active &-content {
+        &.@{selector-prefix}-focused .@{selector-prefix}-content {
           border-color: transparent;
           // todo remove
           box-shadow: none;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在addon-before中的下拉选择，当Input是invalid时，box-shadow还是蓝色的

## What is the new behavior?
取消在invalid时select的box-shadow

## Other information
