### PR TITLE
fix(comp:*): layer stroke in the example border radius modification

### DIFF
--- a/packages/site/src/components/global/GlobalCodeBox.vue
+++ b/packages/site/src/components/global/GlobalCodeBox.vue
@@ -114,7 +114,7 @@ export default defineComponent({
 
   &-content {
     padding: 8px;
-    border-radius: @border-radius-md;
+    border-radius: @border-radius-sm;
     background: @color-graphite-l50;
     box-shadow: inset 0 0 4px 0 rgba(0, 0, 0, 0.1);
 
@@ -124,8 +124,9 @@ export default defineComponent({
       padding: 8px;
       background-color: @background-color-component;
       border: 1px @border-style @border-color-split;
-      border-radius: @border-radius-md;
+      border-radius: @border-radius-sm;
       transition: @transition-all-base;
+      border-color: #edf1f7;
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [X] Tests for the changes have been added/updated or not needed
- [X] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In all the [examples], the inner white card is stroke #EDF1F7; Change the rounded corners of both boxes to 2px for all 8 corners
Link address:http://seerdesign.sangfor.org/
screenshot：
![image](https://github.com/IDuxFE/idux/assets/143491933/2fc5389f-5476-43fb-b752-e3dbb0246b8a)
（All examples）

## What is the new behavior?
In all the [examples], the inner white card is stroke #EDF1F7; Change the rounded corners of both boxes to 2px for all 8 corners


## Other information
No other information