### PR TITLE
fix(pro:table): hovering layout tool trigger shouldn't show resize handle

### DIFF
--- a/packages/pro/table/style/index.less
+++ b/packages/pro/table/style/index.less
@@ -94,7 +94,7 @@
       right: 1px;
       top: 1px;
       padding: 0 calc(var(--ix-padding-size-sm) - 1px);
-      z-index: 3;
+      z-index: 10;
       font-size: var(--ix-font-size-icon);
       color: var(--ix-table-head-color);
       background-color: var(--ix-color-emphasized-container-bg);
@@ -160,7 +160,7 @@
       position: absolute;
       top: 0;
       left: 0;
-      z-index: 8;
+      z-index: 11;
       border-right: 2px var(--ix-line-type) var(--ix-color-border);
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
ProTable的 layoutTool 的 trigger，当其刚好滚动到列的分割线上面的时候，悬浮会出现resize的handle


## What is the new behavior?
修改 z-index，使trigger位于handle上方

## Other information
