### PR TITLE
fix(pro:textarea): readonly not working

### DIFF
--- a/packages/pro/textarea/src/content/Content.tsx
+++ b/packages/pro/textarea/src/content/Content.tsx
@@ -61,6 +61,7 @@ export default defineComponent({
             ref={textareaRef}
             class={`${prefixCls}-textarea`}
             disabled={accessor.disabled}
+            readonly={props.readonly}
             placeholder={props.placeholder}
             onInput={handleInput}
             onCompositionstart={handleCompositionStart}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
IxProTextarea的readonly不生效

## What is the new behavior?
修复以上问题

## Other information
