### PR TITLE
fix(pro:tag-select): tag creation option should hide when input fully matched

### DIFF
--- a/packages/pro/tag-select/src/composables/useTagData.ts
+++ b/packages/pro/tag-select/src/composables/useTagData.ts
@@ -69,7 +69,7 @@ export function useTagData(props: ProTagSelectProps, tagColorContext: TagColorCo
   })
 
   const inputFullyMatched = computed(
-    () => filteredData.value.length === 1 && filteredData.value[0].label === inputValue.value,
+    () => inputValue.value && filteredData.value.findIndex(data => data.label === inputValue.value) > -1,
   )
 
   const getTagDataByKey = (key: VKey) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当搜索输入的内容严格匹配到了一个标签的label，创建标签的选项依然存在

## What is the new behavior?
在严格匹配到一个搜索到的标签的label时，不应该显示创建标签的选项

## Other information
