### PR TITLE
feat(comp:card): `shadow` supports global config now

### DIFF
--- a/packages/components/card/docs/Api.zh.md
+++ b/packages/components/card/docs/Api.zh.md
@@ -9,7 +9,7 @@
 | `cover` | 卡片封面图片 | `string \| CardCover \| #cover` | - | - | - |
 | `header` | 对话框标题 | `string \| HeaderProps \| #header` | - | - | - |
 | `hoverable` | 鼠标 hover 时，是否悬浮 | `boolean` | `false` | ✅ | - |
-| `shadow` | 是否有阴影 | `boolean` | `true` | - | - |
+| `shadow` | 是否有阴影 | `boolean` | `true` | ✅ | - |
 | `loading` | 是否加载中状态 | `boolean` | `false` | - | 当卡片内容还在加载中时，显示占位图 |
 | `size` | 设置卡片大小 | `'sm' \| 'md' \| 'lg'` | `'md'` | ✅ | - |
 | `footer` | 自定义底部按钮 | `CardButtonProps[] \| #footer` | - | - | - |

--- a/packages/components/card/src/Card.tsx
+++ b/packages/components/card/src/Card.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
 
     return () => {
       const prefixCls = mergedPrefixCls.value
-      const { borderless = config.borderless, loading, size = config.size, shadow } = props
+      const { borderless = config.borderless, loading, size = config.size, shadow = config.shadow } = props
 
       const children = slots.default?.() ?? []
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/components/card/src/types.ts
+++ b/packages/components/card/src/types.ts
@@ -37,7 +37,7 @@ export const cardProps = {
   },
   shadow: {
     type: Boolean,
-    default: true,
+    default: undefined,
   },
   loading: {
     type: Boolean,

--- a/packages/components/config/src/defaultConfig.ts
+++ b/packages/components/config/src/defaultConfig.ts
@@ -55,6 +55,7 @@ export const defaultConfig: GlobalConfig = {
     borderless: false,
     hoverable: false,
     size: 'md',
+    shadow: true,
   },
   carousel: {
     autoplayTime: 0,

--- a/packages/components/config/src/types.ts
+++ b/packages/components/config/src/types.ts
@@ -163,6 +163,7 @@ export interface CardConfig {
   size: CardSize
   borderless: boolean
   hoverable: boolean
+  shadow: boolean
 }
 
 export interface CarouselConfig {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
卡片组件的`shadow`配置支持全局配置

## Other information
