### PR TITLE
fix(pro:tag-select): change creation option input font-weight to xl

### DIFF
--- a/packages/pro/tag-select/style/index.less
+++ b/packages/pro/tag-select/style/index.less
@@ -73,7 +73,7 @@
   &-creation {
     color: var(--ix-color-text);
     &-input {
-      font-weight: var(--ix-font-weight-lg);
+      font-weight: var(--ix-font-weight-xl);
       margin-left: var(--ix-margin-size-xs);
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
标签创建选项中的输入文字 font-weight 为 lg （500），效果不明显

## What is the new behavior?
修改为 xl （600）

## Other information
