### PR TITLE
fix(pro:search): container zIndex shouldn't be set when not focused

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -134,9 +134,11 @@ export default defineComponent({
       })
     })
     const containerStyle = computed(() =>
-      normalizeStyle({
-        zIndex: currentZIndex.value,
-      }),
+      focused.value
+        ? normalizeStyle({
+            zIndex: currentZIndex.value,
+          })
+        : undefined,
     )
 
     expose({ focus, blur })

--- a/packages/pro/search/style/index.less
+++ b/packages/pro/search/style/index.less
@@ -35,7 +35,6 @@
 
   &-input-container {
     position: relative;
-    z-index: 1000;
     flex: auto;
     align-self: flex-start;
     width: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索的z-index会在focus之后绑定并且不会消失，导致遮挡其他页面元素

## What is the new behavior?
高级搜索的z-inde只需要在focus的时候设置，其他情况下应当视为页面的内联元素，不赋以z-index

## Other information
