### PR TITLE
fix(pro:search): segment input title should be placeholder when empty

### DIFF
--- a/packages/pro/search/src/components/SearchItem.tsx
+++ b/packages/pro/search/src/components/SearchItem.tsx
@@ -67,7 +67,7 @@ export default defineComponent({
       () => `${props.searchItem!.name}${props.searchItem!.resolvedSearchField.segments.length > 1 ? '' : ':'}`,
     )
     const searchItemTitle = computed(
-      () => searchItemName.value + ' ' + segmentRenderDatas.value.map(data => data.input).join(' '),
+      () => searchItemName.value + ' ' + segmentRenderDatas.value.map(data => data.input || data.placeholder).join(' '),
     )
 
     const handleNameMouseDown = (evt: MouseEvent) => {
@@ -90,6 +90,7 @@ export default defineComponent({
 
     return () => {
       const prefixCls = itemPrefixCls.value
+
       return (
         <IxTooltip
           class={`${prefixCls}-invalid-tooltip`}

--- a/packages/pro/search/src/components/segment/SegmentInput.tsx
+++ b/packages/pro/search/src/components/segment/SegmentInput.tsx
@@ -111,6 +111,7 @@ export default defineComponent({
             value={input.value ?? ''}
             disabled={props.disabled}
             placeholder={props.placeholder}
+            title={input.value ? undefined : props.placeholder}
             onInput={handleInput}
             onCompositionstart={handleCompositionStart}
             onCompositionend={handleCompositionEnd}

--- a/packages/pro/search/src/composables/useResolvedSearchFields.ts
+++ b/packages/pro/search/src/composables/useResolvedSearchFields.ts
@@ -91,6 +91,7 @@ function createSearchItemContentSegments(prefixCls: string, searchField: SearchF
     ? ([
         {
           ...segment,
+          placeholder: segment.placeholder ?? searchField.placeholder,
           inputClassName: [...(segment.inputClassName ?? []), searchField.inputClassName],
           containerClassName: [...(segment.containerClassName ?? []), searchField.containerClassName],
           onVisibleChange: searchField.onPanelVisibleChange,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，搜索项的placeholder过长的时候会被省略，并且input的title也不会显示完整的placeholder

## What is the new behavior?
input在值为空的时候应当悬浮显示placeholder，并且整个搜索项在值为空的时候应当以Placeholder拼接成title显示

## Other information
