### PR TITLE
fix(pro:table): layoutool Clickable when disabled

### DIFF
--- a/packages/pro/table/src/contents/LayoutToolTree.tsx
+++ b/packages/pro/table/src/contents/LayoutToolTree.tsx
@@ -155,7 +155,11 @@ function disableColumn(column: ProTableColumn) {
   if (changeIndex !== false && changeVisible !== false) {
     return false
   }
-  return { check: changeVisible === false, drag: changeIndex === false }
+  return {
+    check: changeVisible === false,
+    select: changeVisible === false,
+    drag: changeIndex === false,
+  }
 }
 
 function getCheckedKeys(columns: ProTableColumn[]) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
proTable layout tool禁用时可点击

![image](https://github.com/IDuxFE/idux/assets/38604634/b9e1e98a-cb3b-4c84-b473-92532c72e3fe)


## What is the new behavior?
proTable layout tool禁用时不可点击


## Other information
