### PR TITLE
fix(comp:select): search input should be cleared after option selected

### DIFF
--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -107,7 +107,7 @@ export default defineComponent({
 
     const handleOptionClick = (option: SelectData) => {
       changeSelected(getKey.value(option))
-      props.allowInput && clearInput()
+      ;(props.allowInput || !props.multiple) && clearInput()
       if (!props.multiple) {
         setOverlayOpened(false)
       }

--- a/packages/components/select/src/composables/useKeyboardEvents.ts
+++ b/packages/components/select/src/composables/useKeyboardEvents.ts
@@ -59,7 +59,7 @@ export function useKeyboardEvents(
           setOverlayOpened(false)
         }
 
-        props.allowInput && clearInput()
+        ;(props.allowInput || !props.multiple) && clearInput()
         break
       }
       case 'Backspace': {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
select组件，在搜索之后选中选项，搜索没有清空

## What is the new behavior?
修复以上问题

## Other information
