### PR TITLE
fix(pro:tag-select): supports beforeRemoveConfirm and beforeSelectConfirm

### DIFF
--- a/packages/pro/tag-select/docs/Api.zh.md
+++ b/packages/pro/tag-select/docs/Api.zh.md
@@ -25,6 +25,8 @@
 | `readonly` | 只读模式 | `boolean` | - | - | - |
 | `removeConfirmHeader` | 删除标签的确认弹窗头部配置 | `string \| HeaderProps` | - | - | - |
 | `removeConfirmTitle` | 删除标签的确认弹窗title | `string \| VNode \| (() => VNodeChild)` | - | - | - |
+| `beforeSelectConfirm` | 选择前点击确认，判断是否可以确认选择 | `(data: TagSelectData) => boolean \| Promise<boolean>` | - | - | - |
+| `beforeRemoveConfirm` | 删除前点击确认，判断是否可以确认删除 | `(data: TagSelectData) => boolean \| Promise<boolean>` | - | - | - |
 | `size` | 设置选择器大小 | `'sm' \| 'md' \| 'lg'` | `md` | - | - |
 | `status` | 手动指定校验状态 | `valid \| invalid \| validating` | - | - | - |
 | `suffix` | 设置后缀图标 | `string \| #suffix` | `down` | - | - |

