### PR TITLE
fix(pro:search): click is correct when key is zero

### DIFF
--- a/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
@@ -9,7 +9,7 @@ import type { SearchState } from '../../composables/useSearchStates'
 
 import { computed, defineComponent, inject, normalizeClass, ref, watch } from 'vue'
 
-import { isObject } from 'lodash-es'
+import { isNil, isObject } from 'lodash-es'
 
 import { Logger, callEmit, useState } from '@idux/cdk/utils'
 import { type IconInstance, IxIcon } from '@idux/components/icon'
@@ -81,7 +81,7 @@ export default defineComponent({
     const confirmValue = (value: unknown) => {
       let searchStateKey = searchState.value?.key
 
-      if (!value && searchStateKey) {
+      if (isNil(value) && searchStateKey) {
         removeSearchState(searchStateKey)
         return
       }


### PR DESCRIPTION
fix #1746
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
searchFileds的key值是0或false，第一次点击选项会清空，第二次点击才能选中

## What is the new behavior?
searchFileds的key值是0或false能选中

## Other information
