### PR TITLE
fix(comp:empty): empty there is no data to change the color

### DIFF
--- a/packages/components/style/variable/color/color.less
+++ b/packages/components/style/variable/color/color.less
@@ -41,7 +41,7 @@
 @color-grey-l20: #e0e0e0;
 @color-grey-l10: #c2c2c2;
 @color-grey: @color-grey-base;
-@color-grey-d10: #7a7a7a;
+@color-grey-d10: #2f3540;
 @color-grey-d20: #5c5c5c;
 @color-grey-d30: #3d3d3d;
 @color-grey-d40: #1f1f1f;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [X] Tests for the changes have been added/updated or not needed
- [X] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Change the "No Data Yet" color of the empty state to #2F3540
Link address:http://seerdesign.sangfor.org/basic-components/class-data-display/empty
screenshot:
![image](https://github.com/IDuxFE/idux/assets/143491933/318b25b4-361d-4c67-b24e-4238b60bd939)


## What is the new behavior?
seerdesign change the "No Data Yet" color of the empty state to #2F3540

## Other information
No other information