### PR TITLE
fix(comp:tree): checkedChange should be called after cascaderStrategy change

### DIFF
--- a/packages/components/tree/src/composables/useCheckable.ts
+++ b/packages/components/tree/src/composables/useCheckable.ts
@@ -148,6 +148,7 @@ export function useCheckable(
   watch(cascaderStrategy, () => {
     const newCheckedKeys = checkedStateResolver.appendKeys([], checkedKeys.value)
     setCheckedKeys(newCheckedKeys)
+    callChange(mergedNodeMap, newCheckedKeys, props.onCheckedChange)
   })
 
   return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当级联策略变化之后，checkedChange不会触发

## What is the new behavior?
级联策略变化之后，勾选的key会被重新计算，应该触发checkedChange通知外部更新数据

## Other information
