### PR TITLE
fix(pro:search): proSearch input shouldn't be auto focused in safari

### DIFF
--- a/packages/pro/search/src/components/segment/Segment.tsx
+++ b/packages/pro/search/src/components/segment/Segment.tsx
@@ -101,23 +101,13 @@ export default defineComponent({
           nextTick(() => {
             if (active) {
               segmentInputRef.value?.getInputElement().focus()
+              updateSelectionStart(
+                (props.selectionStart ?? -1) === -1 ? props.input?.length ?? 0 : props.selectionStart ?? 0,
+              )
             }
-
-            updateSelectionStart(
-              (props.selectionStart ?? -1) === -1 ? (active ? props.input?.length ?? 0 : 0) : props.selectionStart ?? 0,
-            )
           })
         },
         { immediate: true },
-      )
-      watch(
-        () => props.selectionStart,
-        selectionStart => {
-          updateSelectionStart(selectionStart ?? 0)
-        },
-        {
-          immediate: true,
-        },
       )
       watch(
         overlayOpened,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在safari 下，初始渲染之后高级搜索框被异常自动触发focus

## What is the new behavior?
修复以上问题

## Other information
safari下的input.setSelectionRange会自动触发focus，且没有用户操作的focus没有被拦截