### PR TITLE
fix(pro:tag-select): modify tag edit panel style

### DIFF
--- a/packages/pro/tag-select/src/content/TagDataEditPanel.tsx
+++ b/packages/pro/tag-select/src/content/TagDataEditPanel.tsx
@@ -111,6 +111,9 @@ export default defineComponent({
             <IxIcon class={`${prefixCls}-delete-icon`} name="delete" />
             <span class={`${prefixCls}-delete-label`}>{locale.remove}</span>
           </div>
+          <div class={`${prefixCls}-divider`}>
+            <div class={`${prefixCls}-divider-line`}></div>
+          </div>
           <div class={`${prefixCls}-colors`}>
             {mergedTagSelectColors.value.map(color => renderColorItem(`${prefixCls}-colors`, color))}
           </div>

--- a/packages/pro/tag-select/style/index.less
+++ b/packages/pro/tag-select/style/index.less
@@ -98,6 +98,24 @@
         color: var(--ix-color-icon);
         margin-right: var(--ix-margin-size-sm);
       }
+
+      &:hover {
+        background-color: var(--ix-color-container-bg-hover);
+      }
+      &:active,
+      &:hover:active {
+        background-color: var(--ix-color-container-bg-active);
+      }
+    }
+    &-divider {
+      width: 100%;
+      margin: var(--ix-margin-size-xs) 0;
+      padding: 0 var(--ix-padding-size-sm);
+      &-line {
+        width: calc(100%);
+        height: var(--ix-line-width);
+        background-color: var(--ix-color-separator);
+      }
     }
     &-colors {
       display: flex;
@@ -114,8 +132,8 @@
         padding: 0 var(--ix-padding-size-md);
         display: flex;
         align-items: center;
-        &:hover,
-        &-selected:hover {
+        cursor: pointer;
+        &:not(&-selected):hover {
           background-color: var(--ix-color-container-bg-hover);
         }
         &-selected {


### PR DESCRIPTION
1. add divider under delete button
2. selected color item hover color doesn't change
3. add hover and active bg color to delete button

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
1. 标签的删除按钮下增加分割线
2. 已经选中的颜色，悬浮不再变换背景颜色
3. 标签的删除按钮增加悬浮和激活颜色样式

## Other information
