### PR TITLE
fix(comp:textarea): textarea color isn't correct under dark theme

### DIFF
--- a/packages/components/textarea/style/index.less
+++ b/packages/components/textarea/style/index.less
@@ -15,6 +15,7 @@
     width: 100%;
     min-width: 0;
     outline: 0;
+    color: var(--ix-color-text);
     background-color: var(--ix-control-bg-color);
     border: var(--ix-control-line-width) var(--ix-control-line-type) var(--ix-color-border);
     transition: all var(--ix-motion-duration-medium) var(--ix-motion-ease-in-out), height 0s, width 0s;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
textarea组件的文字颜色在dark主题下不正常

## What is the new behavior?
修复以上问题

## Other information
