### PR TITLE
fix(pro:table): layout tool tree shouldn't show empty

### DIFF
--- a/packages/pro/table/src/contents/LayoutToolContent.tsx
+++ b/packages/pro/table/src/contents/LayoutToolContent.tsx
@@ -5,23 +5,38 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
+import type { TreeDragDropOptions } from '@idux/components/tree'
+
 import { computed, defineComponent, inject, normalizeClass } from 'vue'
 
-import { callEmit, useControlledProp } from '@idux/cdk/utils'
+import { type VKey, callEmit, filterTree, mapTree, useControlledProp } from '@idux/cdk/utils'
 import { ɵInput } from '@idux/components/_private/input'
 import { IxButton } from '@idux/components/button'
 import { IxCheckbox } from '@idux/components/checkbox'
+import { IxEmpty } from '@idux/components/empty'
 
 import LayoutToolTree from './LayoutToolTree'
 import { proTableToken } from '../token'
-import { type ProTableColumn, proTableLayoutToolContentProps } from '../types'
-import { loopColumns } from '../utils'
+import { type ProTableColumn, type ProTableColumnBase, proTableLayoutToolContentProps } from '../types'
+
+enum ToolTreeKey {
+  start,
+  center,
+  end,
+}
 
 export default defineComponent({
   props: proTableLayoutToolContentProps,
   setup(props) {
-    const { locale, mergedPrefixCls, mergedColumns, setMergedColumns, mergedColumnMap, resetColumns } =
-      inject(proTableToken)!
+    const {
+      locale,
+      mergedPrefixCls,
+      mergedColumns,
+      checkedColumnKeys,
+      setMergedColumns,
+      mergedColumnMap,
+      resetColumns,
+    } = inject(proTableToken)!
 
     // 判断是否有子节点，处理tree展开节点样式
     const hasChildren = computed(() => mergedColumns.value.length !== mergedColumnMap.value.size)
@@ -30,6 +45,29 @@ export default defineComponent({
     const hiddenColumns = computed(() => mergedColumns.value.filter(column => column.visible === false))
 
     const [searchValue, setSearchValue] = useControlledProp(props, 'searchValue')
+
+    const filteredColumns = computed(() => {
+      const lowerCasedSearchValue = searchValue.value?.toLowerCase()
+
+      return filterTree(
+        mergedColumns.value as (ProTableColumn & { children?: ProTableColumn[] })[],
+        'children',
+        column => {
+          if (column.layoutable === false) {
+            return false
+          }
+
+          if (!lowerCasedSearchValue) {
+            return true
+          }
+
+          const { title } = column as ProTableColumnBase
+
+          return title ? title.toLowerCase().includes(lowerCasedSearchValue) : false
+        },
+      ) as ProTableColumn[]
+    })
+    const groupedColumns = computed(() => groupColumns(filteredColumns.value))
 
     const handleInput = (evt: Event) => {
       const inputValue = (evt.target as HTMLInputElement).value
@@ -42,26 +80,91 @@ export default defineComponent({
     }
 
     const handleCheckAll = (checked: boolean) => {
-      loopColumns(mergedColumns.value, column => {
-        // use child cascaderStrategy，undefined or true
-        if (!column.children && column.changeVisible !== false) {
-          column.visible = checked
-        }
-      })
-      handleFixedChange()
+      const newColumns = mapTree(
+        mergedColumns.value as (ProTableColumn & { children?: ProTableColumn[] })[],
+        'children',
+        (column, parents) => {
+          const newColumn = { ...column } as ProTableColumn
+
+          if (
+            !column.children?.length &&
+            column.changeVisible !== false &&
+            column.layoutable !== false &&
+            parents.every(parent => parent.layoutable !== false)
+          ) {
+            newColumn.visible = checked
+          }
+
+          return newColumn
+        },
+      )
+
+      setMergedColumns(newColumns)
     }
 
-    const handleFixedChange = () => {
+    const handleFixedChange = (changedColumn: ProTableColumn, fixed: 'start' | 'end' | undefined) => {
+      const newColumns = mapTree(
+        mergedColumns.value as (ProTableColumn & { children?: ProTableColumn[] })[],
+        'children',
+        (column, parents) => {
+          const newColumn = { ...column } as ProTableColumn
+
+          if (column.key === changedColumn.key || parents.some(parent => parent.key === changedColumn.key)) {
+            newColumn.fixed = fixed
+          }
+
+          return newColumn
+        },
+      )
+
+      setMergedColumns(newColumns)
+    }
+
+    const handleVisibleChange = (showedKeySet: Set<VKey>, hiddenKeys: Set<VKey>) => {
+      const newColumns = mapTree(
+        mergedColumns.value as (ProTableColumn & { children?: ProTableColumn[] })[],
+        'children',
+        column => {
+          const newColumn = { ...column } as ProTableColumn
+          if (showedKeySet.has(column.key!)) {
+            newColumn.visible = true
+          }
+
+          if (hiddenKeys.has(column.key!)) {
+            newColumn.visible = false
+          }
+
+          return newColumn
+        },
+      )
+
+      setMergedColumns(newColumns)
+    }
+
+    const handleDrop = (key: ToolTreeKey, options: TreeDragDropOptions) => {
+      const { dragNode, dropNode, dropType } = options
+
+      const dragKey = dragNode?.key
+      const dropKey = dropNode?.key
+      if (!dragKey || !dropKey) {
+        return
+      }
+
       const { startColumns, centerColumns, endColumns } = groupColumns(mergedColumns.value)
-      setMergedColumns([...startColumns, ...centerColumns, ...endColumns])
-    }
 
-    const handleVisibleChange = () => {
-      setMergedColumns([...mergedColumns.value])
+      const processedColumns = [startColumns, centerColumns, endColumns].reduce((res, columns, index) => {
+        if (index === key) {
+          return res.concat(getDropColumns(columns, dragKey, dropKey, dropType))
+        }
+
+        return res.concat(columns)
+      }, [] as ProTableColumn[])
+
+      setMergedColumns(processedColumns)
     }
 
     return () => {
-      const { startColumns, centerColumns, endColumns } = groupColumns(mergedColumns.value)
+      const { startColumns, centerColumns, endColumns } = groupedColumns.value
 
       const hasStartFixed = startColumns.length > 0
       const hasEndFixed = endColumns.length > 0
@@ -75,15 +178,6 @@ export default defineComponent({
       })
 
       const { placeholder, all, reset, startPinTitle, noPinTitle, endPinTitle } = locale.table.layout
-      const handleDrop = (key: 'start' | 'center' | 'end', columns: ProTableColumn[]) => {
-        if (key === 'start') {
-          setMergedColumns([...columns, ...centerColumns, ...endColumns])
-        } else if (key === 'center') {
-          setMergedColumns([...startColumns, ...columns, ...endColumns])
-        } else {
-          setMergedColumns([...startColumns, ...centerColumns, ...columns])
-        }
-      }
 
       const settingLength = mergedColumns.value.length
       const hiddenLength = hiddenColumns.value.length
@@ -111,41 +205,48 @@ export default defineComponent({
               </IxButton>
             )}
           </div>
-          <div class={`${prefixCls}-tree-wrapper`}>
-            {hasStartFixed && (
-              <LayoutToolTree
-                key="start"
-                columns={startColumns}
-                searchValue={_searchValue}
-                title={startPinTitle}
-                onDrop={handleDrop}
-                onFixedChange={handleFixedChange}
-                onVisibleChange={handleVisibleChange}
-              />
-            )}
-            {(!withFixed || centerColumns.length > 0) && (
-              <LayoutToolTree
-                key="center"
-                columns={centerColumns}
-                searchValue={_searchValue}
-                title={withFixed ? noPinTitle : undefined}
-                onDrop={handleDrop}
-                onFixedChange={handleFixedChange}
-                onVisibleChange={handleVisibleChange}
-              />
-            )}
-            {hasEndFixed && (
-              <LayoutToolTree
-                key="end"
-                columns={endColumns}
-                searchValue={_searchValue}
-                title={endPinTitle}
-                onDrop={handleDrop}
-                onFixedChange={handleFixedChange}
-                onVisibleChange={handleVisibleChange}
-              />
-            )}
-          </div>
+          {filteredColumns.value.length ? (
+            <div class={`${prefixCls}-tree-wrapper`}>
+              {hasStartFixed && (
+                <LayoutToolTree
+                  key="start"
+                  columns={startColumns}
+                  checkedKeys={checkedColumnKeys.value.start}
+                  searchValue={_searchValue}
+                  title={startPinTitle}
+                  onDrop={(options: TreeDragDropOptions) => handleDrop(ToolTreeKey.start, options)}
+                  onFixedChange={handleFixedChange}
+                  onVisibleChange={handleVisibleChange}
+                />
+              )}
+              {(!withFixed || centerColumns.length > 0) && (
+                <LayoutToolTree
+                  key="center"
+                  columns={centerColumns}
+                  checkedKeys={checkedColumnKeys.value.center}
+                  searchValue={_searchValue}
+                  title={withFixed ? noPinTitle : undefined}
+                  onDrop={(options: TreeDragDropOptions) => handleDrop(ToolTreeKey.center, options)}
+                  onFixedChange={handleFixedChange}
+                  onVisibleChange={handleVisibleChange}
+                />
+              )}
+              {hasEndFixed && (
+                <LayoutToolTree
+                  key="end"
+                  columns={endColumns}
+                  checkedKeys={checkedColumnKeys.value.end}
+                  searchValue={_searchValue}
+                  title={endPinTitle}
+                  onDrop={(options: TreeDragDropOptions) => handleDrop(ToolTreeKey.end, options)}
+                  onFixedChange={handleFixedChange}
+                  onVisibleChange={handleVisibleChange}
+                />
+              )}
+            </div>
+          ) : (
+            <IxEmpty simple />
+          )}
         </div>
       )
     }
@@ -169,4 +270,52 @@ function groupColumns(mergedColumns: ProTableColumn[]) {
   })
 
   return { startColumns, endColumns, centerColumns }
+}
+
+function getDropColumns(columns: ProTableColumn[], dragKey: VKey, dropKey: VKey, dropType: string | undefined) {
+  const newColumns = [...columns]
+  // 原数据中移除被拖拽的节点
+  let dragColumn: ProTableColumn
+  findTargetColumn(newColumns, dragKey, (column, index, columns) => {
+    dragColumn = column
+    columns.splice(index, 1)
+  })
+
+  if (dropType === 'inside') {
+    findTargetColumn(newColumns, dropKey, item => {
+      // 添加到头部
+      ;(item as ProTableColumnBase).children!.unshift(dragColumn)
+    })
+  } else {
+    let targetIndex: number
+    let targetColumns: ProTableColumn[] = []
+
+    findTargetColumn(newColumns, dropKey, (_, index, columns) => {
+      targetIndex = index
+      targetColumns = columns
+    })
+
+    if (dropType === 'before') {
+      targetColumns.splice(targetIndex!, 0, dragColumn!)
+    } else {
+      targetColumns.splice(targetIndex! + 1, 0, dragColumn!)
+    }
+  }
+  return newColumns
+}
+
+function findTargetColumn(
+  columns: ProTableColumn[],
+  key: VKey,
+  callback: (column: ProTableColumn, index: number, columns: ProTableColumn[]) => void,
+) {
+  for (let index = 0; index < columns.length; index++) {
+    const column = columns[index]
+    if (column.key! === key) {
+      return callback(column, index, columns)
+    }
+    if ('children' in column && column.children) {
+      findTargetColumn(column.children, key, callback)
+    }
+  }
 }

--- a/packages/pro/table/src/types.ts
+++ b/packages/pro/table/src/types.ts
@@ -74,6 +74,7 @@ export interface ProTableColumnBase<T = any, K = VKey>
     ProTableColumnLayoutConfig {
   copyable?: boolean
   editable?: boolean
+  title?: string
   tooltip?: string | TooltipProps
   tooltipIcon?: string
 

--- a/packages/pro/table/src/utils/index.ts
+++ b/packages/pro/table/src/utils/index.ts
@@ -10,18 +10,6 @@ import { type ProTableLocale } from '@idux/pro/locales'
 
 import { type ProTableColumn } from '../types'
 
-export function loopColumns(columns: ProTableColumn[] | undefined, callback: (column: ProTableColumn) => void): void {
-  if (!columns || columns.length === 0) {
-    return
-  }
-  columns.forEach(column => {
-    callback(column)
-    if ('children' in column) {
-      loopColumns(column.children!, callback)
-    }
-  })
-}
-
 export function getColumnTitle(column: ProTableColumn, locale: ProTableLocale): string {
   const { title, type } = column
   if (title) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
布局工具中，当同时有固定列和普通列时，搜索内容为空会出现多个空状态

## What is the new behavior?
不应当展示多个空状态，只展示一个空状态

## Other information
