### PR TITLE
fix(comp:*): theme token css var getter is not supported in safari

### DIFF
--- a/packages/components/theme/src/utils/tokenToCss.ts
+++ b/packages/components/theme/src/utils/tokenToCss.ts
@@ -33,7 +33,23 @@ export function tokenToCss(record: TokenRecord<string>, prefix?: string, transfo
 }
 
 function getTokenCssVarName(tokenName: string): string {
-  return tokenName
-    .replace(/(?<![A-Z0-9])([A-Z0-9])/g, (input, upperChar) => (upperChar ? `-${upperChar.toLowerCase()}` : input))
-    .toLowerCase()
+  let name = ''
+  let preChar: string | undefined
+  for (let i = 0; i < tokenName.length; i++) {
+    const char = tokenName[i]
+
+    if (preChar && !isUppercaseOrNumber(preChar) && isUppercaseOrNumber(char)) {
+      name += `-${char}`
+    } else {
+      name += char
+    }
+
+    preChar = char
+  }
+  return name.toLowerCase()
+}
+
+function isUppercaseOrNumber(char: string) {
+  const charCode = char.charCodeAt(0)
+  return (charCode >= 65 && charCode <= 90) || (charCode >= 48 && charCode <= 57)
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
将主题token转换成css变量的正则表达式在safari下不兼容

## What is the new behavior?
修改转换函数，不再用正则实现

## Other information
