### PR TITLE
fix(pro:layout): logo title color theme var reference error

### DIFF
--- a/packages/pro/layout/style/light.less
+++ b/packages/pro/layout/style/light.less
@@ -7,7 +7,7 @@
   }
 
   &-logo > a > h1 {
-    color: var(--ix-text-color-title);
+    color: var(--ix-color-text-title);
   }
 
   .@{menu-prefix}-inline {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
proLayout logo 的标题颜色变量使用不正确

## What is the new behavior?
修复以上问题

## Other information
