### PR TITLE
fix(comp:table): table cell border missing when row span included

### DIFF
--- a/packages/components/table/style/border.less
+++ b/packages/components/table/style/border.less
@@ -45,11 +45,18 @@
       border: @table-border;
 
       > table {
+        border-collapse: collapse;
         > thead > tr > th,
         > tbody > tr > td:not(:last-child),
         > tfoot > tr > th:not(:last-child),
         > tfoot > tr > td:not(:last-child) {
           border-right: @table-border;
+        }
+
+        > tbody > tr > td:last-child:not(:first-child),
+        > tfoot > tr > th:last-child:not(:first-child),
+        > tfoot > tr > td:last-child:not(:first-child) {
+          border-left: @table-border;
         }
 
         > thead > tr:first-child > th:last-child {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
配置了 borderless 为 false 后，当某个单元格的上一行的下一个列的单元格配置了 row-span 并覆盖了其所在的行，刚好在其后，此时该单元格应该有有边框，但目前有边框不会显示

## What is the new behavior?
修复以上问题

## Other information
