### PR TITLE
fix(comp:alert,tag): replace rgba bg color with color with no alpha

### DIFF
--- a/packages/components/alert/theme/default.ts
+++ b/packages/components/alert/theme/default.ts
@@ -11,6 +11,7 @@ export function getDefaultThemeTokens(tokens: GlobalThemeTokens): CertainThemeTo
     heightMd,
     borderRadiusSm,
     alertCompColorAlpha,
+    colorContainerBg,
     colorSuccessBg,
     colorInfoBg,
     colorWarningBg,
@@ -22,10 +23,10 @@ export function getDefaultThemeTokens(tokens: GlobalThemeTokens): CertainThemeTo
     height: heightMd,
     borderRadius: borderRadiusSm,
 
-    successBgColor: getAlphaColor(colorSuccessBg, alertCompColorAlpha),
-    infoBgColor: getAlphaColor(colorInfoBg, alertCompColorAlpha),
-    warningBgColor: getAlphaColor(colorWarningBg, alertCompColorAlpha),
-    errorBgColor: getAlphaColor(colorErrorBg, alertCompColorAlpha),
-    offlineBgColor: getAlphaColor(colorOffline, alertCompColorAlpha),
+    successBgColor: getAlphaColor(colorSuccessBg, alertCompColorAlpha, colorContainerBg),
+    infoBgColor: getAlphaColor(colorInfoBg, alertCompColorAlpha, colorContainerBg),
+    warningBgColor: getAlphaColor(colorWarningBg, alertCompColorAlpha, colorContainerBg),
+    errorBgColor: getAlphaColor(colorErrorBg, alertCompColorAlpha, colorContainerBg),
+    offlineBgColor: getAlphaColor(colorOffline, alertCompColorAlpha, colorContainerBg),
   }
 }

--- a/packages/components/tag/theme/default.ts
+++ b/packages/components/tag/theme/default.ts
@@ -19,6 +19,7 @@ export function getDefaultThemeTokens(
     lineWidth,
     borderRadiusSm,
     tagCompColorAlpha,
+    colorContainerBg,
     colorTextInfo,
     colorSuccessBg,
     colorInfoBg,
@@ -31,7 +32,7 @@ export function getDefaultThemeTokens(
   const greyColors = getGreyColors()
 
   return {
-    bgColorNormal: getAlphaColor(colorTextInfo, tagCompColorAlpha),
+    bgColorNormal: getAlphaColor(colorTextInfo, tagCompColorAlpha, colorContainerBg),
     bgColorFilled: greyColors.base,
     borderWidth: lineWidth,
     borderRadius: borderRadiusSm,
@@ -41,11 +42,11 @@ export function getDefaultThemeTokens(
     minWidthNumeric: 64,
 
     // private
-    successBgColor: getAlphaColor(colorSuccessBg, tagCompColorAlpha),
-    infoBgColor: getAlphaColor(colorInfoBg, tagCompColorAlpha),
-    warningBgColor: getAlphaColor(colorWarningBg, tagCompColorAlpha),
-    riskBgColor: getAlphaColor(colorRiskBg, tagCompColorAlpha),
-    errorBgColor: getAlphaColor(colorErrorBg, tagCompColorAlpha),
-    fatalBgColor: getAlphaColor(colorFatalBg, tagCompColorAlpha),
+    successBgColor: getAlphaColor(colorSuccessBg, tagCompColorAlpha, colorContainerBg),
+    infoBgColor: getAlphaColor(colorInfoBg, tagCompColorAlpha, colorContainerBg),
+    warningBgColor: getAlphaColor(colorWarningBg, tagCompColorAlpha, colorContainerBg),
+    riskBgColor: getAlphaColor(colorRiskBg, tagCompColorAlpha, colorContainerBg),
+    errorBgColor: getAlphaColor(colorErrorBg, tagCompColorAlpha, colorContainerBg),
+    fatalBgColor: getAlphaColor(colorFatalBg, tagCompColorAlpha, colorContainerBg),
   }
 }

--- a/packages/components/theme/src/themeTokens/shared/color/getAlphaColor.ts
+++ b/packages/components/theme/src/themeTokens/shared/color/getAlphaColor.ts
@@ -7,6 +7,12 @@
 
 import { TinyColor } from '@ctrl/tinycolor'
 
-export function getAlphaColor(baseColor: string, alpha: number): string {
-  return new TinyColor(baseColor).setAlpha(alpha).toRgbString()
+export function getAlphaColor(baseColor: string, alpha: number, bgColor?: string): string {
+  const alphaColor = new TinyColor(baseColor).setAlpha(alpha)
+
+  if (!bgColor) {
+    return alphaColor.toRgbString()
+  }
+
+  return alphaColor.onBackground(bgColor).toRgbString()
 }


### PR DESCRIPTION
mix color with alpha with container bg color to get a bg color with no alpha

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
由于tag和alert的背景颜色是有透明度的，在有颜色的背景上展示的颜色会透出底部背景色

## What is the new behavior?
先获取有透明度的颜色，再获取该颜色在默认容器背景色上的颜色，去掉alpha通道值

## Other information
