### PR TITLE
fix(pro:search): select activeValue shouldn't change on mouse leave

### DIFF
--- a/packages/pro/search/src/panel/SelectPanel.tsx
+++ b/packages/pro/search/src/panel/SelectPanel.tsx
@@ -114,7 +114,9 @@ export default defineComponent({
       callEmit(props.onSelectAllClick)
     }
     const handleMouseLeave = () => {
-      setActiveValue(undefined)
+      if (props.setInactiveOnMouseLeave) {
+        setActiveValue(undefined)
+      }
     }
 
     const handleKeyDown = useOnKeyDown(props, panelRef, activeValue, filteredDataSource, changeSelected, handleConfirm)

--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -48,6 +48,7 @@ export function createSelectSegment(
         setOnKeyDown={setOnKeyDown}
         showSelectAll={renderLocation === 'individual' && showSelectAll}
         showFooter={renderLocation === 'individual'}
+        setInactiveOnMouseLeave={renderLocation === 'quick-select-panel'}
         searchValue={searchable ? searchInput : ''}
         searchFn={searchFn}
         onChange={handleChange}

--- a/packages/pro/search/src/types/panels.ts
+++ b/packages/pro/search/src/types/panels.ts
@@ -33,6 +33,7 @@ export const proSearchSelectPanelProps = {
   showSelectAll: { type: Boolean, default: true },
   showFooter: { type: Boolean, default: true },
   autoHeight: { type: Boolean, default: false },
+  setInactiveOnMouseLeave: { type: Boolean, default: false },
   allSelected: Boolean,
   searchValue: { type: String, default: undefined },
   searchFn: Function as PropType<(data: SelectPanelData, searchValue?: string) => boolean>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索的select面板当鼠标移开之后激活状态的选项被清空，导致回车无法正常触发

## What is the new behavior?
修复以上问题，仅在快捷面板中才会在鼠标移出之后清楚激活状态，

## Other information