--- a/packages/pro/tag-select/src/ProTagSelect.tsx
+++ b/packages/pro/tag-select/src/ProTagSelect.tsx
@@ -63,7 +63,7 @@ export default defineComponent({
     const tagEditContext = useTagEdit(overlayStateContext)
     const selectedStateContext = useSelectedState(props, accessor, tagDataContext)
     const selectConfirmContext = useSelectConfirm(props, tagDataContext, selectedStateContext, overlayStateContext)
-    const removeConfirmContext = useRemoveConfirm(tagDataContext, selectedStateContext, overlayStateContext)
+    const removeConfirmContext = useRemoveConfirm(props, tagDataContext, selectedStateContext, overlayStateContext)
     const operationContext = useOperations(
       tagDataContext,
       selectConfirmContext,
@@ -114,6 +114,7 @@ export default defineComponent({
       triggerRef,
       props,
       focused,
+      focus,
       mergedPrefixCls,
       locale: locales.tagSelect,
       mergedTagSelectColors: tagColorsContext.mergedTagSelectColors,

--- a/packages/pro/tag-select/src/composables/useRemoveConfirm.ts
+++ b/packages/pro/tag-select/src/composables/useRemoveConfirm.ts
@@ -8,6 +8,7 @@
 import type { OverlayStateContext } from './useOverlayState'
 import type { SelectedStateContext } from './useSelectedState'
 import type { MergedTagData, TagDataContext } from './useTagData'
+import type { ProTagSelectProps } from '../types'
 import type { ComputedRef } from 'vue'
 
 import { useState } from '@idux/cdk/utils'
@@ -18,12 +19,13 @@ export interface RemoveConfirmContext {
   dataToRemove: ComputedRef<MergedTagData | undefined>
   modalVisible: ComputedRef<boolean>
   handleTagDataRemove: (data: MergedTagData) => Promise<boolean>
-  handleModalOk: () => void
+  handleModalOk: () => Promise<void>
   handleModalCancel: () => void
   handleModalAfterClose: () => void
 }
 
 export function useRemoveConfirm(
+  props: ProTagSelectProps,
   tagDataContext: TagDataContext,
   selectedStateContext: SelectedStateContext,
   overlayStateContext: OverlayStateContext,
@@ -51,7 +53,13 @@ export function useRemoveConfirm(
     return removeConfirmDeferred.wait()
   }
 
-  const handleModalOk = () => {
+  const handleModalOk = async () => {
+    const { beforeRemoveConfirm } = props
+
+    if (beforeRemoveConfirm && !(await beforeRemoveConfirm(dataToRemove.value!))) {
+      return
+    }
+
     setModalVisible(false)
 
     if (dataToRemove.value) {

--- a/packages/pro/tag-select/src/composables/useSelectConfirm.ts
+++ b/packages/pro/tag-select/src/composables/useSelectConfirm.ts
@@ -19,7 +19,7 @@ import { type Deferred, createDeferred } from '../utils'
 export interface SelectConfirmContext {
   dataToSelect: ComputedRef<MergedTagData | undefined>
   handleTagSelect: (data: MergedTagData) => Promise<boolean>
-  handleTagSelectOk: () => void
+  handleTagSelectOk: () => Promise<void>
   handleTagSelectCancel: () => void
 }
 
@@ -69,7 +69,12 @@ export function useSelectConfirm(
     return tagSelectDeferred.wait()
   }
 
-  const handleTagSelectOk = () => {
+  const handleTagSelectOk = async () => {
+    const { beforeSelectConfirm } = props
+    if (beforeSelectConfirm && !(await beforeSelectConfirm(dataToSelect.value!))) {
+      return
+    }
+
     setLocked(false)
     setSelectConfirmPanelOpened(false)
 

--- a/packages/pro/tag-select/src/content/SelectedTag.tsx
+++ b/packages/pro/tag-select/src/content/SelectedTag.tsx
@@ -30,6 +30,7 @@ export default defineComponent({
     const {
       props: proTagSelectProps,
       locale,
+      focus,
       mergedPrefixCls,
       dataToSelect,
       selectConfirmPanelOpened,
@@ -77,6 +78,15 @@ export default defineComponent({
       handleTagRemove(props.value)
     }
 
+    const handleOk = () => {
+      handleTagSelectOk()
+      focus()
+    }
+    const handleCancel = () => {
+      handleTagSelectCancel()
+      focus()
+    }
+
     const renderConfirmOverlay = () => {
       const prefixCls = `${mergedPrefixCls.value}-select-confirm`
       return (
@@ -84,10 +94,10 @@ export default defineComponent({
           <ɵHeader class={`${prefixCls}-header`} header={proTagSelectProps.selectConfirmHeader} size="sm" />
           <div class={`${prefixCls}-content`}>{slots.selectConfirmContent?.(tagData.value)}</div>
           <div class={`${prefixCls}-footer`}>
-            <IxButton mode="primary" size="xs" onClick={handleTagSelectOk}>
+            <IxButton mode="primary" size="xs" onClick={handleOk}>
               {locale.ok}
             </IxButton>
-            <IxButton size="xs" onClick={handleTagSelectCancel}>
+            <IxButton size="xs" onClick={handleCancel}>
               {locale.cancel}
             </IxButton>
           </div>

--- a/packages/pro/tag-select/src/token.ts
+++ b/packages/pro/tag-select/src/token.ts
@@ -25,6 +25,7 @@ export interface ProTagSelectContext
   triggerRef: Ref<SelectorInstance | undefined>
   props: ProTagSelectProps
   focused: ComputedRef<boolean>
+  focus: (options?: FocusOptions) => void
   mergedTagSelectColors: ComputedRef<TagSelectColor[]>
   selectedValue: ComputedRef<VKey[] | undefined>
   mergedData: ComputedRef<MergedTagData[]>

--- a/packages/pro/tag-select/src/types.ts
+++ b/packages/pro/tag-select/src/types.ts
@@ -59,6 +59,8 @@ export const proTagSelectProps = {
   removeConfirmHeader: [String, Object] as PropType<string | HeaderProps>,
   removeConfirmTitle: [String, Object, Function] as PropType<string | VNode | (() => VNodeChild)>,
   selectConfirmHeader: [String, Object] as PropType<string | HeaderProps>,
+  beforeSelectConfirm: Function as PropType<(data: TagSelectData) => boolean | Promise<boolean>>,
+  beforeRemoveConfirm: Function as PropType<(data: TagSelectData) => boolean | Promise<boolean>>,
   size: { type: String as PropType<FormSize>, default: undefined },
   status: String as PropType<ValidateStatus>,
   suffix: { type: String, default: undefined },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
新增支持 beforeRemoveConfirm 和 beforeSelectConfirm，用来判断在移除和选择标签数据时是否可以确认

## Other information
