### PR TITLE
fix(cdk:popper): arrow position is incorrect after shift

### DIFF
--- a/packages/cdk/popper/src/convertOptions.ts
+++ b/packages/cdk/popper/src/convertOptions.ts
@@ -31,17 +31,20 @@ export function convertOptions(baseOptions: BaseOptions, extraOptions: ExtraOpti
   const { placement, strategy, middlewares, offset, autoAdjust } = baseOptions
   const { arrowElement, updatePlacement: _updatePlacement } = extraOptions
 
+  const { width } = arrowElement?.getBoundingClientRect() ?? {}
+  const arrowSize = width ? width / 2 : 0
+
   return {
     placement: kebabCase(placement) as Placement,
     strategy,
     middleware: [
+      autoAdjust && flip({ padding: 2 + arrowSize, crossAxis: false }),
+      autoAdjust && shift(),
       !!arrowElement && arrow(arrowElement),
       offsetMiddleware({
         mainAxis: offset[1],
         crossAxis: offset[0],
       }),
-      autoAdjust && flip({ padding: 2, crossAxis: false }),
-      autoAdjust && shift(),
       referenceHidden(),
       updatePlacement(_updatePlacement),
       ...middlewares,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
popper浮层的箭头位置，在shift中间件处理之后，会出现错位

## What is the new behavior?
修复以上问题

## Other information
