### PR TITLE
fix(pro:tag-select): tag data remove confirm should be configuarable

### DIFF
--- a/packages/pro/tag-select/docs/Api.zh.md
+++ b/packages/pro/tag-select/docs/Api.zh.md
@@ -14,6 +14,7 @@
 | `dataEditable` | 标签数据是否可以编辑 | `boolean` | `true` | - | 配置true则可以在下拉面板的选项末尾点击编辑图标进行编辑 |
 | `disabled` | 是否禁用 | `boolean` | `false` | - | - |
 | `confirmBeforeSelect` | 是否在选择标签之后需要确认 | `boolean \| 'force'` | `false` | - | 配置true或者force时，选择标签后会弹出一个浮层进行确定或者取消，配置force则强制必须确定或者取消才能进行下一步 |
+| `confirmBeforeDataRemove` | 是否在删除标签数据时需要确认 | `boolean` | `false` | - | 配置true时，删除标签数据会弹出一个弹窗进行确定或者取消 |
 | `createdTagDataModifier` | 修改创建的标签数据 | `(data: TagSelectData) => TagSelectData` | - | - | 标签创建时，会随机选择一个内置的颜色，可以通过该函数修改内部创建的数据 |
 | `maxTags` | 选择框内展示的标签最大数量 | `number \| 'responsive'` | `Number.MAX_SAFE_INTEGER` | - | - |
 | `tagsLimit` | 可以选择的标签最大数量 | `number` | `Number.MAX_SAFE_INTEGER` | - | - |

--- a/packages/pro/tag-select/src/composables/useRemoveConfirm.ts
+++ b/packages/pro/tag-select/src/composables/useRemoveConfirm.ts
@@ -44,6 +44,12 @@ export function useRemoveConfirm(
       return Promise.resolve(false)
     }
 
+    if (!props.confirmBeforeDataRemove) {
+      removeData(data)
+      handleRemove(data.key)
+      return Promise.resolve(true)
+    }
+
     setLocked(true)
     setDataToRemove(data)
     setModalVisible(true)

--- a/packages/pro/tag-select/src/types.ts
+++ b/packages/pro/tag-select/src/types.ts
@@ -44,6 +44,7 @@ export const proTagSelectProps = {
   dataEditable: { type: Boolean, default: true },
   disabled: { type: Boolean, default: false },
   confirmBeforeSelect: { type: [Boolean, String] as PropType<boolean | 'force'>, default: false },
+  confirmBeforeDataRemove: { type: Boolean, default: true },
   maxTags: { type: [Number, String] as PropType<number | 'responsive'>, default: Number.MAX_SAFE_INTEGER },
   tagsLimit: { type: Number, default: Number.MAX_SAFE_INTEGER },
   tagDataLimit: { type: Number, default: Number.MAX_SAFE_INTEGER },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
新增 confirmBeforeDataRemove， 可以配置使标签数据的删除不需要弹窗确认

## Other information
