### PR TITLE
fix(comp:collapse,empty): margin size css var reference error

### DIFF
--- a/packages/components/collapse/style/index.less
+++ b/packages/components/collapse/style/index.less
@@ -26,7 +26,7 @@
     .collapse-size(var(--ix-collapse-font-size-md), var(--ix-collapse-expand-icon-size-md), var(--ix-collapse-padding-horizontal-md));
 
     .@{collapse-prefix}-panel + .@{collapse-prefix}-panel {
-      margin-top: var(--ix-spacing-sm);
+      margin-top: var(--ix-margin-size-sm);
     }
 
     .@{collapse-prefix}-panel {

--- a/packages/components/empty/style/index.less
+++ b/packages/components/empty/style/index.less
@@ -30,11 +30,11 @@
   }
 
   &-content {
-    margin-top: var(--ix-spacing-sm);
+    margin-top: var(--ix-margin-size-sm);
   }
 
   &-simple {
-    margin: var(--ix-spacing-sm) 0;
+    margin: var(--ix-margin-size-sm) 0;
   }
 
   &-simple &-description {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
margin 的 css 变量引用错误，引用了不存在的css变量

## What is the new behavior?
修复以上问题

## Other information
