### PR TITLE
fix(comp:table): height of checkbox or radio in selectable column cell isn't right

### DIFF
--- a/packages/components/radio/style/index.less
+++ b/packages/components/radio/style/index.less
@@ -7,6 +7,7 @@
 
     display: inline-flex;
     align-items: center;
+    vertical-align: middle;
     line-height: unset;
     cursor: pointer;
 

--- a/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
+++ b/packages/components/table/__tests__/__snapshots__/table.spec.ts.snap
@@ -38,10 +38,10 @@ exports[`Table > basic work > render work 1`] = `
           <!---->
           <!---->
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -56,10 +56,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 0</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -74,10 +74,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 1</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -92,10 +92,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 2</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -110,10 +110,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 3</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -128,10 +128,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 4</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -146,10 +146,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 5</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -164,10 +164,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 6</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -182,10 +182,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 7</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger ix-table-expandable-trigger-disabled\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->
@@ -200,10 +200,10 @@ exports[`Table > basic work > render work 1`] = `
             <td class=\\"ix-table-cell\\"><a style=\\"margin-right: 8px;\\">Invite Edrward 8</a><a>Delete</a></td>
           </tr>
           <tr class=\\"ix-table-row\\">
-            <td class=\\"ix-table-cell\\">
+            <td class=\\"ix-table-cell ix-table-cell-expandable\\">
               <div class=\\"ix-table-expandable-wrapper\\"><span class=\\"ix-table-expandable-trigger\\"><button class=\\"ix-table-expandable-trigger-button\\" type=\\"button\\"><svg viewBox=\\"0 0 16 16\\"><rect x=\\"1\\" y=\\"1\\" width=\\"14\\" height=\\"14\\" rx=\\"1\\" style=\\"fill: var(--ix-color-emphasized-container-bg);\\"></rect><rect x=\\"5\\" y=\\"7\\" width=\\"6\\" height=\\"2\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect><rect x=\\"7\\" y=\\"5\\" width=\\"2\\" height=\\"6\\" rx=\\"0.2\\" style=\\"fill: var(--ix-color-icon);\\"></rect></svg></button><!----></span><span class=\\"ix-table-expandable-trigger-gap\\"></span><a>expandable</a></div>
             </td>
-            <td class=\\"ix-table-cell\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
+            <td class=\\"ix-table-cell ix-table-cell-selectable\\"><label class=\\"ix-checkbox ix-checkbox-disabled\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"true\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\" disabled=\\"\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>
                 <!---->
                 <!---->
                 <!---->

--- a/packages/components/table/demo/Selectable.vue
+++ b/packages/components/table/demo/Selectable.vue
@@ -9,9 +9,6 @@
       <IxSwitch v-model:checked="selectableColumn.showIndex" :labels="['Index', 'Index']"></IxSwitch>
     </IxSpace>
     <IxTable v-model:selectedRowKeys="selectedRowKeys" :columns="columns" :dataSource="data" :pagination="false">
-      <template #name="{ value }">
-        <IxButton mode="link">{{ value }}</IxButton>
-      </template>
     </IxTable>
   </IxSpace>
 </template>
@@ -46,7 +43,6 @@ const columns: TableColumn<Data>[] = [
   {
     title: 'Name',
     dataKey: 'name',
-    customCell: 'name',
   },
   {
     title: 'Age',

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -65,13 +65,14 @@ export default defineComponent({
     })
 
     const classes = computed(() => {
-      const { fixed, align } = props.column as BodyColumn
+      const { fixed, align, type } = props.column as BodyColumn
       const prefixCls = mergedPrefixCls.value
       let classes = {
         [`${prefixCls}-cell`]: true,
         [`${prefixCls}-cell-sorted`]: !!activeSortOrderBy.value,
         [`${prefixCls}-cell-align-${align.cell}`]: !!align && align.cell != 'start',
         [`${prefixCls}-cell-ellipsis`]: !!mergedEllipsis.value,
+        [`${prefixCls}-cell-${type}`]: !!type,
       }
       if (fixed) {
         classes = {
@@ -348,6 +349,6 @@ function renderIndexableChildren(
     return undefined
   }
 
-  const classes = [`${prefixCls}-indexable`, selectDisabled.value && `${prefixCls}-indexable-disabled`]
+  const classes = [`${prefixCls}-indexable-label`, selectDisabled.value && `${prefixCls}-indexable-label-disabled`]
   return <span class={classes}>{customRender({ record, rowIndex, pageIndex, pageSize })}</span>
 }

--- a/packages/components/table/style/indexable.less
+++ b/packages/components/table/style/indexable.less
@@ -1,5 +1,5 @@
 .@{table-prefix} {
-  &-indexable {
+  &-indexable-label {
     color: var(--ix-color-text);
     cursor: pointer;
 

--- a/packages/components/table/style/selectable.less
+++ b/packages/components/table/style/selectable.less
@@ -14,4 +14,11 @@
       background: var(--ix-table-body-row-bg-color-selected);
     }
   }
+
+  & td.@{table-prefix}-cell-selectable {
+    .@{checkbox-prefix},
+    .@{radio-prefix} {
+      line-height: 1;
+    }
+  }
 }

--- a/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
+++ b/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
@@ -209,7 +209,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -264,7 +264,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -319,7 +319,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -375,7 +375,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -430,7 +430,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -485,7 +485,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -540,7 +540,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -595,7 +595,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -650,7 +650,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -706,7 +706,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -761,7 +761,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -816,7 +816,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -871,7 +871,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -927,7 +927,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -982,7 +982,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -1037,7 +1037,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -1326,7 +1326,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -1371,7 +1371,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -1417,7 +1417,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"
@@ -1462,7 +1462,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
                       
                       
                       <td
-                        class="ix-table-cell"
+                        class="ix-table-cell ix-table-cell-selectable"
                       >
                         <label
                           aria-checked="false"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格的 selectable 列，checkbox和radio的高度不正常，导致showIndex开启之后，悬浮上去高度抖动

## What is the new behavior?
将checkbox和radio的vertical-align设置为middle，并且在table-cell上加上类型相关的class，selectable column下的checkbox和radio的line-height均设置为1

## Other information
