### PR TITLE
fix(comp:radio): gap behaves abnormally when configured without 0px

### DIFF
--- a/packages/components/radio/src/RadioGroup.tsx
+++ b/packages/components/radio/src/RadioGroup.tsx
@@ -64,7 +64,7 @@ export default defineComponent({
       return normalizeClass({
         [prefixCls]: true,
         [`${common.prefixCls}-button-group`]: buttoned,
-        [`${common.prefixCls}-button-group-compact`]: buttoned && (!gap || gap === '0'),
+        [`${common.prefixCls}-button-group-compact`]: buttoned && (!gap || gap === '0' || gap === '0px'),
       })
     })
 


### PR DESCRIPTION
fix #1684 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [-] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [-] Tests for the changes have been added/updated or not needed
- [-] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
IxRadioGroup的gap配置，对字符串和数字的处理不一致 

## What is the new behavior?
IxRadioGroup的gap配置为0px时与配置为0表现一致 

## Other information
