### PR TITLE
fix(pro:search): non-multiple field created state should be overwritten by new state

### DIFF
--- a/packages/components/_private/date-panel/__tests__/__snapshots__/datePanel.spec.ts.snap
+++ b/packages/components/_private/date-panel/__tests__/__snapshots__/datePanel.spec.ts.snap
@@ -637,12 +637,12 @@ exports[`DatePanel > year type disabledDate work 1`] = `
               <div class=\\"ix-date-panel-cell-trigger\\">2022</div>
             </div>
           </td>
-          <td class=\\"ix-date-panel-cell ix-date-panel-cell-current\\" role=\\"gridcell\\">
+          <td class=\\"ix-date-panel-cell\\" role=\\"gridcell\\">
             <div class=\\"ix-date-panel-cell-inner\\">
               <div class=\\"ix-date-panel-cell-trigger\\">2023</div>
             </div>
           </td>
-          <td class=\\"ix-date-panel-cell\\" role=\\"gridcell\\">
+          <td class=\\"ix-date-panel-cell ix-date-panel-cell-current\\" role=\\"gridcell\\">
             <div class=\\"ix-date-panel-cell-inner\\">
               <div class=\\"ix-date-panel-cell-trigger\\">2024</div>
             </div>

--- a/packages/pro/search/demo/Parser.vue
+++ b/packages/pro/search/demo/Parser.vue
@@ -274,6 +274,7 @@ const searchFields = ref<SearchField[]>([
 
 const tableColums: TableColumn[] = [
   {
+    key: 'index',
     type: 'indexable',
   },
   {
@@ -292,9 +293,10 @@ const tableData = computed(() => {
   const parseRes = parse(value.value)
 
   return parseRes.map(res => {
-    const { label, segments } = res
+    const { label, segments, key } = res
 
     return {
+      key,
       name: label,
       input: segments.map(seg => seg.input).join(' '),
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
新创建未确认的非multile搜索项，在value受控更新添加相同的filed的搜索项时，不会被覆盖

## What is the new behavior?
如果一个搜索项是非multiple，即只允许存在一个，则在value受控更新，添加新的搜索项时，原先未确认的搜索项应当被新搜索项覆盖

## Other information
