### PR TITLE
fix(pro:search): name select overlay data blinks after closed

### DIFF
--- a/packages/pro/search/src/components/segment/TempSegment.tsx
+++ b/packages/pro/search/src/components/segment/TempSegment.tsx
@@ -74,6 +74,11 @@ export default defineComponent({
     onMounted(() => {
       tempSegmentInputRef.value = segmentInputRef.value?.getInputElement()
       watch(() => searchStates.value.length, updateOverlay)
+      watch(isActive, active => {
+        if (!active) {
+          setInput('')
+        }
+      })
     })
 
     let panelKeyDown: (evt: KeyboardEvent) => boolean | undefined = () => true

--- a/packages/pro/search/src/composables/useActiveSegment.ts
+++ b/packages/pro/search/src/composables/useActiveSegment.ts
@@ -144,6 +144,10 @@ export function useActiveSegment(
   }
 
   const setTempActive = () => {
+    if (quickSelectActive.value || nameSelectActive.value) {
+      return
+    }
+
     if (enableQuickSelect.value) {
       setQuickSelectActive()
     } else {

--- a/packages/pro/search/src/composables/useControl.ts
+++ b/packages/pro/search/src/composables/useControl.ts
@@ -19,7 +19,8 @@ export function useControl(
   searchStateContext: SearchStateContext,
   focusEventContext: FocusStateContext,
 ): void {
-  const { isActive, nameSelectActive, quickSelectActive, setInactive, setTempActive } = activeSegmentContext
+  const { isActive, nameSelectActive, quickSelectActive, setOverlayOpened, setInactive, setTempActive } =
+    activeSegmentContext
   const { searchStates } = searchStateContext
   const { focused, focusVia, onFocus, onBlur } = focusEventContext
 
@@ -48,8 +49,10 @@ export function useControl(
         return
       }
 
-      if (!nameSelectActive.value || !quickSelectActive.value) {
+      if (!nameSelectActive.value && !quickSelectActive.value) {
         setTempActive()
+      } else {
+        setOverlayOpened(true)
       }
 
       if (!(evt.target instanceof HTMLInputElement)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在有输入过滤的情况下，高级搜索框的搜索项选择浮层中的数据会在关闭的时候闪烁一下

## What is the new behavior?
修复以上问题

## Other information
只在浮层显示的时候更新浮层的数据，避免关闭动画在运行的时候数据被更新