### PR TITLE
fix(comp:table): fixed end column z-index should be above fixed start columns

### DIFF
--- a/packages/components/table/style/fixed.less
+++ b/packages/components/table/style/fixed.less
@@ -1,9 +1,13 @@
 .@{table-prefix} {
   &-fix {
+    &-start {
+      z-index: 2;
+    }
+    &-end {
+      z-index: 3;
+    }
     &-start,
     &-end {
-      z-index: 2;
-
       td& {
         background-color: var(--ix-color-container-bg);
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
 固定列尾的列和固定在列首的列z-index一致，在表头分组的场景下，滚动之后列首的固定列可能会盖住列尾的固定列

## What is the new behavior?
修改以上问题

## Other information
