### PR TITLE
fix(comp:theme): store theme style reference count on style element

### DIFF
--- a/packages/components/theme/src/utils/dynamicCss.ts
+++ b/packages/components/theme/src/utils/dynamicCss.ts
@@ -10,6 +10,7 @@ import type { ContainerType, DynamicCssOptions } from '../types'
 import { isBrowser } from '@idux/cdk/platform'
 
 const IDUX_THEME_KEY = 'idux-theme-key'
+const IDUX_THEME_REF_CNT_KEY = '__IDUX_THEME_REF_CNT__'
 
 function findStyles(container: ContainerType): HTMLStyleElement[] {
   return Array.from(container.children).filter(node => node.tagName === 'STYLE') as HTMLStyleElement[]
@@ -24,10 +25,20 @@ function getContainer(option: DynamicCssOptions): ContainerType {
   return head || document.body
 }
 
-function findExistNode(key: string, option: DynamicCssOptions = {}): HTMLStyleElement | undefined {
+export function findExistNode(key: string, option: DynamicCssOptions = {}): HTMLStyleElement | undefined {
   const container = getContainer(option)
 
   return findStyles(container).find(node => node.getAttribute(IDUX_THEME_KEY) === key)
+}
+
+export function getStyleRefCnt(node: HTMLStyleElement): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (node as any)[IDUX_THEME_REF_CNT_KEY] ?? 0
+}
+
+export function setStyleRefCnt(node: HTMLStyleElement, cnt: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(node as any)[IDUX_THEME_REF_CNT_KEY] = cnt
 }
 
 export function injectCSS(css: string, option: DynamicCssOptions = {}): HTMLStyleElement | null {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在微前端框架中，如果存在了两个版本的idux，子应用的themeProvider上下文销毁时，会清除掉全局的主题变量style元素

## What is the new behavior?
修复以上问题，将style元素的引用次数绑定在style元素上

## Other information
