### PR TITLE
fix(comp:tree): tree select disabled not right

### DIFF
--- a/packages/components/tree/src/composables/useDataSource.ts
+++ b/packages/components/tree/src/composables/useDataSource.ts
@@ -216,7 +216,7 @@ function mergeDisabled(
     check: _mergeDisabled('check'),
     drag: _mergeDisabled('drag'),
     drop: _mergeDisabled('drop'),
-    select: _mergeDisabled('drag'),
+    select: _mergeDisabled('select'),
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
树 select 的禁用拼写错误，导致实际收到 drag的禁用影响

## What is the new behavior?
修复以上问题

## Other information
