### PR TITLE
fix(comp:select): clicking an option created by input selects undefind

### DIFF
--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -106,7 +106,7 @@ export default defineComponent({
     })
 
     const handleOptionClick = (option: SelectData) => {
-      changeSelected(getKey.value(option))
+      changeSelected(getKey.value(option) ?? option.key)
       ;(props.allowInput || !props.multiple) && clearInput()
       if (!props.multiple) {
         setOverlayOpened(false)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当配置了getKey，且数据的key并不是'key'，点击面板选项会选择空

## What is the new behavior?
修复以上问题

## Other information
