### PR TITLE
fix(pro:search): key duplication after controlled value change

### DIFF
--- a/packages/pro/search/src/composables/useSearchStates.ts
+++ b/packages/pro/search/src/composables/useSearchStates.ts
@@ -244,10 +244,18 @@ export function useSearchStates(
     const createdStates = getMarks()
       .map(({ key, mark }) => mark === 'created' && getSearchStateByKey(key))
       .filter(Boolean)
-      .map((state, index) => ({
-        ...state,
-        index: lastIndex + index + 1,
-      })) as SearchState[]
+      .map((state, index) => {
+        // recreate the state key again to avoid key duplication
+        const fieldKey = (state as SearchState).fieldKey
+        const count = dataKeyCountMap.has(fieldKey) ? dataKeyCountMap.get(fieldKey)! : 0
+        const key = getKey(fieldKey, count)
+
+        return {
+          ...state,
+          key,
+          index: lastIndex + index + 1,
+        }
+      }) as SearchState[]
 
     searchStates.value = [...newSearchStates, ...createdStates]
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，当存在未确认的临时创建的搜索项时，外部受控修改value触发初始化后，会出现key重复的问题

## What is the new behavior?
重新初始化时，重新计算未确认的已创建搜索项的key，避免key重复

## Other information
