### PR TITLE
fix(pro:search): quickselect search input shouldn't hide when option selected

### DIFF
--- a/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
+++ b/packages/pro/search/src/components/quickSelect/QuickSelectItem.tsx
@@ -34,20 +34,18 @@ export default defineComponent({
       updateSearchValues,
       getCacheData,
       setCacheData,
-      tempSegmentInputRef,
     } = inject(proSearchContext)!
 
     const searchInputRef = ref<HTMLInputElement>()
     const searchIconRef = ref<IconInstance>()
 
     const [searchInput, setSearchInput] = useState('')
-    const [searchInputOpend, _setSearchInputOpened] = useState(false)
     const setSearchInputOpened = (opened: boolean) => {
-      _setSearchInputOpened(opened)
       if (opened) {
         searchInputRef.value?.focus()
+        props.setSearchInputActive?.(true)
       } else {
-        tempSegmentInputRef.value?.focus()
+        props.setSearchInputActive?.(false)
       }
     }
 
@@ -67,7 +65,7 @@ export default defineComponent({
       const prefixCls = `${mergedPrefixCls.value}-quick-select-item-search-bar`
       return normalizeClass({
         [prefixCls]: true,
-        [`${prefixCls}-opened`]: searchInputOpend.value,
+        [`${prefixCls}-opened`]: props.searchInputActive,
       })
     })
 
@@ -81,6 +79,14 @@ export default defineComponent({
 
     const [itemValue, setItemValue] = useState<unknown>(searchDataSegmentState.value?.value)
     watch(() => searchDataSegmentState.value?.value, setItemValue)
+    watch(
+      () => props.searchInputActive,
+      active => {
+        if (!active) {
+          setSearchInput('')
+        }
+      },
+    )
 
     const confirmValue = (value: unknown) => {
       let searchStateKey = searchState.value?.key
@@ -114,15 +120,20 @@ export default defineComponent({
     const setOnKeyDown = () => {}
 
     const handleBlur = () => {
-      setSearchInput('')
       setSearchInputOpened(false)
     }
     const handleSearchIconClick = () => {
-      setSearchInputOpened(!searchInputOpend.value)
+      setSearchInputOpened(!props.searchInputActive)
     }
     const handleSearchIconMouseDown = (evt: MouseEvent) => {
       evt.preventDefault()
       evt.stopImmediatePropagation()
+    }
+    const handleContentMouseDown = (evt: MouseEvent) => {
+      if (props.searchInputActive) {
+        evt.preventDefault()
+        evt.stopImmediatePropagation()
+      }
     }
 
     return () => {
@@ -167,7 +178,7 @@ export default defineComponent({
               </div>
             )}
           </div>
-          <div class={`${prefixCls}-content`}>
+          <div class={`${prefixCls}-content`} onMousedown={handleContentMouseDown}>
             {searchDataSegment.value?.panelRenderer?.({
               slots,
               input: searchInput.value,

--- a/packages/pro/search/src/types/quickSelectPanel.ts
+++ b/packages/pro/search/src/types/quickSelectPanel.ts
@@ -11,6 +11,8 @@ import type { DefineComponent, HTMLAttributes, PropType } from 'vue'
 
 export const quickSelectPanelItemProps = {
   searchField: { type: Object as PropType<ResolvedSearchField>, required: true },
+  searchInputActive: Boolean,
+  setSearchInputActive: Function as PropType<(active: boolean) => void>,
 } as const
 
 export const quickSelectPanelShortcutProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在快捷面板的搜索项搜索输入框输入内容后，选中下方的选项，输入框被收起并清空

## What is the new behavior?
不应该收起并清空

## Other information
