### PR TITLE
fix(pro:tag-select): removing unselected tag data shouldn't emit tagRemove

### DIFF
--- a/packages/pro/tag-select/src/composables/useSelectedState.ts
+++ b/packages/pro/tag-select/src/composables/useSelectedState.ts
@@ -71,6 +71,11 @@ export function useSelectedState(
       return
     }
 
+    const newSelectedValue = selectedValue.value?.filter(item => key !== item)
+    if (newSelectedValue?.length === selectedValue.value?.length) {
+      return
+    }
+
     setSelectedValue(selectedValue.value?.filter(item => key !== item))
     callEmit(props.onTagRemove, data)
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
移除一个没有被选中的标签数据，同样触发了 onTagRemove 事件

## What is the new behavior?
不应该触发，修复以上问题

## Other information
