### PR TITLE
feat(cdk:scroll): add simulated scroll support to VirtualScroll

### DIFF
--- a/packages/cdk/scroll/__tests__/__snapshots__/virtualScroll.spec.ts.snap
+++ b/packages/cdk/scroll/__tests__/__snapshots__/virtualScroll.spec.ts.snap
@@ -1,21 +1,25 @@
 // Vitest Snapshot v1
 
 exports[`VirtualScroll > basic work > render work 1`] = `
-"<div class=\\"cdk-virtual-scroll\\">
-  <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 100%;\\">
+"<div class=\\"cdk-virtual-scroll cdk-virtual-scroll-overflowed-vertical\\">
+  <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 100%; overflow-x: auto; overflow-y: auto;\\">
     <!---->
     <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 0px;\\"></div>
     <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px; margin-left: 0px;\\"><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-0 - 0</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-1 - 1</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-2 - 2</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-3 - 3</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-4 - 4</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-5 - 5</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-6 - 6</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-7 - 7</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-8 - 8</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-9 - 9</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-10 - 10</span></div>
   </div>
+  <!---->
+  <!---->
 </div>"
 `;
 
 exports[`VirtualScroll > basic work > rowRender work 1`] = `
-"<div class=\\"cdk-virtual-scroll\\">
-  <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 100%;\\">
+"<div class=\\"cdk-virtual-scroll cdk-virtual-scroll-overflowed-vertical\\">
+  <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 100%; overflow-x: auto; overflow-y: auto;\\">
     <!---->
     <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 0px;\\"></div>
     <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px; margin-left: 0px;\\"><span class=\\"virtual-item\\">key-0 - 0</span><span class=\\"virtual-item\\">key-1 - 1</span><span class=\\"virtual-item\\">key-2 - 2</span><span class=\\"virtual-item\\">key-3 - 3</span><span class=\\"virtual-item\\">key-4 - 4</span><span class=\\"virtual-item\\">key-5 - 5</span><span class=\\"virtual-item\\">key-6 - 6</span><span class=\\"virtual-item\\">key-7 - 7</span><span class=\\"virtual-item\\">key-8 - 8</span><span class=\\"virtual-item\\">key-9 - 9</span><span class=\\"virtual-item\\">key-10 - 10</span></div>
   </div>
+  <!---->
+  <!---->
 </div>"
 `;

