### PR TITLE
fix(pro:search): setting value before select option loaded throws error

### DIFF
--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -112,8 +112,11 @@ function formatValue(
   const values = convertArray(value)
 
   const dataKeyMap = new Map(mergedDataSource.map(data => [data.key, data]))
-  const newCacheData = values.map(value => dataKeyMap.get(value))
-  setCacheData(dataSourceCacheKey, newCacheData)
+  const newCacheData = values.map(value => dataKeyMap.get(value)).filter(Boolean)
+
+  if (newCacheData?.length) {
+    setCacheData(dataSourceCacheKey, newCacheData)
+  }
 
   if (concludeAllSelected && values.length > 0 && values.length >= mergedDataSource.length) {
     return allSelected


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索，select类型的field，如果先设置了 value， 之后才加载select的选项数据，会报错

## What is the new behavior?
修复以上问题

## Other information
format的时候会设置缓存，但设置缓存的时候没有过滤掉空数据
