### PR TITLE
fix(pro:search): input is formatted incorrectly after tree select leaf option unchecked

### DIFF
--- a/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
@@ -111,7 +111,7 @@ export function createTreeSelectSegment(
     inputClassName: [`${prefixCls}-tree-select-segment-input`],
     containerClassName: [`${prefixCls}-tree-select-segment-container`],
     parse: input => parseInput(input, config, nodeLabelMap),
-    format: (value, states) => formatValue(value, states, config, nodeKeyMap),
+    format: (value, states) => formatValue(value, states, config, nodeKeyMap, nodeLabelMap),
     panelRenderer,
   }
 }
@@ -134,6 +134,7 @@ function formatValue(
   states: SegmentState[] | undefined,
   config: TreeSelectSearchField['fieldConfig'],
   nodeKeyMap: Map<VKey, TreeSelectPanelData>,
+  nodeLabelMap: Map<string | number, TreeSelectPanelData[]>,
 ): string {
   const { separator, searchable } = config
   if (isNil(value)) {
@@ -147,7 +148,7 @@ function formatValue(
     const inputParts = states ? states[states.length - 1]?.input?.split(_separator) ?? [] : []
     const lastInputPart = inputParts[inputParts.length - 1]?.trim() as string | undefined
 
-    if (lastInputPart && !labels.includes(lastInputPart)) {
+    if (lastInputPart && !getKeyByLabels(nodeLabelMap, [lastInputPart]).length) {
       return [...labels, lastInputPart].join(` ${_separator} `)
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
tree-select 类型的搜索项，当取消勾选一个叶子节点后，搜索输入的解析不正确，被取消勾选的节点label被当作了搜索输入

## What is the new behavior?
修复以上问题

## Other information
