### PR TITLE
feat(comp:table): column align supports cell and title

### DIFF
--- a/packages/components/table/demo/Basic.vue
+++ b/packages/components/table/demo/Basic.vue
@@ -35,6 +35,10 @@ const columns: TableColumn<Data>[] = [
   {
     title: 'Age',
     dataKey: 'age',
+    align: {
+      title: 'start',
+      cell: 'end',
+    },
   },
   {
     title: 'Address',

--- a/packages/components/table/docs/Api.zh.md
+++ b/packages/components/table/docs/Api.zh.md
@@ -60,7 +60,7 @@ export type TableColumn<T = any, V = any> =
 
 | 名称 | 说明 | 类型  | 默认值 | 全局配置 | 备注 |
 | --- | --- | --- | --- | --- | --- |
-| `align` | 文本对齐方式 | `'start' \| 'center' \| 'end'` | `'start'` | ✅ | - |
+| `align` | 文本对齐方式 | `'start' \| 'center' \| 'end' \| { title: 'start' \| 'center' \| 'end', cell: 'start' \| 'center' \| 'end' }` | `'start'` | ✅ | - |
 | `colSpan` | 计算列的 `colSpan` | `(record: T, rowIndex: number) => number` | - | - | 返回为 `0` 时，不渲染, 通常用于列合并 |
 | `fixed` | 是否固定 | `'start' \| 'end'` | - | - | - |
 | `rowSpan` | 计算列的 `rowSpan` | `(record: T, rowIndex: number) => number` | - | - | 返回为 `0` 时，不渲染, 通常用于行合并 |

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -70,7 +70,7 @@ export default defineComponent({
       let classes = {
         [`${prefixCls}-cell`]: true,
         [`${prefixCls}-cell-sorted`]: !!activeSortOrderBy.value,
-        [`${prefixCls}-cell-align-${align}`]: !!align && align != 'start',
+        [`${prefixCls}-cell-align-${align.cell}`]: !!align && align.cell != 'start',
         [`${prefixCls}-cell-ellipsis`]: !!mergedEllipsis.value,
       }
       if (fixed) {

--- a/packages/components/table/src/main/head/HeadCell.tsx
+++ b/packages/components/table/src/main/head/HeadCell.tsx
@@ -70,8 +70,8 @@ export default defineComponent({
         [`${prefixCls}-cell-${type}`]: !!type,
         [`${prefixCls}-cell-filterable`]: !!filterable,
         [`${prefixCls}-cell-sortable`]: !!sortable,
-        [`${prefixCls}-cell-align-center`]: hasChildren || align === 'center',
-        [`${prefixCls}-cell-align-end`]: !hasChildren && align === 'end',
+        [`${prefixCls}-cell-align-center`]: hasChildren || align?.title === 'center',
+        [`${prefixCls}-cell-align-end`]: !hasChildren && align?.title === 'end',
         [`${prefixCls}-cell-ellipsis`]: !!mergedEllipsis.value,
       }
       if (fixed) {

--- a/packages/components/table/src/types.ts
+++ b/packages/components/table/src/types.ts
@@ -87,7 +87,7 @@ export type TableColumn<T = any, K = VKey> =
 
 export interface TableColumnCommon<T = any> {
   key?: VKey
-  align?: TableColumnAlign
+  align?: TableColumnAlign | { title: TableColumnAlign; cell: TableColumnAlign }
   colSpan?: (record: T, rowIndex: number) => number
   rowSpan?: (record: T, rowIndex: number) => number
   fixed?: TableColumnFixed


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格 column的 align 只能表头和表体一起配置，不可以分开配置

## What is the new behavior?
支持传入对象 { title, cell } 的方式，分别配置表头和表体的align

## Other information
