### PR TITLE
fix(comp:text): text blinks when content doesn't exceed one row

### DIFF
--- a/packages/components/text/src/composables/useEllipsis.ts
+++ b/packages/components/text/src/composables/useEllipsis.ts
@@ -100,6 +100,7 @@ export function useEllipsis(
 
     const walk = () => {
       const measureHeight = measureRef.value?.offsetHeight ?? 0
+      const conentHeight = contentRef.value?.offsetHeight ?? 0
 
       if (measureStatus.value === 'preparing') {
         if (!rowMeasureRef.value) {
@@ -108,8 +109,7 @@ export function useEllipsis(
 
         rowHeight = rowMeasureRef.value?.offsetHeight ?? 0
         maxHeight = rows.value * rowHeight
-
-        if (measureHeight <= maxHeight) {
+        if (conentHeight <= maxHeight || measureHeight <= maxHeight) {
           setIsEllipsis(false)
           setLastRenderIndex(contentNodesLength.value)
           currentWalk = undefined
@@ -163,6 +163,10 @@ export function useEllipsis(
       immediate: true,
     })
     useResizeObserver(contentRef, () => {
+      if (measureStatus.value !== 'none') {
+        return
+      }
+
       const width = contentRef.value?.offsetWidth ?? 0
 
       if (width !== contentWidth.value) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
配置ellipsis.row为1，且文字的长度不足以撑满父容器时，会不停渲染，造成闪烁

## What is the new behavior?
修复以上问题，在初始计算内容高度是否超过一行，没有超过则不再进行动态渲染计算

## Other information
