### PR TITLE
fix(comp:theme): optimize global token update logic

### DIFF
--- a/packages/cdk/scroll/demo/SimulatedScroll.vue
+++ b/packages/cdk/scroll/demo/SimulatedScroll.vue
@@ -8,6 +8,7 @@
       :colWidth="200"
       :virtual="true"
       :rowRender="rowRender"
+      scrollMode="simulated"
       getKey="key"
     >
       <template #col="{ row, item, index }">

--- a/packages/components/theme/src/composables/useThemeProvider.ts
+++ b/packages/components/theme/src/composables/useThemeProvider.ts
@@ -90,21 +90,17 @@ export function createThemeProviderContext(
       }
 
       // sub providers don't register reset styles
-      if (props?.inherit && !!supperContext) {
+      if ((props?.inherit && !!supperContext) || isTokensRegistered(resetTokenKey)) {
         return
       }
 
-      if (!isTokensRegistered(resetTokenKey)) {
-        registerToken(
-          resetTokenKey,
-          globalTokens => (useSupper ? supperContext!.getThemeTokens(resetTokenKey) : getResetTokens(globalTokens)),
-          undefined,
-          false,
-          useSupper ? supperContext!.getThemeHashId(resetTokenKey) : undefined,
-        )
-      } else {
-        updateToken(resetTokenKey, useSupper ? supperContext!.getThemeHashId(resetTokenKey) : undefined)
-      }
+      registerToken(
+        resetTokenKey,
+        globalTokens => (useSupper ? supperContext!.getThemeTokens(resetTokenKey) : getResetTokens(globalTokens)),
+        undefined,
+        false,
+        useSupper ? supperContext!.getThemeHashId(resetTokenKey) : undefined,
+      )
     },
     {
       immediate: true,

--- a/packages/components/theme/src/composables/useTokenRegister.ts
+++ b/packages/components/theme/src/composables/useTokenRegister.ts
@@ -132,9 +132,11 @@ export function useTokenRegister(
 
     if (key === globalTokenKey) {
       setGlobalHashId(record.hashId)
-      ;[...tokenRecordMap.keys()].forEach(componentTokenKey => {
-        updateToken(componentTokenKey)
-      })
+      ;[...tokenRecordMap.keys()]
+        .filter(key => key !== globalTokenKey)
+        .forEach(componentTokenKey => {
+          updateToken(componentTokenKey)
+        })
     }
 
     return record.hashId


### PR DESCRIPTION
after global token update, all registered tokens should be updated, and global token key should be excluded
reset tokens shouldn't be explicitly updated because updating global tokens will trigger all token updates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
全局token更新时，会触发所有的token更新，但是没有把global排除掉导致重复的计算
reset tokens 会在全局token更新后自动更新，但是也被显式重复更新了

## What is the new behavior?
优化以上逻辑

## Other information
