### PR TITLE
fix(pro:search): select in quickselect panel should have active value

### DIFF
--- a/packages/pro/search/src/panel/SelectPanel.tsx
+++ b/packages/pro/search/src/panel/SelectPanel.tsx
@@ -60,7 +60,7 @@ export default defineComponent({
         if (key) {
           setActiveValue(key)
         } else if (_filteredDataSource && _filteredDataSource.findIndex(item => item.key === activeValue.value) < 0) {
-          setActiveValue(_filteredDataSource[0]?.key)
+          setActiveValue(props.setDefaultActiveValue ? _filteredDataSource[0]?.key : undefined)
         }
       },
       { immediate: true },

--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -50,6 +50,7 @@ export function createSelectSegment(
         setOnKeyDown={setOnKeyDown}
         showSelectAll={renderLocation === 'individual' && showSelectAll}
         showFooter={renderLocation === 'individual'}
+        setDefaultActiveValue={renderLocation === 'individual'}
         setInactiveOnMouseLeave={renderLocation === 'quick-select-panel'}
         searchValue={searchable ? searchInput : ''}
         searchFn={searchFn}

--- a/packages/pro/search/src/types/panels.ts
+++ b/packages/pro/search/src/types/panels.ts
@@ -33,6 +33,7 @@ export const proSearchSelectPanelProps = {
   showSelectAll: { type: Boolean, default: true },
   showFooter: { type: Boolean, default: true },
   autoHeight: { type: Boolean, default: false },
+  setDefaultActiveValue: { type: Boolean, default: true },
   setInactiveOnMouseLeave: { type: Boolean, default: false },
   allSelected: Boolean,
   searchValue: { type: String, default: undefined },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索的快捷选择面板中的select组件，也会在选项为空时默认使第一个选项处于激活状态

## What is the new behavior?
在快捷选择面板中的select不应当有默认的激活状态选项，保持面板整洁

## Other information
