### PR TITLE
fix(comp:collapse): modify header font-size to fontSizeHeaderSm

### DIFF
--- a/packages/components/collapse/style/index.less
+++ b/packages/components/collapse/style/index.less
@@ -106,9 +106,8 @@
 }
 
 .collapse-size(@font-size, @expand-icon-font-size, @padding-horizontal) {
-  .reset-font-size(@font-size);
-
   .@{header-prefix} {
+    .reset-font-size(@font-size);
     padding-left: @padding-horizontal;
     padding-right: @padding-horizontal;
   }

--- a/packages/components/collapse/style/index.less
+++ b/packages/components/collapse/style/index.less
@@ -108,6 +108,7 @@
 .collapse-size(@font-size, @expand-icon-font-size, @padding-horizontal) {
   .@{header-prefix} {
     .reset-font-size(@font-size);
+
     padding-left: @padding-horizontal;
     padding-right: @padding-horizontal;
   }

--- a/packages/components/collapse/theme/default.ts
+++ b/packages/components/collapse/theme/default.ts
@@ -7,8 +7,15 @@
 
 import type { CertainThemeTokens, GlobalThemeTokens } from '@idux/components/theme'
 export function getDefaultThemeTokens(tokens: GlobalThemeTokens): CertainThemeTokens<'collapse'> {
-  const { colorContainerBg, colorInfoContainerBg, fontSizeHeaderSm, fontSizeXl, fontSize2xl, paddingSizeMd, paddingSizeLg } =
-    tokens
+  const {
+    colorContainerBg,
+    colorInfoContainerBg,
+    fontSizeHeaderSm,
+    fontSizeXl,
+    fontSize2xl,
+    paddingSizeMd,
+    paddingSizeLg,
+  } = tokens
 
   return {
     fontSizeSm: fontSizeHeaderSm,

--- a/packages/components/collapse/theme/default.ts
+++ b/packages/components/collapse/theme/default.ts
@@ -7,12 +7,12 @@
 
 import type { CertainThemeTokens, GlobalThemeTokens } from '@idux/components/theme'
 export function getDefaultThemeTokens(tokens: GlobalThemeTokens): CertainThemeTokens<'collapse'> {
-  const { colorContainerBg, colorInfoContainerBg, fontSizeSm, fontSizeXl, fontSize2xl, paddingSizeMd, paddingSizeLg } =
+  const { colorContainerBg, colorInfoContainerBg, fontSizeHeaderSm, fontSizeXl, fontSize2xl, paddingSizeMd, paddingSizeLg } =
     tokens
 
   return {
-    fontSizeSm: fontSizeSm,
-    fontSizeMd: fontSizeSm,
+    fontSizeSm: fontSizeHeaderSm,
+    fontSizeMd: fontSizeHeaderSm,
 
     expandIconSizeSm: fontSizeXl,
     expandIconSizeMd: fontSize2xl,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
折叠面板的头部字体大小为 fontSizeSm，且字体大小样式不生效
## What is the new behavior?
修改为 fontSizeHeaderSm，并修复样式不生效的问题

## Other information
