### PR TITLE
fix(comp:table): table header not visible when width not collected

### DIFF
--- a/packages/components/table/src/composables/useColumns.ts
+++ b/packages/components/table/src/composables/useColumns.ts
@@ -56,7 +56,7 @@ export function useColumns(
 
   const columnCount = computed(() => flattedColumnsWithScrollBar.value.length)
 
-  const { columnWidthMap, columnWidths, changeColumnWidth, clearColumnWidth } = useColumnWidths(flattedColumns)
+  const { columnWidthMap, columnWidths, changeColumnWidth } = useColumnWidths(flattedColumns)
   const { columnOffsets, columnOffsetsWithScrollBar } = useColumnOffsets(fixedColumns, columnWidthMap, columnCount)
 
   const mergedRows = computed(() => mergeRows(mergedColumns.value, scrollBarColumn.value))
@@ -72,7 +72,6 @@ export function useColumns(
     columnWidthMap,
     columnWidths,
     changeColumnWidth,
-    clearColumnWidth,
     columnOffsets,
     columnOffsetsWithScrollBar,
     mergedRows,
@@ -96,7 +95,6 @@ export interface ColumnsContext {
   columnWidthMap: Ref<Record<VKey, number>>
   columnWidths: Ref<number[]>
   changeColumnWidth: (key: VKey, width: number | false) => void
-  clearColumnWidth: () => void
   columnOffsets: ComputedRef<{
     starts: Record<VKey, { index: number; offset: number }>
     ends: Record<VKey, { index: number; offset: number }>
@@ -339,11 +337,7 @@ function useColumnWidths(flattedColumns: ComputedRef<TableColumnMerged[]>) {
     }
   }
 
-  const clearColumnWidth = () => {
-    widthMap.value = {}
-  }
-
-  return { columnWidthMap: widthMap, columnWidths, changeColumnWidth, clearColumnWidth }
+  return { columnWidthMap: widthMap, columnWidths, changeColumnWidth }
 }
 
 function useColumnOffsets(

--- a/packages/components/table/src/main/FixedHolder.tsx
+++ b/packages/components/table/src/main/FixedHolder.tsx
@@ -56,7 +56,6 @@ export default defineComponent({
       fixedColumns,
       mergedRows,
       isSticky,
-      columnWidths,
     } = inject(TABLE_TOKEN)!
 
     const virtualScrollRef = ref<VirtualScrollInstance>()
@@ -97,14 +96,6 @@ export default defineComponent({
       }
     })
 
-    const tableStyle = computed<CSSProperties>(() => {
-      const visibility = hasData.value && scrollWidth.value && !columnWidths.value.length ? 'hidden' : undefined
-      return {
-        tableLayout: 'fixed',
-        visibility,
-      }
-    })
-
     const virtualData = computed<VirtualScrollRowData<TableColumnMergedExtra>[]>(() => {
       if (!mergedVirtual.value.horizontal) {
         return []
@@ -134,7 +125,7 @@ export default defineComponent({
           }
 
           return (
-            <table style={tableStyle.value}>
+            <table style={{ tableLayout: 'fixed' }}>
               {showColGroup && <ColGroup columns={flattedColumns} isFixedHolder />}
               <Head>{children}</Head>
             </table>
@@ -190,7 +181,7 @@ export default defineComponent({
       return (
         <div class={classes.value} style={style.value} ref={scrollHeadRef}>
           {
-            <table style={tableStyle.value}>
+            <table style={{ tableLayout: 'fixed' }}>
               {showColGroup && <ColGroup isFixedHolder />}
               <Head></Head>
             </table>

--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -62,7 +62,6 @@ export default defineComponent({
       mergedAutoHeight,
       columnWidths,
       changeColumnWidth,
-      clearColumnWidth,
       flattedData,
       flattedColumns,
       fixedColumns,
@@ -112,12 +111,6 @@ export default defineComponent({
     onMounted(() => {
       triggerScroll()
 
-      watch(
-        () => flattedColumns.value.length,
-        () => {
-          clearColumnWidth()
-        },
-      )
       watch([() => props.dataSource, scrollWidth], ([, width]) => {
         if (width) {
           triggerScroll()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 表格列宽度会在列数变化后清空，并没有重新计算
2. 表头在列没有计算的时候不显示

## What is the new behavior?
1. 不应该清空，在resize之后重新计算即可
2. 表格列宽默认会使用配置的宽度，如果列宽没有计算并不会导致表头闪烁，因此不需要隐藏

## Other information
