### PR TITLE
fix(comp:carousel): pre and next arrow should hide when item count is 0

### DIFF
--- a/packages/components/carousel/__tests__/carousel.spec.ts
+++ b/packages/components/carousel/__tests__/carousel.spec.ts
@@ -107,11 +107,8 @@ describe('Carousel', () => {
       },
     })
 
-    await wrapper.find('.ix-carousel-arrow-prev').trigger('click')
-    expect(onChange).toHaveBeenCalledTimes(0)
-
-    await wrapper.find('.ix-carousel-arrow-next').trigger('click')
-    expect(onChange).toHaveBeenCalledTimes(0)
+    expect(wrapper.find('.ix-carousel-arrow-prev').exists()).toBeFalsy()
+    expect(wrapper.find('.ix-carousel-arrow-next').exists()).toBeFalsy()
   })
 
   test('slot dot work', async () => {

--- a/packages/components/carousel/src/Carousel.tsx
+++ b/packages/components/carousel/src/Carousel.tsx
@@ -191,7 +191,7 @@ export default defineComponent({
               ))}
             </div>
           </div>
-          {mergedShowArrow.value && (
+          {mergedShowArrow.value && children.length > 1 && (
             <>
               <div key="__arrow-prev" class={`${prefixCls}-arrow ${prefixCls}-arrow-prev`} onClick={prev}>
                 {slots.arrow ? slots.arrow({ type: 'prev' }) : <IxIcon name="left-filled" />}

--- a/packages/components/carousel/src/composables/useStrategy.ts
+++ b/packages/components/carousel/src/composables/useStrategy.ts
@@ -88,6 +88,11 @@ export function useStrategy(
     }
 
     const { from, to } = getBoundary(activeIndex.value, index, length)
+
+    if (from === to) {
+      return
+    }
+
     nextIndex.value = index
     runningIndex.value = to
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
Carousel的item 数量只有一个的时候，next,pre,goto的跳转调用，会触发切换动画，但实际上没有可切换的内容

## What is the new behavior?
1. 当item数量只有一个的时候，切换的调用不应该执行
2. 当item数量只有一个的时候，切换的箭头按钮不应该显示

## Other information
