### PR TITLE
fix(comp:card): footer button style should use class but not button

### DIFF
--- a/packages/components/card/style/index.less
+++ b/packages/components/card/style/index.less
@@ -217,7 +217,7 @@
     padding-top: 4px;
   }
 
-  .@{card-prefix}-footer button {
+  .@{card-prefix}-footer .@{card-prefix}-footer-button {
     margin: @footer-margin 0;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
card组件中，.card-size使用了 button 指定元素样式，导致污染到内部自定义的button样式

## What is the new behavior?
使用class而非button

## Other information
