### PR TITLE
fix(comp:text): native tooltip should show when not ellipsised

### DIFF
--- a/packages/components/text/__tests__/__snapshots__/text.spec.ts.snap
+++ b/packages/components/text/__tests__/__snapshots__/text.spec.ts.snap
@@ -103,8 +103,7 @@ exports[`Text > tag work 2`] = `
 `;
 
 exports[`Text > tooltip work 1`] = `
-"<div class=\\"ix-text\\"><span class=\\"ix-text-inner\\" title=\\"@idux 是一套企业级中后台 UI 组件库, 致力于提供高效愉悦的开发体验。 基于 Vue 3.x + TypeScript 开发,
-      全部代码开源并遵循 MIT 协议，任何企业、组织及个人均可免费使用。\\">@idux 是一套企业级中后台 UI 组件库, 致力于提供高效愉悦的开发体验。 基于 Vue 3.x + TypeScript 开发,
+"<div class=\\"ix-text\\"><span class=\\"ix-text-inner\\">@idux 是一套企业级中后台 UI 组件库, 致力于提供高效愉悦的开发体验。 基于 Vue 3.x + TypeScript 开发,
       全部代码开源并遵循 MIT 协议，任何企业、组织及个人均可免费使用。<!----></span>
   <!---->
   <!---->

--- a/packages/components/text/demo/Tooltip.vue
+++ b/packages/components/text/demo/Tooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <IxRadioGroup v-model:value="tooltip" :dataSource="radios"></IxRadioGroup>
   <div style="width: 280px; margin-top: 16px">
-    <IxText :tooltip="tooltip">
+    <IxText ellipsis :tooltip="tooltip">
       @idux是一套企业级中后台UI组件库, 致力于提供高效愉悦的开发体验。
       <template #title>
         @idux是一套企业级中后台UI组件库, 致力于提供高效愉悦的开发体验。

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -128,7 +128,7 @@ export default defineComponent({
         <Tag
           ref={innerRef}
           class={`${prefixCls}-inner`}
-          title={isNative ? getStringBySlot(titleSlot) : undefined}
+          title={isNative && isEllipsis.value ? getStringBySlot(titleSlot) : undefined}
           onClick={expandable.value && !hasExpandIcon ? toggleExpanded : undefined}
           {...attrs}
         >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
IxText配置了natvie的tooltip时，文字没有省略也显示了tooltip

## What is the new behavior?
再没有文字省略时不显示tooltip

## Other information
