### PR TITLE
fix(comp:cascader): remote search data is alaways empty

### DIFF
--- a/packages/components/cascader/src/composables/useSearchable.ts
+++ b/packages/components/cascader/src/composables/useSearchable.ts
@@ -32,7 +32,7 @@ export function useSearchable(
   const searchedKeys = computed(() => {
     const searchValue = props.searchValue
     const searchFn = mergedSearchFn.value
-    if (!searchValue || !searchFn) {
+    if (!searchValue) {
       return NoopArray as unknown as VKey[]
     }
     const _parentEnabled = parentEnabled.value
@@ -70,7 +70,7 @@ function getDefaultSearchFn(labelKey: string): CascaderSearchFn {
 function doSearch(
   keySet: Set<VKey>,
   data: MergedData,
-  searchFn: CascaderSearchFn,
+  searchFn: CascaderSearchFn | false,
   searchValue: string,
   _parentEnabled: boolean,
   getDisabledFn: GetDisabledFn,
@@ -79,7 +79,7 @@ function doSearch(
   if (keySet.has(key) || getDisabledFn(rawData)) {
     return
   }
-  if (searchFn(rawData, searchValue)) {
+  if (searchFn === false || searchFn(rawData, searchValue)) {
     if (_parentEnabled || data.isLeaf) {
       keySet.add(key)
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [ ] Tests for the changes have been added/updated or not needed
- [ ] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
远程搜索后动态修改dataSource
直接搜索会显示空，失焦后再触发才会显示最新的数据

## What is the new behavior?
动态修改dataSource后，会直接显示出来

## Other information
```javascript
<template>
  <IxCascader placeholder="Please search" :dataSource="dataSource" searchable :search-fn="false" @search="handler" />
</template>

<script setup lang="ts">
import { ref } from 'vue'

import { type CascaderData } from '@idux/components/cascader'
import { type RadioData } from '@idux/components/radio'

const searchable = ref(true)

const searchableData = [
  { key: true, label: 'true' },
  { key: 'overlay', label: 'overlay' },
  { key: false, label: 'false' },
] as RadioData[]

const dataSource = ref([
  {
    key: 'components',
    label: 'Components',
    children: [
      {
        key: 'general',
        label: 'General',
        children: [
          {
            key: 'button',
            label: 'Button',
          },
          {
            key: 'header',
            label: 'Header',
          },
          {
            key: 'icon',
            label: 'Icon',
          },
        ],
      },
      {
        key: 'layout',
        label: 'Layout',
        children: [
          {
            key: 'divider',
            label: 'Divider',
          },
          {
            key: 'grid',
            label: 'Grid',
          },
          {
            key: 'space',
            label: 'Space',
          },
        ],
      },
      {
        key: 'navigation',
        label: 'Navigation',
        children: [
          {
            key: 'breadcrumb',
            label: 'Breadcrumb',
          },
          {
            key: 'dropdown',
            label: 'Dropdown',
          },
          {
            key: 'menu',
            label: 'Menu',
          },
          {
            key: 'pagination',
            label: 'Pagination',
          },
        ],
      },
    ],
  },
  {
    key: 'pro',
    label: 'Pro',
    children: [
      {
        key: 'pro-layout',
        label: 'Layout',
      },
      {
        key: 'pro-table',
        label: 'Table',
        disabled: true,
      },
      {
        key: 'pro-transfer',
        label: 'Transfer',
      },
    ],
  },
  {
    key: 'cdk',
    label: 'CDK',
    disabled: true,
    children: [
      {
        key: 'a11y',
        label: 'Accessibility',
      },
      {
        key: 'breakpoint',
        label: 'Breakpoint',
      },
      {
        key: 'click-outside',
        label: 'ClickOutside',
      },
      {
        key: 'clipboard',
        label: 'Clipboard',
      },
      {
        key: 'forms',
        label: 'Forms',
      },
    ],
  },
])

const handler = () => {
  dataSource.value = [dataSource.value[0]]
}
</script>

```