### PR TITLE
fix(comp:alert): change alert marigin-right to 4px

### DIFF
--- a/packages/components/alert/style/index.less
+++ b/packages/components/alert/style/index.less
@@ -26,7 +26,7 @@
   }
 
   &-icon {
-    margin-right: 8px;
+    margin-right: var(--ix-margin-size-xs);
   }
 
   &-close-icon {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
图标与文案的右边距为8px

## What is the new behavior?
图标与文案的改为右边距为4px

## Other information
