### PR TITLE
fix(comp:table): refactor table column width measure logic

### DIFF
--- a/packages/components/table/src/composables/useColumnOffsets.ts
+++ b/packages/components/table/src/composables/useColumnOffsets.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { VKey } from '@idux/cdk/utils'
+
+import { type ComputedRef, type Ref, computed } from 'vue'
+
+import { TableColumnMerged, TableColumnScrollBar } from './useColumns'
+
+export interface ColumnOffsetsContext {
+  columnOffsets: ComputedRef<{
+    starts: Record<VKey, { index: number; offset: number }>
+    ends: Record<VKey, { index: number; offset: number }>
+  }>
+  columnOffsetsWithScrollBar: ComputedRef<{
+    starts: Record<VKey, { index: number; offset: number }>
+    ends: Record<VKey, { index: number; offset: number }>
+  }>
+}
+
+export function useColumnOffsets(
+  fixedColumns: ComputedRef<{
+    fixedStartColumns: (TableColumnMerged | TableColumnScrollBar)[]
+    fixedEndColumns: (TableColumnMerged | TableColumnScrollBar)[]
+    fixedColumnIndexMap: Record<VKey, number>
+  }>,
+  columnWidthsMap: Ref<Record<VKey, number>>,
+  columnCount: Ref<number>,
+): ColumnOffsetsContext {
+  const columnOffsets = computed(() => {
+    const { fixedStartColumns, fixedEndColumns, fixedColumnIndexMap } = fixedColumns.value
+    return calculateOffsets(
+      fixedStartColumns,
+      fixedEndColumns.filter(column => column.type !== 'scroll-bar'),
+      fixedColumnIndexMap,
+      columnWidthsMap.value,
+      columnCount.value - 1,
+    )
+  })
+  const columnOffsetsWithScrollBar = computed(() => {
+    const { fixedStartColumns, fixedEndColumns, fixedColumnIndexMap } = fixedColumns.value
+    return calculateOffsets(
+      fixedStartColumns,
+      fixedEndColumns,
+      fixedColumnIndexMap,
+      columnWidthsMap.value,
+      columnCount.value,
+    )
+  })
+  return { columnOffsets, columnOffsetsWithScrollBar }
+}
+
+function calculateOffsets(
+  startColumns: (TableColumnMerged | TableColumnScrollBar)[],
+  endColumns: (TableColumnMerged | TableColumnScrollBar)[],
+  columnIndexMap: Record<VKey, number>,
+  columnWidthsMap: Record<VKey, number>,
+  columnCount: number,
+) {
+  const startOffsets: Record<VKey, { index: number; offset: number }> = {}
+  const endOffsets: Record<VKey, { index: number; offset: number }> = {}
+
+  let startOffset = 0
+  let endOffset = 0
+
+  for (let index = 0; index < startColumns.length; index++) {
+    const column = startColumns[index]
+    const width = columnWidthsMap[column.key] ?? column.width ?? 0
+
+    startOffsets[column.key] = { index: columnIndexMap[column.key] ?? index, offset: startOffset }
+    startOffset += width
+  }
+
+  for (let index = 0; index < endColumns.length; index++) {
+    const column = endColumns[endColumns.length - index - 1]
+    const width = columnWidthsMap[column.key] ?? column.width ?? 0
+
+    endOffsets[column.key] = { index: columnIndexMap[column.key] ?? columnCount - index - 1, offset: endOffset }
+    endOffset += width
+  }
+
+  return {
+    starts: startOffsets,
+    ends: endOffsets,
+  }
+}

--- a/packages/components/table/src/composables/useColumnWidthMeasure.ts
+++ b/packages/components/table/src/composables/useColumnWidthMeasure.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { TableColumnMerged } from './useColumns'
+import type { VKey } from '@idux/cdk/utils'
+
+import { type ComputedRef, type Ref, ref, watch } from 'vue'
+
+export interface ColumnWidthMeasureContext {
+  measuredColumnWidthMap: Ref<Record<VKey, number>>
+  changeColumnWidth: (key: VKey, width: number | false) => void
+}
+
+export function useColumnWidthMeasure(flattedColumns: ComputedRef<TableColumnMerged[]>): ColumnWidthMeasureContext {
+  const measuredColumnWidthMap = ref<Record<VKey, number>>({})
+
+  const changeColumnWidth = (key: VKey, width: number | false) => {
+    if (width === false) {
+      delete measuredColumnWidthMap.value[key]
+    } else {
+      measuredColumnWidthMap.value[key] = width
+    }
+  }
+
+  watch(flattedColumns, columns => {
+    const columnKeySet = new Set(columns.map(column => column.key))
+    Object.keys(measuredColumnWidthMap).forEach(key => {
+      if (!columnKeySet.has(key)) {
+        delete measuredColumnWidthMap.value[key]
+      }
+    })
+  })
+
+  return {
+    measuredColumnWidthMap,
+    changeColumnWidth,
+  }
+}

