### PR TITLE
fix(pro:search): segment input scroll event doesn't work in safari

### DIFF
--- a/packages/pro/search/src/components/segment/SegmentInput.tsx
+++ b/packages/pro/search/src/components/segment/SegmentInput.tsx
@@ -21,6 +21,7 @@ import {
 
 import { debounce } from 'lodash-es'
 
+import { isSafari } from '@idux/cdk/platform'
 import { useResizeObserver } from '@idux/cdk/resize'
 import { getScroll, setScroll } from '@idux/cdk/scroll'
 import { callEmit, convertCssPixel, useEventListener, useState } from '@idux/cdk/utils'
@@ -231,8 +232,8 @@ function useSegmentScroll(
 
   onMounted(() => {
     if (props.ellipsis) {
+      /* eslint-disable indent */
       listenerStops = [
-        useEventListener(inputRef, 'scroll', updateScroll),
         useResizeObserver(inputRef, () => {
           if (document.activeElement === inputRef.value) {
             scrollIntoView()
@@ -241,7 +242,15 @@ function useSegmentScroll(
         }),
         useEventListener(inputRef, 'input', updateScroll),
         useEventListener(inputRef, 'compositionend', scrollIntoView),
-      ]
+        ...(isSafari
+          ? [
+              useEventListener(inputRef, 'keydown', updateScroll),
+              useEventListener(inputRef, 'wheel', updateScroll),
+              useEventListener(inputRef, 'select', updateScroll),
+            ]
+          : [useEventListener(inputRef, 'scroll', updateScroll)]),
+      ].filter(Boolean)
+      /* eslint-enable indent */
     }
   })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
safari下高级搜索框的segment左右的省略号不会随着光标移动自动消失

## What is the new behavior?
修复以上问题

## Other information
safari下光标移动或者select，不会触发滚动事件