### PR TITLE
fix(comp:table): scroll classes is determined by scroll overflowed

### DIFF
--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -75,6 +75,8 @@ export default defineComponent({
       pingedEnd,
       scrollWidth,
       scrollHeight,
+      scrollHorizontalOverflowed,
+      scrollVerticalOverflowed,
       hasFixed,
       tableLayout,
     } = inject(TABLE_TOKEN)!
@@ -140,8 +142,8 @@ export default defineComponent({
         [`${prefixCls}-fixed-layout`]: tableLayout.value === 'fixed',
         [`${prefixCls}-fixed-column`]: hasFixed.value,
         [`${prefixCls}-inset-shadow`]: mergedInsetShadow.value,
-        [`${prefixCls}-scroll-horizontal`]: scrollWidth.value,
-        [`${prefixCls}-scroll-vertical`]: scrollHeight.value,
+        [`${prefixCls}-scroll-horizontal`]: scrollHorizontalOverflowed.value,
+        [`${prefixCls}-scroll-vertical`]: scrollVerticalOverflowed.value,
       })
     })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
scroll-horizontal 和 scroll-vertical 的class是由 scrollWidth和scrollHeight判断的，并不是由是否真的由滚动判断

## What is the new behavior?
修改以上问题，改为由 scrollHorizontalOverflowed和scrollVerticalOverflowed判断

## Other information
