### PR TITLE
fix(pro:search): name input width shouldn't exceeds container

### DIFF
--- a/packages/pro/search/style/index.less
+++ b/packages/pro/search/style/index.less
@@ -27,6 +27,7 @@
   }
   .@{overflow-prefix}-item {
     height: auto;
+    max-width: 100%;
   }
 
   &-input-container {
@@ -213,6 +214,9 @@
     &-overlay {
       .overlay()
     }
+  }
+  &-temp-segment-input {
+    max-width: 100%;
   }
 
   &-name-segment-overlay {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索的搜索项选择的input输入会超出容器长度


## What is the new behavior?
修复以上问题，增加max-width

## Other information