--- a/packages/cdk/scroll/__tests__/virtualScroll.spec.ts
+++ b/packages/cdk/scroll/__tests__/virtualScroll.spec.ts
@@ -28,6 +28,10 @@ describe('VirtualScroll', () => {
   const VirtualScrollMount = (options?: MountingOptions<Partial<VirtualScrollProps>>) => {
     const { props, ...rest } = options || {}
     const mergedOptions = { props: { ...defaultProps, ...props }, ...rest } as MountingOptions<VirtualScrollProps>
+    const scrollHeight = (props?.dataSource?.length ?? 0) * 20
+
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(() => scrollHeight)
+
     return mount(VirtualScroll, mergedOptions) as VueWrapper<VirtualScrollInstance>
   }
 
@@ -35,8 +39,9 @@ describe('VirtualScroll', () => {
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => 200)
   })
 
-  afterAll(() => {
+  afterEach(() => {
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockClear()
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockClear()
   })
 
   describe('basic work', () => {

--- a/packages/cdk/scroll/demo/SimulatedScroll.md
+++ b/packages/cdk/scroll/demo/SimulatedScroll.md
@@ -1,0 +1,14 @@
+---
+title:
+  zh: 模拟滚动
+  en: Simulated scroll
+order: 4
+---
+
+## zh
+
+使用模拟滚动替代原生滚动。
+
+## en
+
+Use simulated scroll instead of native scroll.

--- a/packages/cdk/scroll/demo/SimulatedScroll.vue
+++ b/packages/cdk/scroll/demo/SimulatedScroll.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="demo-both-scroll-wrapper">
+    <CdkVirtualScroll
+      ref="listRef"
+      :dataSource="rowData"
+      :height="200"
+      :rowHeight="20"
+      :colWidth="200"
+      :virtual="true"
+      :rowRender="rowRender"
+      getKey="key"
+    >
+      <template #col="{ row, item, index }">
+        <span class="virtual-item" @click="onItemClick(item.key)">{{ row.key }} - {{ index }}</span>
+      </template>
+    </CdkVirtualScroll>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h, ref } from 'vue'
+
+import { VirtualRowRenderFn, VirtualScrollInstance, VirtualScrollRowData } from '@idux/cdk/scroll'
+
+const listRef = ref<VirtualScrollInstance>()
+const colData: { key: string }[] = []
+for (let index = 0; index < 1000; index++) {
+  colData.push({ key: `col-key-${index}` })
+}
+const rowData: VirtualScrollRowData[] = []
+for (let index = 0; index < 1000; index++) {
+  rowData.push({
+    key: `row-key-${index}`,
+    data: colData,
+  })
+}
+
+const rowRender: VirtualRowRenderFn = ({ children }) =>
+  h(
+    'div',
+    {
+      class: 'virtual-row',
+    },
+    children,
+  )
+
+const onItemClick = (key: string) => {
+  console.log('click:', key)
+}
+</script>
+
+<style lang="less">
+.demo-both-scroll-wrapper {
+  height: 240px;
+  .cdk-virtual-scroll {
+    border: 1px solid red;
+    margin-bottom: 8px;
+  }
+
+  .virtual-row {
+    flex-shrink: 0;
+    display: flex;
+    height: 20px;
+    flex-wrap: nowrap;
+    border: 1px solid gray;
+  }
+
+  .virtual-item {
+    flex-shrink: 0;
+    padding-left: 16px;
+    border: 1px solid gray;
+    height: 100%;
+    width: 200px;
+    line-height: 18px;
+  }
+}
+</style>

--- a/packages/cdk/scroll/docs/Api.zh.md
+++ b/packages/cdk/scroll/docs/Api.zh.md
@@ -17,10 +17,13 @@
 | `fullHeight` | 是否永远使用 `height` 作为容器高度 | `boolean` | `false` | - | 仅在不符合虚拟滚动条件时生效 |
 | `width` | 列表的宽度 | `number \| 100%` | `0` | - | 设置为大于 0 时才可以启用虚拟滚动 |
 | `fullHeight` | 是否永远使用 `width` 作为容器的宽度 | `boolean` | `false` | - | 仅在不符合虚拟滚动条件时生效 |
-| `rowHeight` | 列表行的高度 | `number` | `0` | - | 设置为大于 0 时才可以启用虚拟滚动 |
-| `colWidth` | 列表列的宽度 | `number` | `0` | - | 设置为大于 0 时才可以启用虚拟滚动 |
+| `rowHeight` | 默认列表行的高度 | `number` | `0` | - | 设置为大于 0 时才可以启用虚拟滚动 |
+| `colWidth` | 默认列表列的宽度 | `number` | `0` | - | 设置为大于 0 时才可以启用虚拟滚动 |
+| `getRowHeight` | 列表行的高度获取函数 | `(rowKey: VKey) => number \| undefined` | - | - | 在行高不固定的场景下尽可能减少抖动 |
+| `getColWidth` | 列表列的宽度获取函数 | `(rowKey: VKey, colWidth: VKey) => number \| undefined` | - | - | 在列宽不固定的场景下尽可能减少抖动 |
 | `rowRender` | 列表行的渲染函数 | `VirtualRowRenderFn \| #row={item, index}` | - | - | 必须设置或者提供 `row` 插槽 |
 | `colRender` | 列表列的渲染函数 | `VirtualColRenderFn \| #col={row, item, index}` | - | - | 必须设置或者提供 `col` 插槽 |
+| `scrollMode` | 使用的滚动模式，支持原生滚动和模拟滚动 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `virtual` | 是否启用虚拟滚动 | `boolean \| VirtualScrollEnabled` | `{ horizontal: true, vertical: false }` | - | - |
 | `buffer` | 缓冲区大小 | `numnber` | `0` | - | - |
 | `bufferOffset` | 在距离数据边界有几项时开始渲染下一屏数据 | `numnber` | `0` | - | - |
@@ -44,6 +47,8 @@ type VirtualScrollEnabled = { horizontal: boolean; vertical: boolean }
 | 名称 | 说明 | 参数类型 | 备注 |
 | --- | --- | --- | --- |
 | `scrollTo` | 手动设置滚动条位置 | `(value?: number \| VirtualScrollToOptions) => void` | 支持滚动到具体的 key 或者 index, 以及设置偏移量 |
+
+### FAQ
 
 #### 如何开启横向虚拟滚动
 
@@ -75,3 +80,13 @@ interface RowData {
 在开启了 `buffer` 后，会在当前窗口可渲染的行列基础上，再多渲染一些数据来缓解渲染频率过高的问题，但这在数据的渲染过于复杂的情况下并不适用，因为单次渲染的节点会增加，从而会导致渲染卡顿。
 
 `bufferOffset` 的意义，是在滚动到距离所有渲染的项目边界还有几项时就提前渲染下一屏的数据，它可以一定程度上让滚动更加顺滑，但是也增加了渲染频率。
+
+#### 虚拟滚动组件在滚动比较快的时候出现短暂白屏如何处理？
+
+由于虚拟滚动默认使用原生滚动来实现，而原生滚动触发的渲染总是会在虚拟滚动内部计算和渲染之前，因此当滚动过快或者内部元素渲染的复杂度太高时，不可避免会出现短暂的白屏。
+
+优化方式有以下几种：
+
+1. 当内部的渲染可优化的空间很大，且短暂的白屏区域并不会影响用户体验时，建议保留原生滚动，对渲染过程进行优化，减少dom节点数，将不必要的计算提前，复用重复的组件等。
+
+2. 当以上无法解决痛点时，可以将 `scrollMode` 配置为 `simulated` 开启模拟滚动，这种滚动方式会在滚动发生之后首先通知组件进行计算并准备下一步的渲染，可视区域的滚动位置和虚拟滚动区域的渲染就会发生在同一时间，因此不会出现白屏。但是需要特别注意的是，由于模拟滚动主要是为了处理性能问题，模拟滚动并不会像原生滚动那样平滑，建议尽量避免使用模拟滚动。

--- a/packages/cdk/scroll/index.ts
+++ b/packages/cdk/scroll/index.ts
@@ -6,6 +6,8 @@
  */
 
 export * from './src/strategy'
+export * from './src/scrollbar'
+export * from './src/useScroll'
 export * from './src/utils'
 
 import type { VirtualScrollComponent } from './src/virtual/types'
@@ -27,4 +29,5 @@ export type {
   VirtualScrollToFn,
   VirtualScrollEnabled,
   VirtualScrollRowData,
+  VirtualScrollMode,
 } from './src/virtual/types'

--- a/packages/cdk/scroll/src/scrollbar/Scrollbar.tsx
+++ b/packages/cdk/scroll/src/scrollbar/Scrollbar.tsx
@@ -1,0 +1,55 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import { computed, defineComponent, normalizeStyle, ref } from 'vue'
+
+import { convertCssPixel } from '@idux/cdk/utils'
+
+import { useScrollbarState } from './composables/useScrollbarState'
+import { scrollbarProps } from './types'
+
+export default defineComponent({
+  props: scrollbarProps,
+  setup(props) {
+    const scrollbarRef = ref<HTMLElement>()
+    const thumbRef = ref<HTMLElement>()
+
+    const { canScroll, offset, isDragging, thumbSize } = useScrollbarState(props, scrollbarRef, thumbRef)
+
+    const classes = computed(() => ({
+      'cdk-scrollbar': true,
+      'cdk-scrollbar-vertical': !props.horizontal,
+      'cdk-scrollbar-horizontal': !!props.horizontal,
+    }))
+    const style = computed(() => normalizeStyle(props.containerStyle))
+    const thumbClass = computed(() => ({
+      'cdk-scrollbar-thumb': true,
+      'cdk-scrollbar-thumb-moving': isDragging.value,
+    }))
+    const thumbStyle = computed(() => {
+      const thumbSizeStyle = convertCssPixel(thumbSize.value)
+      const offsetSizeStyle = convertCssPixel(offset.value)
+      const _style = props.horizontal
+        ? {
+            marginLeft: offsetSizeStyle,
+            width: thumbSizeStyle,
+          }
+        : {
+            marginTop: offsetSizeStyle,
+            height: thumbSizeStyle,
+          }
+
+      return normalizeStyle([_style, props.thumbStyle])
+    })
+
+    return () => (
+      <div ref={scrollbarRef} class={classes.value} style={style.value}>
+        <div v-show={canScroll.value} ref={thumbRef} class={thumbClass.value} style={thumbStyle.value} />
+      </div>
+    )
+  },
+})

--- a/packages/cdk/scroll/src/scrollbar/composables/useScrollbarState.ts
+++ b/packages/cdk/scroll/src/scrollbar/composables/useScrollbarState.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { ScrollbarProps } from '../types'
+
+import { type ComputedRef, type Ref, computed, onBeforeUnmount, onMounted } from 'vue'
+
+import { callEmit, cancelRAF, rAF, useEventListener, useState } from '@idux/cdk/utils'
+
+export interface ScrollbarStateContext {
+  canScroll: ComputedRef<boolean>
+  offset: ComputedRef<number>
+  thumbSize: ComputedRef<number>
+  isDragging: ComputedRef<boolean>
+}
+
+export function useScrollbarState(
+  props: ScrollbarProps,
+  scrollbarRef: Ref<HTMLElement | undefined>,
+  thumbRef: Ref<HTMLElement | undefined>,
+): ScrollbarStateContext {
+  const thumbSize = computed(() => getThumbSize(props.thumbMinSize, props.containerSize, props.scrollRange))
+
+  const enabledScrollRange = computed(() => Math.max(props.scrollRange - props.containerSize, 0))
+  const enabledOffsetRange = computed(() => Math.max(props.containerSize - thumbSize.value, 0))
+  const offset = computed(() => {
+    if (props.scrollOffset === 0 || enabledOffsetRange.value === 0) {
+      return 0
+    }
+
+    return (props.scrollOffset / enabledScrollRange.value) * enabledOffsetRange.value
+  })
+  const canScroll = computed(() => enabledScrollRange.value > 0)
+
+  const [isDragging, setIsDragging] = useState(false)
+  const [startOffset, setStartOffset] = useState(0)
+  const [pageXY, setPageXY] = useState(0)
+  let rafId: number
+
+  const onThumbMouseDown = (evt: MouseEvent | TouchEvent) => {
+    setIsDragging(true)
+    setPageXY(getPageXY(evt, props.horizontal))
+    setStartOffset(offset.value)
+
+    callEmit(props.onMoveStart)
+    evt.stopPropagation()
+    evt.preventDefault()
+  }
+
+  const onMouseMove = (evt: MouseEvent | TouchEvent) => {
+    cancelRAF(rafId)
+    if (!isDragging.value) {
+      return
+    }
+
+    const _enabledScrollRange = enabledScrollRange.value
+    const movedOffset = getPageXY(evt, props.horizontal) - pageXY.value
+    const newOffset = startOffset.value + movedOffset
+
+    const ptg = _enabledScrollRange ? newOffset / enabledOffsetRange.value : 0
+
+    let newScrollOffset = Math.ceil(ptg * _enabledScrollRange)
+    newScrollOffset = Math.max(newScrollOffset, 0)
+    newScrollOffset = Math.min(newScrollOffset, _enabledScrollRange)
+
+    rafId = rAF(() => {
+      callEmit(props.onScroll, newScrollOffset)
+    })
+  }
+  const onMouseUp = () => {
+    setIsDragging(false)
+    callEmit(props.onMoveEnd)
+  }
+
+  const onScrollbarTouchStart = (evt: TouchEvent) => {
+    evt.preventDefault()
+  }
+
+  let listenerStops: (() => void)[] = []
+  const clearListeners = () => {
+    listenerStops.forEach(stop => stop())
+  }
+
+  onMounted(() => {
+    listenerStops = [
+      useEventListener(scrollbarRef, 'touchstart', onScrollbarTouchStart),
+      useEventListener(thumbRef, 'touchstart', onThumbMouseDown),
+      useEventListener(thumbRef, 'mousedown', onThumbMouseDown),
+      useEventListener(window, 'mousemove', onMouseMove),
+      useEventListener(window, 'touchmove', onMouseMove),
+      useEventListener(window, 'mouseup', onMouseUp),
+      useEventListener(window, 'touchend', onMouseUp),
+    ]
+  })
+  onBeforeUnmount(() => {
+    clearListeners()
+    cancelRAF(rafId)
+  })
+
+  return {
+    canScroll,
+    offset,
+    thumbSize,
+    isDragging,
+  }
+}
+
+function getPageXY(evt: MouseEvent | TouchEvent, horizontal: boolean) {
+  const pageData = 'touches' in evt ? evt.touches[0] : evt
+  return pageData[horizontal ? 'pageX' : 'pageY']
+}
+
+function getThumbSize(thumbMinSize: number, containerSize = 0, scrollRange = 0) {
+  let baseSize = (containerSize / scrollRange) * containerSize
+  if (isNaN(baseSize)) {
+    baseSize = 0
+  }
+  baseSize = Math.max(baseSize, thumbMinSize)
+  baseSize = Math.min(baseSize, containerSize / 2)
+  return Math.floor(baseSize)
+}

--- a/packages/cdk/scroll/src/scrollbar/index.ts
+++ b/packages/cdk/scroll/src/scrollbar/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { ScrollbarComponent } from './types'
+
+import Scrollbar from './Scrollbar'
+
+const CdkScrollbar = Scrollbar as ScrollbarComponent
+
+export { CdkScrollbar }
+
+export type { ScrollbarComponent, ScrollBarInstance, ScrollbarPublicProps as ScrollbarProps } from './types'

--- a/packages/cdk/scroll/src/scrollbar/types.ts
+++ b/packages/cdk/scroll/src/scrollbar/types.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray } from '@idux/cdk/utils'
+import type { CSSProperties, DefineComponent, HTMLAttributes, PropType } from 'vue'
+
+export const scrollbarProps = {
+  horizontal: { type: Boolean, default: false },
+  scrollOffset: { type: Number, default: 0 },
+  scrollRange: { type: Number, required: true },
+  containerSize: { type: Number, required: true },
+  thumbMinSize: { type: Number, default: 10 },
+  containerStyle: { type: Object as PropType<CSSProperties> },
+  thumbStyle: { type: Object as PropType<CSSProperties> },
+
+  onScroll: [Function, Array] as PropType<MaybeArray<(offset: number) => void>>,
+  onMoveStart: [Function, Array] as PropType<MaybeArray<() => void>>,
+  onMoveEnd: [Function, Array] as PropType<MaybeArray<() => void>>,
+} as const
+
+export type ScrollbarProps = ExtractInnerPropTypes<typeof scrollbarProps>
+export type ScrollbarPublicProps = ExtractPublicPropTypes<typeof scrollbarProps>
+export type ScrollbarComponent = DefineComponent<
+  Omit<HTMLAttributes, keyof ScrollbarPublicProps> & ScrollbarPublicProps
+>
+export type ScrollBarInstance = InstanceType<DefineComponent<ScrollbarProps>>

--- a/packages/cdk/scroll/src/useScroll/index.ts
+++ b/packages/cdk/scroll/src/useScroll/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+export { useScroll } from './useScroll'
+
+export type { ScrollContext, UseScrollOption } from './useScroll'

--- a/packages/cdk/scroll/src/useScroll/useScroll.ts
+++ b/packages/cdk/scroll/src/useScroll/useScroll.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import { type Ref, ref } from 'vue'
+
+import { isNil } from 'lodash-es'
+
+import { isFirefox } from '@idux/cdk/platform'
+import { useResizeObserver } from '@idux/cdk/resize'
+import { useEventListener } from '@idux/cdk/utils'
+
+import { useTouchMove } from './useTouchMove'
+import { useWheel } from './useWheel'
+import { type ScrollOptions, setScroll } from '../utils'
+
+export interface ScrollContext {
+  scrolledTop: Ref<boolean>
+  scrolledBottom: Ref<boolean>
+  scrolledLeft: Ref<boolean>
+  scrolledRight: Ref<boolean>
+  scrollTop: Ref<number>
+  scrollLeft: Ref<number>
+  scrollHeight: Ref<number>
+  scrollWidth: Ref<number>
+
+  syncScroll: (option: { top?: number; left?: number }, setContainerScroll?: boolean) => { top: number; left: number }
+  init: () => void
+  update: () => void
+  destroy: () => void
+}
+
+export interface UseScrollOption {
+  updateOnResize?: boolean
+  setContainerScroll?: boolean
+  simulatedScroll?: boolean
+  onScroll?: (top: number, left: number) => void
+  onScrolledBottom?: () => void
+  onScrolledTop?: () => void
+  onScrolledLeft?: () => void
+  onScrolledRight?: () => void
+}
+
+export function useScroll(elementRef: Ref<HTMLElement | undefined>, option?: UseScrollOption): ScrollContext {
+  const {
+    updateOnResize = true,
+    setContainerScroll = true,
+    simulatedScroll = false,
+    onScroll,
+    onScrolledBottom,
+    onScrolledTop,
+    onScrolledLeft,
+    onScrolledRight,
+  } = option ?? {}
+  const scrolledTop = ref(false)
+  const scrolledBottom = ref(false)
+  const scrolledLeft = ref(false)
+  const scrolledRight = ref(false)
+  const scrollTop = ref(0)
+  const scrollLeft = ref(0)
+  const scrollHeight = ref(0)
+  const scrollWidth = ref(0)
+
+  let maxScrollHeight = 0
+  let maxScrollWidth = 0
+  let containerWidth = 0
+  let containerHeight = 0
+
+  const calcScrollEdge = () => {
+    scrolledTop.value = scrollTop.value <= 0
+    scrolledBottom.value = scrollTop.value + containerHeight >= scrollHeight.value
+    scrolledLeft.value = scrollLeft.value <= 0
+    scrolledRight.value = scrollLeft.value + containerWidth >= scrollWidth.value
+
+    if (scrolledTop.value) {
+      onScrolledTop?.()
+    }
+    if (scrolledBottom.value) {
+      onScrolledBottom?.()
+    }
+    if (scrolledLeft.value) {
+      onScrolledLeft?.()
+    }
+    if (scrolledRight.value) {
+      onScrolledRight?.()
+    }
+  }
+
+  const syncScroll = ({ top, left }: { top?: number; left?: number }, _setContainerScroll = false) => {
+    const scrollOptions: ScrollOptions = {}
+    let updated = false
+
+    update()
+
+    if (!isNil(top)) {
+      scrollTop.value = keepInRange(maxScrollHeight, top)
+      scrollOptions.scrollTop = scrollTop.value
+      updated = true
+    }
+
+    if (!isNil(left)) {
+      scrollLeft.value = keepInRange(maxScrollWidth, left)
+      scrollOptions.scrollLeft = scrollLeft.value
+      updated = true
+    }
+
+    if (updated) {
+      _setContainerScroll && setScroll(scrollOptions, elementRef.value)
+      calcScrollEdge()
+    }
+
+    return {
+      top: scrollTop.value,
+      left: scrollLeft.value,
+    }
+  }
+
+  const onScrollChange = (offset: number, isHorizontal: boolean) => {
+    if (!elementRef.value) {
+      return
+    }
+
+    let scrollOption: { top?: number; left?: number } = {}
+    if (isHorizontal) {
+      scrollOption = { left: scrollLeft.value + offset }
+    } else {
+      scrollOption = { top: scrollTop.value + offset }
+    }
+
+    syncScroll(scrollOption, setContainerScroll)
+    onScroll?.(scrollTop.value, scrollLeft.value)
+  }
+
+  const { init: initWheel, destroy: destroyWheel } = useWheel(
+    elementRef,
+    scrolledTop,
+    scrolledBottom,
+    scrolledLeft,
+    scrolledRight,
+    onScrollChange,
+  )
+  const { init: initTouchMove, destroy: destroyTouchMove } = useTouchMove(
+    elementRef,
+    scrolledTop,
+    scrolledBottom,
+    scrolledLeft,
+    scrolledRight,
+    onScrollChange,
+  )
+
+  let pixelScrollListenerStop: (() => void) | null = null
+  let resizeObserverStop: (() => void) | null = null
+
+  const update = () => {
+    const target = elementRef.value
+    if (!target) {
+      return
+    }
+
+    const { scrollHeight: _scrollHeight, scrollWidth: _scrollWidth, clientHeight, clientWidth } = target
+    containerHeight = clientHeight
+    containerWidth = clientWidth
+    scrollHeight.value = _scrollHeight
+    scrollWidth.value = _scrollWidth
+    maxScrollHeight = _scrollHeight > 0 ? Math.max(_scrollHeight - clientHeight, 0) : 0
+    maxScrollWidth = _scrollWidth > 0 ? Math.max(_scrollWidth - clientWidth, 0) : 0
+
+    calcScrollEdge()
+
+    if (isFirefox && !pixelScrollListenerStop && (_scrollHeight > clientHeight || _scrollWidth > clientWidth)) {
+      pixelScrollListenerStop = useEventListener(elementRef, 'MozMousePixelScroll', evt => evt.preventDefault())
+    } else {
+      pixelScrollListenerStop?.()
+      pixelScrollListenerStop = null
+    }
+  }
+
+  const stop = () => {
+    pixelScrollListenerStop?.()
+    resizeObserverStop?.()
+    pixelScrollListenerStop = null
+    resizeObserverStop = null
+  }
+
+  const init = () => {
+    destroy()
+    update()
+
+    if (updateOnResize) {
+      resizeObserverStop = useResizeObserver(elementRef, () => update())
+    }
+
+    if (simulatedScroll) {
+      initWheel()
+      initTouchMove()
+    }
+  }
+
+  const destroy = () => {
+    stop()
+    destroyWheel()
+    destroyTouchMove()
+  }
+
+  return {
+    scrolledTop,
+    scrolledBottom,
+    scrolledLeft,
+    scrolledRight,
+    scrollTop,
+    scrollLeft,
+    scrollHeight,
+    scrollWidth,
+    syncScroll,
+    init,
+    update,
+    destroy,
+  }
+}
+
+function keepInRange(maxScrollSize: number, newScrollSize: number) {
+  let newSize = Math.max(newScrollSize, 0)
+  if (!Number.isNaN(maxScrollSize)) {
+    newSize = Math.min(newSize, maxScrollSize)
+  }
+  return newSize
+}

--- a/packages/cdk/scroll/src/useScroll/useScrollLock.ts
+++ b/packages/cdk/scroll/src/useScroll/useScrollLock.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { Ref } from 'vue'
+
+export type CheckScrollLocked = (delta: number, isHorizontal: boolean, smoothOffset?: boolean) => boolean
+
+export function useScrollLock(
+  scrolledTop: Ref<boolean>,
+  scrolledBottom: Ref<boolean>,
+  scrolledLeft: Ref<boolean>,
+  scrolledRight: Ref<boolean>,
+): CheckScrollLocked {
+  // Do lock for a wheel when scrolling
+  let lock = false
+  let lockTimeout: number
+  const lockScroll = () => {
+    clearTimeout(lockTimeout)
+    lock = true
+    lockTimeout = setTimeout(() => (lock = false), 50) as unknown as number
+  }
+
+  return (delta: number, isHorizontal: boolean, smoothOffset = false) => {
+    const scrolledStart = isHorizontal ? scrolledLeft.value : scrolledTop.value
+    const scrolledEnd = isHorizontal ? scrolledRight.value : scrolledBottom.value
+    const originScroll =
+      // Pass origin wheel when on the top
+      (delta < 0 && scrolledStart) ||
+      // Pass origin wheel when on the bottom
+      (delta > 0 && scrolledEnd)
+
+    if (smoothOffset && originScroll) {
+      // No need lock anymore when it's smooth offset from touchMove interval
+      clearTimeout(lockTimeout)
+      lock = false
+    } else if (!originScroll || lock) {
+      lockScroll()
+    }
+
+    return !lock && originScroll
+  }
+}

--- a/packages/cdk/scroll/src/useScroll/useTouchMove.ts
+++ b/packages/cdk/scroll/src/useScroll/useTouchMove.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { Ref } from 'vue'
+
+import { cancelRAF, rAF, useEventListener } from '@idux/cdk/utils'
+
+import { useScrollLock } from './useScrollLock'
+
+const SMOOTH_PTG = 14 / 15
+
+export function useTouchMove(
+  elementRef: Ref<HTMLElement | undefined>,
+  scrolledTop: Ref<boolean>,
+  scrolledBottom: Ref<boolean>,
+  scrolledLeft: Ref<boolean>,
+  scrolledRight: Ref<boolean>,
+  callback: (offset: number, isHorizontal: boolean) => void,
+): {
+  init: () => void
+  destroy: () => void
+} {
+  let touched = false
+  let touchY = 0
+  let touchX = 0
+
+  let rafId: number
+  let interval: number
+
+  let listenerStops: (() => void)[] = []
+  const clearListeners = () => {
+    listenerStops.forEach(stop => stop())
+    listenerStops = []
+  }
+
+  const checkScrollLock = useScrollLock(scrolledTop, scrolledBottom, scrolledLeft, scrolledRight)
+
+  const updateOffset = (offset: number, isHorizontal: boolean) => {
+    cancelRAF(rafId)
+
+    rafId = rAF(() => {
+      callback(offset, isHorizontal)
+    })
+  }
+
+  const onTouchMove = (evt: TouchEvent) => {
+    if (!touched) {
+      return
+    }
+
+    const currentTouch = evt.touches[0]
+    const currentY = currentTouch.pageY
+    const currentX = currentTouch.pageX
+
+    const offsetX = touchX - currentX
+    const offsetY = touchY - currentY
+
+    const isHorizontal = Math.abs(offsetX) > Math.abs(offsetY)
+    let offset = isHorizontal ? offsetX : offsetY
+
+    if (checkScrollLock(offset, isHorizontal)) {
+      evt.preventDefault()
+      return
+    }
+
+    updateOffset(offset, isHorizontal)
+
+    clearInterval(interval)
+    interval = setInterval(() => {
+      offset = offset * SMOOTH_PTG
+
+      if (checkScrollLock(offset, isHorizontal) || Math.abs(offset) <= 0.1) {
+        clearInterval(interval)
+      } else {
+        updateOffset(offset, isHorizontal)
+      }
+    }, 16)
+  }
+
+  const onTouchEnd = () => {
+    touched = false
+    clearListeners()
+  }
+
+  const onTouchStart = (evt: TouchEvent) => {
+    clearListeners()
+
+    if (evt.touches.length !== 1 || touched) {
+      return
+    }
+
+    touched = true
+
+    const currentTouch = evt.touches[0]
+    touchY = currentTouch.pageY
+    touchX = currentTouch.pageX
+
+    listenerStops = [
+      useEventListener(elementRef, 'touchmove', onTouchMove),
+      useEventListener(elementRef, 'touchend', onTouchEnd),
+    ]
+  }
+
+  let stopTouchStart: (() => void) | null = null
+
+  const destroy = () => {
+    stopTouchStart?.()
+    stopTouchStart = null
+    clearListeners()
+  }
+
+  const init = () => {
+    stopTouchStart = useEventListener(elementRef, 'touchstart', onTouchStart)
+  }
+
+  return {
+    init,
+    destroy,
+  }
+}

--- a/packages/cdk/scroll/src/useScroll/useWheel.ts
+++ b/packages/cdk/scroll/src/useScroll/useWheel.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import { type Ref } from 'vue'
+
+import { isFirefox } from '@idux/cdk/platform'
+import { cancelRAF, rAF, useEventListener } from '@idux/cdk/utils'
+
+import { useScrollLock } from './useScrollLock'
+
+interface FireFoxDOMMouseScrollEvent {
+  detail: number
+  preventDefault: VoidFunction
+}
+
+export function useWheel(
+  elementRef: Ref<HTMLElement | undefined>,
+  scrolledTop: Ref<boolean>,
+  scrolledBottom: Ref<boolean>,
+  scrolledLeft: Ref<boolean>,
+  scrolledRight: Ref<boolean>,
+  callback: (offset: number, isHorizontal: boolean) => void,
+): {
+  init: () => void
+  destroy: () => void
+} {
+  let rafId: number
+  let wheelDirection: 'x' | 'y' | 'sx' | null = null
+  let directionRafId: number
+
+  let currentDelta: number
+  let isFirefoxWheel = false
+
+  const checkScrollLock = useScrollLock(scrolledTop, scrolledBottom, scrolledLeft, scrolledRight)
+
+  const _onWheel = (delta: number, horizontal: boolean) => {
+    cancelRAF(rafId)
+    currentDelta = delta
+
+    if (checkScrollLock(delta, horizontal, false)) {
+      return
+    }
+
+    rafId = rAF(() => {
+      const fixedDelta = isFirefoxWheel ? 10 * delta : delta
+      callback(fixedDelta, horizontal)
+    })
+  }
+
+  const onWheel = (evt: WheelEvent) => {
+    cancelRAF(directionRafId)
+    directionRafId = rAF(() => {
+      rAF(() => (wheelDirection = null))
+    })
+
+    const { deltaX, deltaY, shiftKey } = evt
+
+    let _deltaX = deltaX
+    let _deltaY = deltaY
+
+    if (wheelDirection === 'sx' || (!wheelDirection && shiftKey && deltaY && !deltaX)) {
+      _deltaX = deltaY
+      _deltaY = 0
+
+      wheelDirection = 'sx'
+    }
+
+    if (wheelDirection === null) {
+      wheelDirection = Math.abs(_deltaX) > Math.abs(_deltaY) ? 'x' : 'y'
+    }
+
+    if (!isFirefox) {
+      evt.preventDefault()
+    }
+
+    if (wheelDirection === 'x' || wheelDirection === 'sx') {
+      _onWheel(_deltaX, true)
+    } else {
+      _onWheel(_deltaY, false)
+    }
+  }
+
+  const onFirefoxWheel = (evt: FireFoxDOMMouseScrollEvent) => {
+    isFirefoxWheel = evt.detail === currentDelta
+  }
+
+  let listenerStops: (() => void)[] = []
+
+  const destroy = () => {
+    listenerStops.forEach(stop => stop())
+    listenerStops = []
+  }
+
+  const init = () => {
+    listenerStops = [
+      useEventListener(elementRef, 'wheel', onWheel),
+      useEventListener(elementRef, 'DOMMouseScroll', onFirefoxWheel as unknown as (evt: Event) => void),
+    ]
+  }
+
+  return {
+    init,
+    destroy,
+  }
+}

--- a/packages/cdk/scroll/src/utils.ts
+++ b/packages/cdk/scroll/src/utils.ts
@@ -23,19 +23,19 @@ export interface ScrollOptions {
 export function setScroll(options: number | ScrollOptions, target: Element | Window = window): void {
   const { scrollTop, scrollLeft }: ScrollOptions = isObject(options) ? options : { scrollTop: options }
   if (target === window) {
-    if (scrollTop) {
+    if (!isNil(scrollTop)) {
       document.body.scrollTop = scrollTop
       document.documentElement.scrollTop = scrollTop
     }
-    if (scrollLeft) {
+    if (!isNil(scrollLeft)) {
       document.body.scrollLeft = scrollLeft
       document.documentElement.scrollLeft = scrollLeft
     }
   } else {
-    if (scrollTop) {
+    if (!isNil(scrollTop)) {
       ;(target as Element).scrollTop = scrollTop
     }
-    if (scrollLeft) {
+    if (!isNil(scrollLeft)) {
       ;(target as Element).scrollLeft = scrollLeft
     }
   }

--- a/packages/cdk/scroll/src/virtual/composables/useContainerSize.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useContainerSize.ts
@@ -16,10 +16,10 @@ import { useState } from '@idux/cdk/utils'
 
 export function useContainerSize(
   props: VirtualScrollProps,
-  containerRef: Ref<HTMLElement | undefined>,
+  holderRef: Ref<HTMLElement | undefined>,
 ): ComputedRef<{ width: number; height: number }> {
   const [size, setSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
-  useResizeObserver(containerRef, entry => {
+  useResizeObserver(holderRef, entry => {
     const {
       contentRect: { height, width },
     } = entry

--- a/packages/cdk/scroll/src/virtual/composables/useSizeCollect.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useSizeCollect.ts
@@ -161,11 +161,13 @@ export function useSizeCollect(props: VirtualScrollProps): SizeCollectContext {
   }
 
   const getRowHeight = (rowKey: VKey) => {
-    return sizes.get(rowKey)?.height ?? props.rowHeight
+    return sizes.get(rowKey)?.height ?? props.getRowHeight?.(rowKey) ?? props.rowHeight
   }
   const getColWidth = (rowKey: VKey, colKey: VKey) => {
     return (
-      (props.isStrictGrid ? strictGridColSizes.get(colKey) : sizes.get(rowKey)?.colWidths.get(colKey)) ?? props.colWidth
+      (props.isStrictGrid ? strictGridColSizes.get(colKey) : sizes.get(rowKey)?.colWidths.get(colKey)) ??
+      props.getColWidth?.(rowKey, colKey) ??
+      props.colWidth
     )
   }
 

--- a/packages/cdk/scroll/src/virtual/contents/Holder.tsx
+++ b/packages/cdk/scroll/src/virtual/contents/Holder.tsx
@@ -49,6 +49,8 @@ export default defineComponent({
       return {
         [fullHeight || isString(height) ? 'height' : 'maxHeight']: resolvedHeight,
         [fullWidth || isString(width) ? 'width' : 'maxWidth']: resolvedWidth,
+        overflowX: props.scrollMode !== 'native' || !resolvedWidth || resolvedWidth === 'auto' ? 'hidden' : 'auto',
+        overflowY: props.scrollMode !== 'native' || !resolvedHeight || resolvedHeight === 'auto' ? 'hidden' : 'auto',
       }
     })
 
@@ -82,8 +84,12 @@ export default defineComponent({
     const contentRef = ref<HTMLDivElement>()
     const onContentResize = throttle(collectSize, 16)
     // 这里不能用 useResizeObserver, 会有 test 爆栈警告, 具体原因后面再排查。
-    onMounted(() => onResize(contentRef.value, onContentResize))
-    onBeforeUnmount(() => offResize(contentRef.value, onContentResize))
+    onMounted(() => {
+      onResize(contentRef.value, onContentResize)
+    })
+    onBeforeUnmount(() => {
+      offResize(contentRef.value, onContentResize)
+    })
 
     return () => {
       const children = slots.default!()

--- a/packages/cdk/scroll/src/virtual/token.ts
+++ b/packages/cdk/scroll/src/virtual/token.ts
@@ -12,6 +12,10 @@ import type { ComputedRef, InjectionKey, Ref, Slots } from 'vue'
 export interface VirtualScrollContext {
   props: VirtualScrollProps
   slots: Slots
+  containerSize: ComputedRef<{
+    width: number
+    height: number
+  }>
   enabled: ComputedRef<VirtualScrollEnabled>
   holderRef: Ref<HTMLElement | undefined>
   fillerHorizontalRef: Ref<HTMLElement | undefined>

--- a/packages/cdk/scroll/src/virtual/types.ts
+++ b/packages/cdk/scroll/src/virtual/types.ts
@@ -22,6 +22,8 @@ export interface RowSize {
 
 export type VirutalDataSizes = Map<VKey, RowSize>
 
+export type VirtualScrollMode = 'native' | 'simulated'
+
 export interface ModifiedData {
   data: any
   index: number
@@ -52,6 +54,8 @@ export const virtualListProps = {
   width: { type: [Number, String] as PropType<number | '100%'>, default: '100%' },
   fullWidth: { type: Boolean, default: true },
   colWidth: { type: Number, default: 0 },
+  getRowHeight: Function as PropType<(rowKey: VKey) => number | undefined>,
+  getColWidth: Function as PropType<(rowKey: VKey, colKey: VKey) => number | undefined>,
   /**
    * @deprecated use rowRender instead
    */
@@ -61,6 +65,10 @@ export const virtualListProps = {
   virtual: {
     type: [Boolean, Object] as PropType<boolean | VirtualScrollEnabled>,
     default: (): VirtualScrollEnabled => ({ horizontal: false, vertical: true }),
+  },
+  scrollMode: {
+    type: String as PropType<VirtualScrollMode>,
+    default: 'native',
   },
   isStrictGrid: {
     type: Boolean,

--- a/packages/cdk/scroll/style/index.less
+++ b/packages/cdk/scroll/style/index.less
@@ -1,6 +1,48 @@
+@scrollbar-width: var(--ix-cdk-scrollbar-width, var(--ix-scrollbar-width, 12px));
+@scrollbar-height: var(--ix-cdk-scrollbar-height, var(--ix-scrollbar-height, 12px));
+@scrollbar-padding: var(--ix-cdk-scrollbar-padding, var(--ix-scrollbar-thumb-border-width, 2px));
+
+.cdk-scroll-block {
+  overflow: hidden;
+}
+
+.cdk-scrollbar {
+  .cdk-scrollbar-thumb {
+    background-color: var(--ix-cdk-scrollbar-thumb-bg, var(--ix-scrollbar-thumb-bg, #e1e5eb));
+    border-radius: var(--ix-cdk-scrollbar-thumb-border-radius, var(--ix-scrollbar-thumb-border-radius, 6px));
+    cursor: pointer;
+    user-select: none;
+
+    &:hover,
+    &-moving {
+      background-color: var(--ix-cdk-scrollbar-thumb-bg-hover, var(--ix-scrollbar-thumb-bg-hover, #bec3cc));
+    }
+    &:active {
+      background-color: var(--ix-cdk-scrollbar-thumb-bg-active, var(--ix-scrollbar-thumb-bg-active, #bec3cc));
+    }
+  }
+
+  &&-vertical {
+    height: 100%;
+    width: @scrollbar-width;
+    padding: 0 @scrollbar-padding 0 @scrollbar-padding;
+    .cdk-scrollbar-thumb {
+      width: 100%;
+    }
+  }
+
+  &&-horizontal {
+    width: 100%;
+    height: @scrollbar-height;
+    padding: @scrollbar-padding 0 @scrollbar-padding 0;
+    .cdk-scrollbar-thumb {
+      height: 100%;
+    }
+  }
+}
+
 .cdk-virtual-scroll {
   &-holder {
-    overflow: auto;
     overflow-anchor: none;
   }
 
@@ -12,8 +54,36 @@
     display: flex;
     flex-flow: column wrap;
   }
-}
 
-.cdk-scroll-block {
-  overflow: hidden;
+  &-simulated-scroll {
+    position: relative;
+
+    .cdk-scrollbar {
+      position: absolute;
+
+      &:not(.cdk-scrollbar-horizontal) {
+        top: 0;
+        right: 0;
+      }
+      .cdk-scrollbar-horizontal {
+        bottom: 0;
+        left: 0;
+      }
+    }
+
+    &.cdk-virtual-scroll-overflowed-horizontal {
+      padding-bottom: @scrollbar-height;
+    }
+    &.cdk-virtual-scroll-overflowed-vertical {
+      padding-right: @scrollbar-width;
+    }
+    &.cdk-virtual-scroll-overflowed-horizontal.cdk-virtual-scroll-overflowed-vertical {
+      .cdk-scrollbar-vertical {
+        height: calc(100% - @scrollbar-height);
+      }
+      .cdk-scrollbar-horizontal {
+        width: calc(100% - @scrollbar-width);
+      }
+    }
+  }
 }

--- a/packages/components/cascader/docs/Api.zh.md
+++ b/packages/components/cascader/docs/Api.zh.md
@@ -45,6 +45,7 @@
 | `strategy` | 设置级联策略 | `'all' \| 'parent' \| 'child' \| 'off'` | `'all'` | - | 具体用法参见 [级联策略](#components-cascader-demo-Strategy) |
 | `suffix` | 设置后缀图标 | `string \| #suffix` | `down` | ✅ | - |
 | `virtual` | 是否开启虚拟滚动 | `boolean` | `false` | - | 需要设置 `height` |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `onChange` | 选中值发生改变后的回调 | `(value: any, oldValue: any) => void` | - | - | - |
 | `onClear` | 清除图标被点击后的回调 | `(evt: MouseEvent) => void` | - | - | - |
 | `onExpand` | 点击展开图标时触发 | `(expanded: boolean, data: CascaderData) => void` | - | - | - |
@@ -122,6 +123,7 @@ interface SelectedItemProps {
 | `separator` | 设置分割符 | `string` | `/` | - | - |
 | `strategy` | 设置级联策略 | `'all' \| 'parent' \| 'child' \| 'off'` | `'all'` | - | 具体用法参见 [级联策略](#components-cascader-demo-Strategy) |
 | `virtual` | 是否开启虚拟滚动 | `boolean` | `false` | - | 需要设置 `height` |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `onSelect` | 选中值触发 | `(option: CascaderData, oldValue: any) => void` | - | - | - |
 | `onExpand` | 点击展开图标时触发 | `(expanded: boolean, isSelected: boolean) => void` | - | - | - |
 | `onExpandedChange` | 展开状态发生变化时触发 | `(expendedKeys: VKey[], expendedData: CascaderData[]) => void` | - | - | - |

--- a/packages/components/cascader/src/composables/usePanelProps.ts
+++ b/packages/components/cascader/src/composables/usePanelProps.ts
@@ -47,10 +47,12 @@ export function usePanelProps(
     searchValue: searchValue.value,
     strategy: props.strategy,
     virtual: props.virtual,
+    virtualScrollMode: props.virtualScrollMode,
     virtualItemHeight: props.virtualItemHeight,
 
     'onUpdate:expandedKeys': setExpandedKeys,
     'onUpdate:loadedKeys': setLoadedKeys,
     onSelect,
+    onLoaded: props.onLoaded,
   }))
 }

--- a/packages/components/cascader/src/panel/OptionGroup.tsx
+++ b/packages/components/cascader/src/panel/OptionGroup.tsx
@@ -33,7 +33,7 @@ export default defineComponent({
       const { dataSource } = props
       let children: VNode
       if (dataSource.length > 0) {
-        const { _virtualScrollHeight, virtualItemHeight, virtual } = cascaderPanelProps
+        const { _virtualScrollHeight, virtualItemHeight, virtualScrollMode, virtual } = cascaderPanelProps
         const rowRender: VirtualRowRenderFn<MergedData> = ({ item, index }) => (
           <Option index={index} optionKey={item.key} {...item} />
         )
@@ -45,6 +45,7 @@ export default defineComponent({
             rowHeight={virtualItemHeight}
             rowRender={rowRender}
             virtual={virtual}
+            scrollMode={virtual ? virtualScrollMode : undefined}
           />
         )
       } else {

--- a/packages/components/cascader/src/types.ts
+++ b/packages/components/cascader/src/types.ts
@@ -8,6 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { AbstractControl, ValidateStatus } from '@idux/cdk/forms'
+import type { VirtualScrollMode } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
 import type { FormSize } from '@idux/components/form'
@@ -45,6 +46,7 @@ export const cascaderPanelProps = {
   separator: { type: String, default: '/' },
   strategy: { type: String as PropType<CascaderStrategy>, default: 'all' },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: 32 },
 
   // events
@@ -112,6 +114,7 @@ export const cascaderProps = {
   suffix: { type: String, default: undefined },
   virtual: { type: Boolean, default: false },
   virtualItemHeight: { type: Number, default: undefined },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
 
   // events
   'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: any) => void>>,

--- a/packages/components/select/docs/Api.zh.md
+++ b/packages/components/select/docs/Api.zh.md
@@ -38,6 +38,7 @@
 | `status` | 手动指定校验状态 | `valid \| invalid \| validating` | - | - | - |
 | `suffix` | 设置后缀图标 | `string \| #suffix` | `down` | ✅ | - |
 | `virtual` | 是否开启虚拟滚动 | `boolean` | `false` | - | - |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `onChange` | 选中值发生改变后的回调 | `(value: any, oldValue: any) => void` | - | - | - |
 | `onClear` | 清除图标被点击后的回调 | `(evt: MouseEvent) => void` | - | - | - |
 | `onSearch` | 开启搜索功能后，输入后的回调 | `(searchValue: string) => void` | - | - | 通常用于服务端搜索 |

--- a/packages/components/select/src/composables/usePanelProps.ts
+++ b/packages/components/select/src/composables/usePanelProps.ts
@@ -30,6 +30,7 @@ export function usePanelProps(
     multipleLimit: props.multipleLimit,
     virtual: props.virtual,
     virtualItemHeight: props.virtualItemHeight,
+    virtualScrollMode: props.virtualScrollMode,
     'onUpdate:activeValue': setActiveValue,
     onOptionClick,
     onScroll: props.onScroll,

--- a/packages/components/select/src/panel/Panel.tsx
+++ b/packages/components/select/src/panel/Panel.tsx
@@ -94,7 +94,7 @@ export default defineComponent({
     }
 
     return () => {
-      const { _virtualScrollHeight, virtualItemHeight, virtual, onScroll, onScrolledBottom } = props
+      const { _virtualScrollHeight, virtualItemHeight, virtualScrollMode, virtual, onScroll, onScrolledBottom } = props
       const options = flattenedOptions.value
       const children = [<ListBox v-slots={slots} />]
 
@@ -115,6 +115,7 @@ export default defineComponent({
             getKey="key"
             height={_virtualScrollHeight}
             rowHeight={virtualItemHeight}
+            scrollMode={virtual ? virtualScrollMode : undefined}
             rowRender={rowRender}
             virtual={virtual}
             onScroll={onScroll}

--- a/packages/components/select/src/types.ts
+++ b/packages/components/select/src/types.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { AbstractControl, ValidateStatus } from '@idux/cdk/forms'
-import type { VirtualScrollToFn } from '@idux/cdk/scroll'
+import type { VirtualScrollMode, VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
 import type { FormSize } from '@idux/components/form'
@@ -29,6 +29,7 @@ export const selectPanelProps = {
   multiple: { type: Boolean, default: false },
   multipleLimit: { type: Number, default: Number.MAX_SAFE_INTEGER },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: 32 },
 
   // events
@@ -86,6 +87,7 @@ export const selectProps = {
   suffix: { type: String, default: undefined },
   spin: { type: [Boolean, Object] as PropType<boolean | SpinProps>, default: undefined },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: undefined },
 
   // events

--- a/packages/components/table/demo/VirtualBoth.vue
+++ b/packages/components/table/demo/VirtualBoth.vue
@@ -5,6 +5,7 @@
     :pagination="false"
     virtual
     virtualHorizontal
+    virtualScrollMode="simulated"
     :scroll="scroll"
     :virtualColWidth="150"
   >

--- a/packages/components/table/docs/Api.zh.md
+++ b/packages/components/table/docs/Api.zh.md
@@ -27,6 +27,7 @@
 | `tableLayout` | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性 | `'auto' \| 'fixed'` | - | - | 固定表头/列或设置了 `column.ellipsis` 时，默认值为 `fixed` |
 | `virtual` | 是否开启纵向虚拟滚动 | `boolean` | `false` | - | 需要设置 `scroll.height` |
 | `virtualHorizontal` | 是否开启横向虚拟滚动 | `boolean` | `false` | - | 不可以设置 `scroll.width`，并且每列的宽度必须配置 |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `virtualItemHeight` | 虚拟滚动每一行的高度 | `number` | - | - | 标准大小的表格不需要设置，会自动设置。如果有非标准大小的表格，可以设置一个准确的值来提高性能。 |
 | `virtualColWidth` | 虚拟滚动每一列的宽度 | `number` | - | - | 需要设置一个默认的值。 |
 | `virtualBufferSize` | 虚拟滚动的buffer大小 | `number` | - | - | - |

--- a/packages/components/table/src/main/FixedHolder.tsx
+++ b/packages/components/table/src/main/FixedHolder.tsx
@@ -48,6 +48,7 @@ export default defineComponent({
       mergedPrefixCls,
       mergedVirtual,
       mergedVirtualColWidth,
+      getVirtualColWidth,
       scrollHeadRef,
       handleScroll,
       scrollWidth,
@@ -166,6 +167,7 @@ export default defineComponent({
                 height={0}
                 width={'100%'}
                 colWidth={mergedVirtualColWidth.value}
+                getColWidth={getVirtualColWidth}
                 rowRender={rowRender}
                 colRender={colRneder}
                 contentRender={contentRender}

--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -65,6 +65,7 @@ export default defineComponent({
       flattedData,
       flattedColumns,
       fixedColumns,
+      getVirtualColWidth,
       isSticky,
       mergedSticky,
       virtualScrollRef,
@@ -330,10 +331,12 @@ export default defineComponent({
               width={'100%'}
               rowHeight={mergedVirtualItemHeight.value}
               colWidth={mergedVirtualColWidth.value}
+              getColWidth={getVirtualColWidth}
               rowRender={rowRender}
               colRender={colRender}
               contentRender={contentRender}
               virtual={mergedVirtual.value}
+              scrollMode={props.virtualScrollMode}
               bufferSize={props.virtualBufferSize}
               bufferOffset={props.virtualBufferOffset}
               onScroll={handleScroll}

--- a/packages/components/table/src/token.ts
+++ b/packages/components/table/src/token.ts
@@ -35,6 +35,7 @@ export interface TableContext
   slots: Slots
   config: TableConfig
   locale: Locale
+  getVirtualColWidth: (rowKey: VKey, colKey: VKey) => number | undefined
   mergedPrefixCls: ComputedRef<string>
   mergedAutoHeight: ComputedRef<boolean>
   mergedEmptyCell: ComputedRef<string | ((options: TableEmptyCellOptions) => VNodeChild) | undefined>

--- a/packages/components/table/src/types.ts
+++ b/packages/components/table/src/types.ts
@@ -11,7 +11,7 @@ import type { TableColumnMerged, TableColumnMergedExtra } from './composables/us
 import type { FlattedData } from './composables/useDataSource'
 import type { ActiveFilter } from './composables/useFilterable'
 import type { ActiveSorter } from './composables/useSortable'
-import type { VirtualScrollToFn } from '@idux/cdk/scroll'
+import type { VirtualScrollMode, VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
 import type { HeaderProps } from '@idux/components/header'
@@ -48,6 +48,7 @@ export const tableProps = {
   scrollToTopOnChange: { type: Boolean, default: undefined },
   tableLayout: { type: String as PropType<'auto' | 'fixed'>, default: undefined },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualHorizontal: { type: Boolean, default: false },
   virtualItemHeight: { type: Number, default: undefined },
   virtualColWidth: { type: Number, default: undefined },

--- a/packages/components/table/style/index.less
+++ b/packages/components/table/style/index.less
@@ -195,6 +195,10 @@
 
       &-fixed-holder {
         flex-shrink: 0;
+
+        .cdk-virtual-scroll-holder {
+          overflow: hidden !important;
+        }
       }
     }
   }

--- a/packages/components/transfer/docs/Api.zh.md
+++ b/packages/components/transfer/docs/Api.zh.md
@@ -29,6 +29,7 @@
 | `onChange` | 已选数据改变回调函数 | `(keys: VKey[], oldKeys: Vkey[]) => void` | - | - | - |
 | `onScroll` | 数据列表滚动事件 | `(isSource: boolean, evt: Event) => void` | - | - | 仅使用默认列表并开启 `virtual` 下可用 |
 | `onScrolledChange` | 数据列表滚动的位置发生变化 | `(isSource: boolean, startIndex: number, endIndex: number, visibleNodes: unknown[]) => void` | - | - | 仅使用默认列表并开启 `virtual` 下可用 |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `onScrolledBottom` | 数据列表滚动到底部时触发 | `(isSource: boolean) => void` | - | - | 仅使用默认列表并开启 `virtual` 下可用 |
 | `onSearch` | 穿梭框搜索触发回调函数 | `(isSource: boolean, searchValue: string \| undefined) => void` | - | - | - |
 | `onSelectAll` | 数据列表全部勾选回调函数 | `(isSource: boolean, checked: boolean) => void` | - | - | - |

--- a/packages/components/transfer/src/content/Body.tsx
+++ b/packages/components/transfer/src/content/Body.tsx
@@ -96,6 +96,7 @@ export default defineComponent({
           removable={!props.isSource && transferProps.mode === 'immediate'}
           virtual={transferProps.virtual}
           virtualItemHeight={transferProps.virtualItemHeight}
+          virtualScrollMode={transferProps.virtualScrollMode}
           scroll={transferProps.scroll}
           v-slots={listSlots}
           onCheckChange={onCheckChange}

--- a/packages/components/transfer/src/list/List.tsx
+++ b/packages/components/transfer/src/list/List.tsx
@@ -75,7 +75,7 @@ export default defineComponent({
     }
 
     const renderBody = () => {
-      const { dataSource, virtual, virtualItemHeight, scroll } = props
+      const { dataSource, virtual, virtualItemHeight, virtualScrollMode, scroll } = props
       const data = dataSource ?? []
 
       if (data.length <= 0) {
@@ -93,6 +93,7 @@ export default defineComponent({
             rowHeight={virtualItemHeight}
             rowRender={renderListItem}
             virtual
+            scrollMode={virtualScrollMode}
             onScroll={handleScroll}
             onScrolledBottom={handleScrolledBottom}
             onScrolledChange={handleScrolledChange}

--- a/packages/components/transfer/src/types.ts
+++ b/packages/components/transfer/src/types.ts
@@ -9,7 +9,7 @@
 
 import type { TransferOperationsContext } from './composables/useTransferOperations'
 import type { ConvertToSlotParams } from './utils'
-import type { VirtualScrollToFn } from '@idux/cdk/scroll'
+import type { VirtualScrollMode, VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { EmptyProps } from '@idux/components/empty'
 import type { PaginationProps } from '@idux/components/pagination'
@@ -162,6 +162,7 @@ export const transferProps = {
   },
   showSelectAll: { type: Boolean, default: undefined },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: undefined },
 
   //Events
@@ -238,6 +239,7 @@ export const transferListProps = {
   labelKey: String,
   scroll: Object as PropType<TransferScroll>,
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: 32 },
 
   onCheckChange: [Function, Array] as PropType<MaybeArray<(item: TransferData, checked: boolean) => void>>,

--- a/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
@@ -373,8 +373,8 @@ exports[`Tree > getKey work 2`] = `
 exports[`Tree > height and virtual work 1`] = `
 "<div class=\\"ix-tree ix-tree-active ix-tree-virtual\\" role=\\"tree\\">
   <!----><input style=\\"width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;\\" tabindex=\\"0\\" aria-label=\\"for screen reader\\">
-  <div class=\\"cdk-virtual-scroll ix-tree-content\\">
-    <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 100px; width: 100%;\\">
+  <div class=\\"cdk-virtual-scroll cdk-virtual-scroll-overflowed-vertical ix-tree-content\\">
+    <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 100px; width: 100%; overflow-x: auto; overflow-y: auto;\\">
       <div class=\\"cdk-virtual-scroll-filler-horizontal\\"></div>
       <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 308px; width: 0px;\\"></div>
       <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px;\\">
@@ -412,6 +412,8 @@ exports[`Tree > height and virtual work 1`] = `
         </div>
       </div>
     </div>
+    <!---->
+    <!---->
   </div>
 </div>"
 `;

--- a/packages/components/tree/docs/Api.zh.md
+++ b/packages/components/tree/docs/Api.zh.md
@@ -33,6 +33,7 @@
 | `selectable` | 是否允许选择 | `boolean \| 'multiple'` | `true` | - | 为 `multiple` 时表示允许多选 |
 | `showLine` | 是否显示连接线 | `boolean` | `false` | ✅ | - |
 | `virtual` | 是否开启虚拟滚动 | `boolean` | `false` | - | 需要设置 `height` |
+| `virtualScrollMode` | 虚拟滚动的滚动模式 | `'native' \| 'simulated'` | `'native'` | - | - |
 | `onCheck` | 选择框勾选状态发生变化时触发 | `(checked: boolean, node: TreeNode) => void` | - | - | - |
 | `onCheckedChange` | 选择框勾选状态发生变化时触发 | `(checkedKeys: VKey[], checkedNodes: TreeNode[]) => void` | - | - | - |
 | `onDragStart` | `dragstart` 触发时调用 | `(options: TreeDragDropOptions) => void` | - | - | - |

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -185,7 +185,7 @@ export default defineComponent({
         const rowRender: VirtualRowRenderFn<MergedNode> = ({ item }) => (
           <TreeNode v-slots={slots} node={item} {...item}></TreeNode>
         )
-        const { height, virtual, virtualItemHeight, onScroll, onScrolledBottom } = props
+        const { height, virtual, virtualItemHeight, virtualScrollMode, onScroll, onScrolledBottom } = props
         children = virtual ? (
           <CdkVirtualScroll
             ref={virtualScrollRef}
@@ -196,6 +196,7 @@ export default defineComponent({
             rowHeight={virtualItemHeight}
             rowRender={rowRender}
             virtual
+            scrollMode={virtualScrollMode}
             onScroll={onScroll}
             onScrolledBottom={onScrolledBottom}
             onScrolledChange={handleScrolledChange}

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { MergedNode } from './composables/useDataSource'
-import type { VirtualScrollToFn } from '@idux/cdk/scroll'
+import type { VirtualScrollMode, VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, VKey } from '@idux/cdk/utils'
 import type { CascaderStrategy } from '@idux/components/cascader'
 import type { EmptyProps } from '@idux/components/empty'
@@ -76,6 +76,7 @@ export const treeProps = {
   },
   showLine: { type: Boolean, default: undefined },
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: 28 },
 
   // events

--- a/packages/pro/transfer/src/composables/useTransferTableProps.ts
+++ b/packages/pro/transfer/src/composables/useTransferTableProps.ts
@@ -80,6 +80,7 @@ export function useTransferTableProps(
       pagination: false,
       selectedRowKeys: selectedKeys.value,
       virtual: props.virtual,
+      virtualScrollMode: props.virtualScrollMode,
       virtualItemHeight: props.virtualItemHeight,
       getKey: getKey.value as (record: unknown) => number | string,
       onColumnsChange,

--- a/packages/pro/transfer/src/composables/useTransferTreeProps.ts
+++ b/packages/pro/transfer/src/composables/useTransferTreeProps.ts
@@ -98,6 +98,7 @@ export function useTransferTreeProps<V extends TreeTransferData<V, C>, C extends
       loadChildren: loadChildren.value,
       selectable: true,
       virtual: props.virtual,
+      virtualScrollMode: props.virtualScrollMode,
       virtualItemHeight: props.virtualItemHeight,
       onCheck: handleChecked,
       'onUpdate:checkedKeys': handleCheckedKeysUpdate,

--- a/packages/pro/transfer/src/types.ts
+++ b/packages/pro/transfer/src/types.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { VirtualScrollToFn } from '@idux/cdk/scroll'
+import type { VirtualScrollMode, VirtualScrollToFn } from '@idux/cdk/scroll'
 import type { ExtractInnerPropTypes, ExtractPublicPropTypes, MaybeArray, TreeTypeData, VKey } from '@idux/cdk/utils'
 import type { CascaderStrategy } from '@idux/components/cascader'
 import type { EmptyProps } from '@idux/components/empty'
@@ -103,6 +103,7 @@ export const proTransferProps = {
   sourceExpandedKeys: Array as PropType<VKey[]>,
   targetExpandedKeys: Array as PropType<VKey[]>,
   virtual: { type: Boolean, default: false },
+  virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
   virtualItemHeight: { type: Number, default: undefined },
 
   //Events


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
虚拟滚动支持模拟滚动

新增 `scrollMode` prop配置，支持 `'native'` 和 `'simulated'`

所有支持虚拟滚动的组件均新增 `virtualScrollMode` prop 配置，同上

新增 `useScroll` API，用于模拟容器滚动交互并替代原始滚动

新增 `CdkScrollbar` 组件，用于模拟滚动条
## Other information
