### PR TITLE
fix(comp:button): button is not vertical center when it has icon

### DIFF
--- a/packages/components/button/style/index.less
+++ b/packages/components/button/style/index.less
@@ -8,6 +8,7 @@
 
   position: relative;
   display: inline-flex;
+  vertical-align: middle;
   align-items: center;
   justify-content: center;
   white-space: nowrap;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
多个按钮，如果部分有icon部分没有icon，在父级没有配置dispaly：flex时会无法对齐

## What is the new behavior?
可以对齐

## Other information
