### PR TITLE
fix(comp:table): clicking expand icon shouldn't trigger row select

### DIFF
--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -255,14 +255,19 @@ function renderExpandableChildren(
     }
   }
 
+  const handleClick = (evt: MouseEvent) => {
+    evt.preventDefault()
+    evt.stopImmediatePropagation()
+
+    if (!expandDisabled.value) {
+      handleExpend()
+    }
+  }
+
   return [
     ...indents,
     <span class={triggerCls} style={indentStyle}>
-      <button
-        class={`${prefixCls}-expandable-trigger-button`}
-        type="button"
-        onClick={expandDisabled.value ? undefined : handleExpend}
-      >
+      <button class={`${prefixCls}-expandable-trigger-button`} type="button" onClick={handleClick}>
         {iconNode}
       </button>
       {mergedShowLine && [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格展开按钮的点击会触发行的选中


## What is the new behavior?
阻止点击事件冒泡和默认行为触发，修复以上问题

## Other information