--- a/packages/components/table/src/main/ColGroup.tsx
+++ b/packages/components/table/src/main/ColGroup.tsx
@@ -17,8 +17,13 @@ import { TABLE_TOKEN } from '../token'
 export default defineComponent({
   props: { isFixedHolder: Boolean, columns: Array as PropType<TableColumnMerged[]> },
   setup(props) {
-    const { flattedColumns, flattedColumnsWithScrollBar, columnWidthMap, mergedSelectableMenus, mergedPrefixCls } =
-      inject(TABLE_TOKEN)!
+    const {
+      flattedColumns,
+      flattedColumnsWithScrollBar,
+      measuredColumnWidthMap,
+      mergedSelectableMenus,
+      mergedPrefixCls,
+    } = inject(TABLE_TOKEN)!
 
     const resolvedColumns = computed(() => {
       const { isFixedHolder, columns } = props
@@ -42,7 +47,7 @@ export default defineComponent({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const { key, type } = column
-        const mergedWidth = column.width ?? columnWidthMap.value[key]
+        const mergedWidth = props.isFixedHolder ? measuredColumnWidthMap.value[key] ?? column.width : column.width
         const className = type
           ? normalizeClass({
               [`${prefixCls}-col-${type}`]: true,

--- a/packages/components/table/src/main/body/BodyRowSingle.tsx
+++ b/packages/components/table/src/main/body/BodyRowSingle.tsx
@@ -11,13 +11,12 @@ import { type PropType, type VNodeChild, computed, defineComponent, inject } fro
 
 import { convertCssPixel } from '@idux/cdk/utils'
 
-import { TABLE_TOKEN, tableBodyToken } from '../../token'
+import { TABLE_TOKEN } from '../../token'
 
 export default defineComponent({
   props: { columns: Array as PropType<TableColumnMerged[]>, isEmpty: Boolean },
   setup(props, { slots }) {
-    const { mergedPrefixCls, hasFixed, scrollHorizontalOverflowed, scrollBarColumn } = inject(TABLE_TOKEN)!
-    const { mainTableWidth } = inject(tableBodyToken)!
+    const { clientWidth, mergedPrefixCls, hasFixed, scrollHorizontalOverflowed, scrollBarColumn } = inject(TABLE_TOKEN)!
     const columnCount = computed(() => props.columns?.length ?? 1)
     return () => {
       let children: VNodeChild = slots.default!()
@@ -28,7 +27,7 @@ export default defineComponent({
           <div
             class={`${mergedPrefixCls.value}-fixed-row`}
             style={{
-              width: convertCssPixel(mainTableWidth.value - (scrollBar ? scrollBar.width : 0)),
+              width: convertCssPixel(clientWidth.value - (scrollBar ? scrollBar.width : 0)),
               position: 'sticky',
               left: 0,
               overflow: 'hidden',

--- a/packages/components/table/src/token.ts
+++ b/packages/components/table/src/token.ts
@@ -5,6 +5,8 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
+import type { ColumnOffsetsContext } from './composables/useColumnOffsets'
+import type { ColumnWidthMeasureContext } from './composables/useColumnWidthMeasure'
 import type { ColumnsContext } from './composables/useColumns'
 import type { DataSourceContext } from './composables/useDataSource'
 import type { ExpandableContext } from './composables/useExpandable'
@@ -23,6 +25,8 @@ import type { ComputedRef, InjectionKey, Ref, Slots, VNodeChild } from 'vue'
 
 export interface TableContext
   extends ColumnsContext,
+    ColumnWidthMeasureContext,
+    ColumnOffsetsContext,
     DataSourceContext,
     ExpandableContext,
     PaginationContext,
@@ -36,6 +40,8 @@ export interface TableContext
   config: TableConfig
   locale: Locale
   getVirtualColWidth: (rowKey: VKey, colKey: VKey) => number | undefined
+  clientWidth: ComputedRef<number>
+  setClientWidth: (clientWidth: number) => void
   mergedPrefixCls: ComputedRef<string>
   mergedAutoHeight: ComputedRef<boolean>
   mergedEmptyCell: ComputedRef<string | ((options: TableEmptyCellOptions) => VNodeChild) | undefined>
@@ -50,7 +56,6 @@ export interface TableContext
 export const TABLE_TOKEN: InjectionKey<TableContext> = Symbol('TABLE_TOKEN')
 
 export interface TableBodyContext {
-  mainTableWidth: Ref<number>
   changeColumnWidth: (key: VKey, width: number | false) => void
 }
 


### PR DESCRIPTION
1. measured width should be used in table header fix holder
2. column width is evenly aligned when scroll.width is provided
3. table content colgroup width is set using width config in columns

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表头的colgroup也优先使用了column中给定的width，导致表头会有错位


## What is the new behavior?
重构宽度测量和计算逻辑，在表格体的colgroup中仅使用配置的宽度，而在固定的表头中和固定列的offset计算中使用测量得到的宽度

## Other information
