### PR TITLE
fix(comp:tree-select): search input shouldn't be cleared after option checked

### DIFF
--- a/packages/components/tree-select/src/TreeSelect.tsx
+++ b/packages/components/tree-select/src/TreeSelect.tsx
@@ -94,9 +94,7 @@ export default defineComponent({
     }
 
     const handleNodeClick = () => {
-      if (props.multiple) {
-        clearInput()
-      } else {
+      if (!props.multiple) {
         setOverlayOpened(false)
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
多选时，勾选树节点之后，搜索输入会被清除

## What is the new behavior?
不应该清除

## Other information
