### PR TITLE
fix(comp:popover): the header slot height is 40px

### DIFF
--- a/packages/components/popover/style/index.less
+++ b/packages/components/popover/style/index.less
@@ -26,6 +26,6 @@
   }
 
   .@{header-prefix} + &-content {
-    padding-top: var(--ix-padding-size-xs);
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
pop 组件的内容区有一个4px的上边距，导致header部分视觉高度不为40px
pop 组件的内容区有一个8px的下边距，导popConfirm 的content部分与footer间距过大

## What is the new behavior?
pop 组件header部分视觉高度为40px
popConfirm 的content部分与footer间距为8px
## Other information
