### PR TITLE
fix(comp:popover,tooltip): replace paddings with theme variables

### DIFF
--- a/packages/components/popover/style/index.less
+++ b/packages/components/popover/style/index.less
@@ -16,16 +16,16 @@
     z-index: 1;
 
     > .@{header-prefix} {
-      padding-left: 12px;
-      padding-right: 12px;
+      padding-left: var(--ix-padding-size-md);
+      padding-right: var(--ix-padding-size-md);
     }
   }
 
   &-content {
-    padding: 12px;
+    padding: var(--ix-padding-size-sm) var(--ix-padding-size-md);
   }
 
   .@{header-prefix} + &-content {
-    padding-top: 4px;
+    padding-top: var(--ix-padding-size-xs);
   }
 }

--- a/packages/components/tooltip/style/index.less
+++ b/packages/components/tooltip/style/index.less
@@ -14,7 +14,7 @@
     word-wrap: break-word;
     min-width: var(--ix-tooltip-min-width);
     max-width: var(--ix-tooltip-max-width);
-    padding: 4px 8px;
+    padding: var(--ix-padding-size-xs) var(--ix-padding-size-sm);
     z-index: 1;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
padding 是写死的

## What is the new behavior?
padding 替换成主题变量

## Other information
