### PR TITLE
fix(cdk:scroll): optimize virtual scroll render pool resuage

### DIFF
--- a/packages/components/table/src/utils/index.ts
+++ b/packages/components/table/src/utils/index.ts
@@ -99,10 +99,17 @@ export function modifyVirtualData(
 
     const index = flattedColumns.findIndex(col => col.key === column.key)
 
+    let poolKey: string
+    if (isString(column.key)) {
+      poolKey = `fix-${rowIndex}-${column.key}`
+    } else {
+      poolKey = `fix-${rowIndex}-${index}`
+    }
+
     return {
       data: column,
       index,
-      poolKey: `fix-${rowIndex}-${index}`,
+      poolKey,
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
虚拟滚动渲染池的复用没有规则，仅仅会从池里面找到第一个可用的元素，在渲染数据整体变更后，重新生成的渲染视图不能保证完全复用上次渲染的dom或组件，即使复用了也不能保证和上次渲染的顺序一致，导致性能问题

## What is the new behavior?
在从渲染池中拿元素时，优先获取和当前需要渲染的数据的key相同的渲染池元素，最大可能保证两次渲染的稳定性

## Other information
