### PR TITLE
fix(comp:tree-select): removing item from selector doesn't uncheck tree node

### DIFF
--- a/packages/cdk/utils/src/tree.ts
+++ b/packages/cdk/utils/src/tree.ts
@@ -36,13 +36,13 @@ export function traverseTree<V extends TreeTypeData<V, C>, C extends keyof V>(
 export function mapTree<V extends TreeTypeData<V, C>, R extends object, C extends keyof V>(
   data: V[],
   childrenKey: C,
-  mapFn: (item: V, parents: V[]) => R | undefined,
+  mapFn: (item: V, parents: V[], index: number) => R | undefined,
 ): (R & TreeTypeData<R, C>)[] {
   const map = (_data: V[], parents: V[]) => {
     const res: (TreeTypeData<R, C> & R)[] = []
     for (let idx = 0; idx < _data.length; idx++) {
       const item = _data[idx]
-      const mappedItem = mapFn(item, parents) as R & TreeTypeData<R, C>
+      const mappedItem = mapFn(item, parents, idx) as R & TreeTypeData<R, C>
       if (!mappedItem) {
         continue
       }

--- a/packages/components/tree-select/src/TreeSelect.tsx
+++ b/packages/components/tree-select/src/TreeSelect.tsx
@@ -45,6 +45,7 @@ export default defineComponent({
     const mergedLabelKey = computed(() => props.labelKey ?? config.labelKey)
 
     const triggerRef = ref<SelectorInstance>()
+    const treeRef = ref<TreeInstance>()
     const [inputValue, setInputValue] = useState('')
     const focus = () => triggerRef.value?.focus()
     const blur = () => triggerRef.value?.blur()
@@ -63,11 +64,11 @@ export default defineComponent({
     const { selectedValue, selectedNodes, changeSelected, handleRemove, handleClear } = useSelectedState(
       props,
       accessor,
+      treeRef,
       mergedNodeMap,
     )
     const [overlayOpened, setOverlayOpened] = useControlledProp(props, 'open', false)
 
-    const treeRef = ref<TreeInstance>()
     const scrollTo: VirtualScrollToFn = options => {
       treeRef.value?.scrollTo(options)
     }

--- a/packages/components/tree-select/src/composables/useSelectedState.ts
+++ b/packages/components/tree-select/src/composables/useSelectedState.ts
@@ -7,15 +7,15 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { type ComputedRef, computed, toRaw } from 'vue'
+import type { TreeInstance } from '@idux/components/tree'
+
+import { type ComputedRef, type Ref, computed, toRaw } from 'vue'
 
 import { type FormAccessor } from '@idux/cdk/forms'
 import { type VKey, callEmit, convertArray } from '@idux/cdk/utils'
 
 import { type MergedNode } from './useDataSource'
 import { type TreeSelectNode, type TreeSelectProps } from '../types'
-
-//import { generateOption } from '../utils/generateOption'
 
 export interface SelectedStateContext {
   selectedValue: ComputedRef<VKey[]>
@@ -28,6 +28,7 @@ export interface SelectedStateContext {
 export function useSelectedState(
   props: TreeSelectProps,
   accessor: FormAccessor,
+  treeRef: Ref<TreeInstance | undefined>,
   mergedNodeMap: ComputedRef<Map<VKey, MergedNode>>,
 ): SelectedStateContext {
   const selectedValue = computed(() => convertArray(accessor.value))
@@ -54,7 +55,7 @@ export function useSelectedState(
   }
 
   const handleRemove = (key: VKey) => {
-    setValue(selectedValue.value.filter(item => key !== item))
+    treeRef.value?._handleCheck(key)
   }
 
   const handleClear = (evt: MouseEvent) => {

--- a/packages/components/tree/__tests__/tree.spec.ts
+++ b/packages/components/tree/__tests__/tree.spec.ts
@@ -193,16 +193,16 @@ describe('Tree', () => {
 
       const allNodes = wrapper.findAll('.ix-tree-node')
 
-      expect(allNodes[0].find('.ix-checkbox-checked').exists()).toBe(false)
+      expect(allNodes[0].find('.ix-checkbox-checked').exists()).toBe(true)
       expect(allNodes[1].find('.ix-checkbox-checked').exists()).toBe(true)
       // 0-1 exclude disabled
-      expect(allNodes[2].find('.ix-checkbox-checked').exists()).toBe(false)
+      expect(allNodes[2].find('.ix-checkbox-checked').exists()).toBe(true)
       expect(allNodes[3].find('.ix-checkbox-checked').exists()).toBe(true)
 
       // 0-0, unchecked
       await allNodes[1].find('input').setValue(false)
 
-      expect(onUpdateCheckedKeys).toBeCalledWith(['0-2'])
+      expect(onUpdateCheckedKeys).toBeCalledWith(['0-1', '0-2'])
 
       await wrapper.setProps({ checkedKeys: [] })
 
@@ -262,8 +262,8 @@ describe('Tree', () => {
       await wrapper.setProps({ checkedKeys: [] })
 
       expect(allNodes[0].find('.ix-checkbox-checked').exists()).toBe(false)
-      expect(allNodes[0].find('.ix-checkbox-checked').exists()).toBe(false)
-      expect(allNodes[0].find('.ix-checkbox-checked').exists()).toBe(false)
+      expect(allNodes[1].find('.ix-checkbox-checked').exists()).toBe(false)
+      expect(allNodes[2].find('.ix-checkbox-checked').exists()).toBe(false)
 
       //0, checked
       await allNodes[0].find('input').setValue(true)

--- a/packages/components/tree/src/node/Checkbox.tsx
+++ b/packages/components/tree/src/node/Checkbox.tsx
@@ -15,11 +15,16 @@ import { treeNodeCheckboxProps } from '../types'
 export default defineComponent({
   props: treeNodeCheckboxProps,
   setup(props) {
-    const { mergedPrefixCls, allCheckedKeys, indeterminateKeys, handleCheck } = inject(treeToken)!
+    const {
+      mergedPrefixCls,
+      isChecked: _isChecked,
+      isIndeterminate: _isIndeterminate,
+      handleCheck,
+    } = inject(treeToken)!
     const isChecked = computed(() => {
-      return allCheckedKeys.value.includes(props.node.key)
+      return _isChecked(props.node.key)
     })
-    const isIndeterminate = computed(() => indeterminateKeys.value.includes(props.node.key))
+    const isIndeterminate = computed(() => _isIndeterminate(props.node.key))
 
     const onChange = () => handleCheck(props.node)
 

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -134,6 +134,7 @@ export interface TreeBindings<K = VKey> {
 
   //private
   _getFlattedNodes: () => MergedNode[]
+  _handleCheck: (key: VKey) => void
 }
 export type TreeComponent = DefineComponent<Omit<HTMLAttributes, keyof TreePublicProps> & TreePublicProps, TreeBindings>
 export type TreeInstance = InstanceType<DefineComponent<TreeProps, TreeBindings>>

--- a/packages/components/utils/src/useTreeCheckStateResolver.ts
+++ b/packages/components/utils/src/useTreeCheckStateResolver.ts
@@ -25,7 +25,7 @@ interface GetAllUncheckedKeys<V extends TreeTypeData<V, C>, C extends keyof V> {
 export interface TreeCheckStateResolverContext<V extends TreeTypeData<V, C>, C extends keyof V> {
   data: V[] | undefined
   dataMap: Map<VKey, V>
-  parentKeyMap: Map<VKey, VKey>
+  parentKeyMap: Map<VKey, VKey | undefined>
   depthMap: Map<VKey, number>
 }
 export interface TreeCheckStateResolver<V extends TreeTypeData<V, C>, C extends keyof V> {
@@ -151,7 +151,7 @@ export function useTreeCheckStateResolver<V extends TreeTypeData<V, C>, C extend
     appendedKeys.forEach(key => {
       _getParents(key, resolverContext).forEach(parent => {
         if (parent[childrenKey.value]?.every(child => newKeySet.has(getKey.value(child)))) {
-          newKeySet.add(key)
+          newKeySet.add(getKey.value(parent))
         }
       })
     })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
从选择框中移除已选项，不会同步取消树的勾选

## What is the new behavior?
1. 使用 components/utils 中的 useTreeCheckStateResolver 重构 tree 组件的勾选计算逻辑
2. 在从选择框中移除选项后，应该调用树的勾选触发函数，根据级联策略计算取消该项勾选后的value

## Other information
