### PR TITLE
fix(comp:cascader): the value is incorrect after clicking the clear icon

### DIFF
--- a/packages/components/cascader/__tests__/cascader.spec.ts
+++ b/packages/components/cascader/__tests__/cascader.spec.ts
@@ -229,6 +229,20 @@ describe('Cascader', () => {
       expect(getAllOptionGroup(wrapper)[2].find('.ix-cascader-option-disabled').exists()).toBe(false)
       expect(getAllOptionGroup(wrapper)[0].find('.ix-cascader-option-disabled').text()).toBe('Pro')
     })
+
+    test('clearable  work', async () => {
+      const onUpdateValue = vi.fn()
+      const wrapper = CascaderMount({
+        props: {
+          clearable: true,
+          'onUpdate:value': onUpdateValue,
+        },
+      })
+
+      await wrapper.find('.ix-selector-clear').trigger('click')
+
+      expect(onUpdateValue).toBeCalledWith([])
+    })
   })
 
   describe('multiple work', () => {

--- a/packages/components/cascader/src/composables/useSelectedState.ts
+++ b/packages/components/cascader/src/composables/useSelectedState.ts
@@ -76,28 +76,30 @@ export function useSelectedState(
     return [...indeterminateKeySet]
   })
 
-  const setValue = (keys: VKey[]) => {
-    let currValue: VKey | VKey[] | VKey[][]
+  const getFullPath = (currKey: VKey) => {
+    const getDisabledFn = mergedGetDisabled.value
+    const dataMap = mergedDataMap.value
+    const fullPath = getParentKeys(dataMap, dataMap.get(currKey), true, getDisabledFn)
+    fullPath.push(currKey)
+    return fullPath
+  }
 
+  const getCurrValue = (keys: VKey[]) => {
     if (!mergedFullPath.value) {
-      currValue = multiple.value ? keys : keys[0]
-    } else {
-      const getDisabledFn = mergedGetDisabled.value
-      if (!multiple.value) {
-        const currKey = keys[0]
-        const dataMap = mergedDataMap.value
-        currValue = getParentKeys(dataMap, dataMap.get(currKey), true, getDisabledFn)
-        currValue.push(currKey)
-      } else {
-        const dataMap = mergedDataMap.value
-        currValue = keys.map(currKey => {
-          const parentKeys = getParentKeys(dataMap, dataMap.get(currKey), true, getDisabledFn)
-          parentKeys.push(currKey)
-          return parentKeys
-        })
-      }
+      return multiple.value ? keys : keys[0]
     }
+    if (keys.length === 0) {
+      return keys
+    }
+    if (multiple.value) {
+      return keys.map(getFullPath)
+    } else {
+      return getFullPath(keys[0])
+    }
+  }
 
+  const setValue = (keys: VKey[]) => {
+    const currValue = getCurrValue(keys)
     const oldValue = toRaw(selectedKeys.value)
     if (currValue !== oldValue) {
       setSelectedKeys(currValue)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- 在单选，并且开启 fullPath 的条件下，点击清空图标，值设置错误。
  - 会错误的设置成 [undefined]

## What is the new behavior?

- 正确设置成空数组 []


## Other information
