### PR TITLE
fix(comp:tooltip): tooltip content should wrap on line break

### DIFF
--- a/packages/components/tooltip/docs/Theme.zh.md
+++ b/packages/components/tooltip/docs/Theme.zh.md
@@ -4,3 +4,4 @@
 | `fontSize` |  | `number` | `12` | `12` |
 | `maxWidth` |  | `number` | `400` | `400` |
 | `minWidth` |  | `number` | `32` | `32` |
+| `whiteSpace` |  | `string` | `pre-wrap` | `pre-wrap` |

--- a/packages/components/tooltip/style/index.less
+++ b/packages/components/tooltip/style/index.less
@@ -12,6 +12,7 @@
   &-wrapper {
     position: relative;
     word-wrap: break-word;
+    white-space: var(--ix-tooltip-white-space);
     min-width: var(--ix-tooltip-min-width);
     max-width: var(--ix-tooltip-max-width);
     padding: var(--ix-padding-size-xs) var(--ix-padding-size-sm);

--- a/packages/components/tooltip/theme/dark.css
+++ b/packages/components/tooltip/theme/dark.css
@@ -4,4 +4,5 @@
   --ix-tooltip-color: #808999;
   --ix-tooltip-min-width: 32px;
   --ix-tooltip-max-width: 400px;
+  --ix-tooltip-white-space: pre-wrap;
 }

--- a/packages/components/tooltip/theme/default.css
+++ b/packages/components/tooltip/theme/default.css
@@ -4,4 +4,5 @@
   --ix-tooltip-color: #6f7785;
   --ix-tooltip-min-width: 32px;
   --ix-tooltip-max-width: 400px;
+  --ix-tooltip-white-space: pre-wrap;
 }

--- a/packages/components/tooltip/theme/default.ts
+++ b/packages/components/tooltip/theme/default.ts
@@ -15,5 +15,7 @@ export function getDefaultThemeTokens(tokens: GlobalThemeTokens): CertainThemeTo
 
     minWidth: 32,
     maxWidth: 400,
+
+    whiteSpace: 'pre-wrap',
   }
 }

--- a/packages/components/tooltip/theme/tokens.ts
+++ b/packages/components/tooltip/theme/tokens.ts
@@ -11,4 +11,6 @@ export interface TooltipThemeTokens {
 
   minWidth: number
   maxWidth: number
+
+  whiteSpace: string
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
tooltip 组件内容的white-space不允许换行

## What is the new behavior?
1. 提供 whiteSpace 主题变量，可以配置内容是否可以换行
2. 默认的 whiteSpace 为 pre-wrap

## Other information
如果这个修改对业务有影响，自定义主题变量可以解决