### PR TITLE
fix(comp:drawer): unable to open drawer after quick opening and closing

### DIFF
--- a/packages/components/drawer/src/Drawer.tsx
+++ b/packages/components/drawer/src/Drawer.tsx
@@ -84,7 +84,7 @@ export default defineComponent({
     useScrollStrategy(props, mask, mergedVisible)
 
     return () => {
-      if (!mergedVisible.value && props.destroyOnHide) {
+      if (!visible.value && props.destroyOnHide) {
         return null
       }
       return (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
快速打开、关闭抽屉后，页面被蒙版蒙住了

mergedVisible中判断了动画是否在进行中，
导致抽屉关闭，但是如果动画还在进行的话，不会移除上一次抽屉的mask

## What is the new behavior?
快速打开、关闭抽屉后，页面不会被蒙版蒙住


## Other information
