### PR TITLE
fix(pro:tag-select): tag min width should be auto

### DIFF
--- a/packages/pro/tag-select/style/index.less
+++ b/packages/pro/tag-select/style/index.less
@@ -33,6 +33,7 @@
 
     &-tag {
       height: var(--ix-pro-tag-select-tag-height);
+      min-width: auto;
       line-height: calc(var(--ix-pro-tag-select-tag-height) - var(--ix-control-line-width) * 2);
 
       .@{control-trigger-prefix}-overlay-match-width & {
@@ -165,6 +166,7 @@
     height: @select-item-height;
     line-height: @select-item-line-height;
     max-width: 100%;
+    min-width: auto;
     margin: @select-margin-half 0;
     margin-inline-end: var(--ix-margin-size-xs);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
标签选择，面板选项中的标签以及选中的标签，都有一个最小宽度

## What is the new behavior?
取消最小宽度，配置 min-width: auto

## Other information
