### PR TITLE
fix(cdk:virtual): render pool item reuse doesn't take effect

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
@@ -281,6 +281,8 @@ function createPool(): Pool {
       }
 
       pooledItemMap.delete(poolItem!.itemKey)
+
+      return poolItem!
     }
 
     return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
虚拟滚动下，列表或表格的dom或组件应该在离屏后被回收，并在新数据渲染时被复用，但并没有生效


## What is the new behavior?
修复以上问题

## Other information
renderPool的 getPoolItem 在找到可复用的item后没有返回，每次都重新创建了