### PR TITLE
fix(comp:select): icon is not vertically centered

### DIFF
--- a/packages/components/_private/selector/style/index.less
+++ b/packages/components/_private/selector/style/index.less
@@ -117,6 +117,7 @@
   }
 
   &-borderless &-content {
+    --ix-control-line-width: 0px;
     .borderless();
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
select处于 borderless模式时，icon未居中

## What is the new behavior?
select处于 borderless模式时，icon居中

## Other information
