### PR TITLE
fix(cdk:popper): arrow size not properly calculated

### DIFF
--- a/packages/cdk/popper/src/convertOptions.ts
+++ b/packages/cdk/popper/src/convertOptions.ts
@@ -35,13 +35,13 @@ export function convertOptions(baseOptions: BaseOptions, extraOptions: ExtraOpti
     placement: kebabCase(placement) as Placement,
     strategy,
     middleware: [
-      autoAdjust && flip({ padding: 4 }),
-      autoAdjust && shift(),
       !!arrowElement && arrow(arrowElement),
       offsetMiddleware({
         mainAxis: offset[1],
         crossAxis: offset[0],
       }),
+      autoAdjust && flip({ padding: 2, crossAxis: false }),
+      autoAdjust && shift(),
       referenceHidden(),
       updatePlacement(_updatePlacement),
       ...middlewares,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
popper的箭头尺寸计算不正常

## What is the new behavior?
将 flip 和 shift 中间件放在 arrow 之后执行

## Other information
