### PR TITLE
fix(comp:tree): leave no blank hover without spacing

### DIFF
--- a/packages/pro/tree/docs/Theme.zh.md
+++ b/packages/pro/tree/docs/Theme.zh.md
@@ -10,7 +10,7 @@
 | `@pro-tree-header-wrapper-icon-font-size` | `@font-size-lg` | - | - |
 | `@pro-tree-header-wrapper-icon-hover-color` | `@color-primary` | - | - |
 | `@pro-tree-header-wrapper-height` | `38px` | - | - |
-| `@pro-tree-content-horizontal-spacing` | `12px` | - | - |
+| `@pro-tree-content-horizontal-spacing` | `0` | - | - |
 | `@pro-tree-content-vertical-spacing` | `0` | - | - |
 | `@pro-tree-divider-horizontal-spacing` | `@pro-tree-header-search-wrapper-horizontal-spacing` | - | - |
 | `@pro-tree-divider-vertical-spacing` | `8px` | - | - |

--- a/packages/pro/tree/style/themes/default.variable.less
+++ b/packages/pro/tree/style/themes/default.variable.less
@@ -8,7 +8,7 @@
 @pro-tree-header-wrapper-icon-font-size: @font-size-lg;
 @pro-tree-header-wrapper-icon-hover-color: @color-primary;
 @pro-tree-header-wrapper-height: 38px;
-@pro-tree-content-horizontal-spacing: 12px;
+@pro-tree-content-horizontal-spacing: 0;
 @pro-tree-content-vertical-spacing: 0;
 
 @pro-tree-divider-horizontal-spacing: @pro-tree-header-search-wrapper-horizontal-spacing;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [X] Tests for the changes have been added/updated or not needed
- [X] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1, the left side does not leave a blank, the overall left alignment
2. The right side is not blank, and the icon and search box are right aligned
3, hover background directly through, left and right without leaving spacing

## What is the new behavior?
modify the horizontal spacing of the tree component instance content area

## Other information
No Other information