### PR TITLE
fix(cdk:resizable): position should be set at start of resizing

### DIFF
--- a/packages/cdk/resize/src/resizable/useResizable.ts
+++ b/packages/cdk/resize/src/resizable/useResizable.ts
@@ -125,10 +125,12 @@ export function useResizable(
 
   const handleResizeStart = (placement: ResizableHandlePlacement, evt: PointerEvent) => {
     activePlacement.value = placement
+    resizing.value = true
     const { width, height, left, top } = convertElement(target)!.getBoundingClientRect()
     const { clientX, clientY } = evt
     startPosition.value = { width, height, left, top, clientX, clientY }
     const position = { width, height, offsetWidth: 0, offsetHeight: 0 }
+    currPosition.value = position
     callEmit(options.onResizeStart, position, evt)
   }
 
@@ -138,7 +140,6 @@ export function useResizable(
       return
     }
     setBodyCursor(currPlacement)
-    resizing.value = true
 
     const { width: currWidth, height: currHeight } = calcSizeByEvent(currPlacement, evt)
     const { width: newWidth, height: newHeight } = calcSizeByBounds(currPlacement, currWidth, currHeight, -1)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 拖动开始的时候没有设置position，这期间如果元素的尺寸发生变化，之前记录的position并不会更新，如果仅仅点击边界不拖动，会让缩放异常进行
2. 只有在拖动的时候才设置resizing为true


## What is the new behavior?
拖动开始的时候就设置position，并设置 resizing 为 true

## Other information
