### PR TITLE
fix(date-picker): range panel onSelect should be triggered when panel not visible

### DIFF
--- a/packages/components/date-picker/src/composables/useRangePanelState.ts
+++ b/packages/components/date-picker/src/composables/useRangePanelState.ts
@@ -28,8 +28,12 @@ export function useRangePanelState(props: DateRangePanelProps, dateConfig: DateC
 
   watch(
     () => props.visible,
-    () => {
+    visible => {
       setIsSelecting(false)
+
+      if (!visible) {
+        callEmit(props.onSelect, props.value)
+      }
     },
   )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
文档中只能选择7天内的demo，选择开始时间之后，关闭面板，会导致面板上日期的禁用状态不正常

## What is the new behavior?
以上问题的原因是面板收起时没有触发onSelect，因此在visible变更后新增onSelect的触发

## Other information
