### PR TITLE
fix(comp:tag): reset bordered style from box-shadow to border

### DIFF
--- a/packages/components/tag/style/index.less
+++ b/packages/components/tag/style/index.less
@@ -11,8 +11,9 @@
   align-items: center;
   color: var(--ix-tag-color, var(--ix-color-text-info));
   background-color: var(--ix-tag-background-color, var(--ix-color-emphasized-container-bg));
-  padding: 0 var(--ix-margin-size-sm);
+  padding: 0 calc(var(--ix-margin-size-sm) - var(--ix-tag-border-width));
   line-height: @tag-line-height;
+  border: var(--ix-tag-border-width) var(--ix-line-type) transparent;
   border-radius: var(--ix-tag-border-radius);
 
   & + &,
@@ -37,7 +38,7 @@
   }
 
   &-bordered {
-    box-shadow: inset 0 0 0 var(--ix-tag-border-width) var(--ix-tag-border-color, var(--ix-color-border));
+    border-color: var(--ix-tag-border-color, var(--ix-color-border));
   }
 
   &-round {
@@ -70,7 +71,7 @@
 }
 
 .@{tag-prefix}-numeric {
-  @tag-prefix-size: calc(@tag-line-height + var(--ix-margin-size-xs));
+  @tag-prefix-size: calc(@tag-line-height + var(--ix-tag-border-width) * 4);
 
   position: relative;
   padding-left: calc(@tag-prefix-size + var(--ix-tag-border-width));
@@ -79,15 +80,15 @@
 
   &-prefix {
     position: absolute;
-    left: -2px;
-    top: -2px;
+    left: calc(var(--ix-tag-border-width) * -2);
+    top: calc(var(--ix-tag-border-width) * -2);
     display: flex;
     align-items: center;
     justify-content: center;
     height: @tag-prefix-size;
     width: @tag-prefix-size;
     background-color: inherit;
-    box-shadow: inset 0 0 0 var(--ix-tag-border-width) var(--ix-color-container-bg);
+    border: var(--ix-tag-border-width) solid var(--ix-color-container-bg);
     border-radius: @tag-prefix-size;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
改为用 box-shadow 实现 bordered 效果后，数字标签的边框会有锯齿

## What is the new behavior?
改回之前用border实现

## Other information
