### PR TITLE
[WIP] fix(comp:table): column minWidth doesn't work in chrome under 80

### DIFF
--- a/packages/components/table/demo/Basic.vue
+++ b/packages/components/table/demo/Basic.vue
@@ -34,10 +34,12 @@ const columns: TableColumn<Data>[] = [
     title: 'Name',
     dataKey: 'name',
     customCell: 'name',
+    width: 150,
   },
   {
     title: 'Age',
     dataKey: 'age',
+    minWidth: 200,
     align: {
       title: 'start',
       cell: 'end',

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -20,6 +20,7 @@ import { useGetKey } from '@idux/components/utils'
 
 import { useColumnOffsets } from './composables/useColumnOffsets'
 import { useColumnWidthMeasure } from './composables/useColumnWidthMeasure'
+import { useColumnWidths } from './composables/useColumnWidths'
 import { type TableColumnMerged, useColumns } from './composables/useColumns'
 import { useDataSource } from './composables/useDataSource'
 import { useExpandable } from './composables/useExpandable'
@@ -77,12 +78,14 @@ export default defineComponent({
 
     const { flattedColumns, flattedColumnsWithScrollBar, fixedColumns } = columnsContext
 
+    const columnWidthMap = useColumnWidths(flattedColumns, scrollContext.scrollWidth, clientWidth)
+
     const columnMeasureContext = useColumnWidthMeasure(flattedColumns)
     const { measuredColumnWidthMap } = columnMeasureContext
 
     const columnCount = computed(() => flattedColumnsWithScrollBar.value.length)
 
-    const columnOffsetsContext = useColumnOffsets(fixedColumns, measuredColumnWidthMap, columnCount)
+    const columnOffsetsContext = useColumnOffsets(fixedColumns, measuredColumnWidthMap, columnWidthMap, columnCount)
     const sortableContext = useSortable(flattedColumns)
     const filterableContext = useFilterable(flattedColumns)
     const expandableContext = useExpandable(props, flattedColumns)
@@ -138,6 +141,7 @@ export default defineComponent({
       config,
       locale,
       clientWidth,
+      columnWidthMap,
       setClientWidth,
       mergedPrefixCls,
       mergedEmptyCell,

--- a/packages/components/table/src/composables/useColumnOffsets.ts
+++ b/packages/components/table/src/composables/useColumnOffsets.ts
@@ -28,7 +28,8 @@ export function useColumnOffsets(
     fixedEndColumns: (TableColumnMerged | TableColumnScrollBar)[]
     fixedColumnIndexMap: Record<VKey, number>
   }>,
-  columnWidthsMap: Ref<Record<VKey, number>>,
+  measuredColumnWidthMap: Ref<Record<VKey, number>>,
+  columnWidthMap: ComputedRef<Map<VKey, number | string | undefined>>,
   columnCount: Ref<number>,
 ): ColumnOffsetsContext {
   const columnOffsets = computed(() => {
@@ -37,8 +38,9 @@ export function useColumnOffsets(
       fixedStartColumns,
       fixedEndColumns.filter(column => column.type !== 'scroll-bar'),
       fixedColumnIndexMap,
-      columnWidthsMap.value,
+      columnWidthMap.value,
       columnCount.value - 1,
+      measuredColumnWidthMap.value,
     )
   })
   const columnOffsetsWithScrollBar = computed(() => {
@@ -47,8 +49,9 @@ export function useColumnOffsets(
       fixedStartColumns,
       fixedEndColumns,
       fixedColumnIndexMap,
-      columnWidthsMap.value,
+      columnWidthMap.value,
       columnCount.value,
+      measuredColumnWidthMap.value,
     )
   })
   return { columnOffsets, columnOffsetsWithScrollBar }
@@ -58,8 +61,9 @@ function calculateOffsets(
   startColumns: (TableColumnMerged | TableColumnScrollBar)[],
   endColumns: (TableColumnMerged | TableColumnScrollBar)[],
   columnIndexMap: Record<VKey, number>,
-  columnWidthsMap: Record<VKey, number>,
+  columnWidthMap: Map<VKey, number | string | undefined>,
   columnCount: number,
+  measuredColumnWidthMap: Record<VKey, number>,
 ) {
   const startOffsets: Record<VKey, { index: number; offset: number }> = {}
   const endOffsets: Record<VKey, { index: number; offset: number }> = {}
@@ -69,7 +73,7 @@ function calculateOffsets(
 
   for (let index = 0; index < startColumns.length; index++) {
     const column = startColumns[index]
-    const width = columnWidthsMap[column.key] ?? column.width ?? 0
+    const width = measuredColumnWidthMap[column.key] ?? columnWidthMap.get(column.key) ?? 0
 
     startOffsets[column.key] = { index: columnIndexMap[column.key] ?? index, offset: startOffset }
     startOffset += width
@@ -77,7 +81,7 @@ function calculateOffsets(
 
   for (let index = 0; index < endColumns.length; index++) {
     const column = endColumns[endColumns.length - index - 1]
-    const width = columnWidthsMap[column.key] ?? column.width ?? 0
+    const width = measuredColumnWidthMap[column.key] ?? columnWidthMap.get(column.key) ?? 0
 
     endOffsets[column.key] = { index: columnIndexMap[column.key] ?? columnCount - index - 1, offset: endOffset }
     endOffset += width

--- a/packages/components/table/src/composables/useColumnWidths.ts
+++ b/packages/components/table/src/composables/useColumnWidths.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
+ */
+
+import type { TableColumnMerged } from './useColumns'
+import type { VKey } from '@idux/cdk/utils'
+
+import { type ComputedRef, computed } from 'vue'
+
+export function useColumnWidths(
+  flattenedColumns: ComputedRef<TableColumnMerged[]>,
+  scrollWidth: ComputedRef<string>,
+  clientWidth: ComputedRef<number>,
+): ComputedRef<Map<VKey, number | string | undefined>> {
+  return computed(() => {
+    const maxFitWidth = scrollWidth.value ? parseScrollWidth(scrollWidth.value) : clientWidth.value
+    if (!maxFitWidth || maxFitWidth <= 0 || !flattenedColumns.value.some(column => !!column.minWidth)) {
+      return new Map(flattenedColumns.value.map(column => [column.key, column.width]))
+    }
+
+    let totalWidth = 0
+    let missedColumnCnt = 0
+    const minWidthColumns: TableColumnMerged[] = []
+    const widthMap = new Map<VKey, number | string | undefined>()
+
+    flattenedColumns.value.forEach(col => {
+      const colWidth = parseColWidth(maxFitWidth, col.width)
+
+      if (colWidth) {
+        totalWidth += colWidth
+        widthMap.set(col.key, col.width)
+      } else {
+        missedColumnCnt++
+
+        if (col.minWidth) {
+          minWidthColumns.push(col)
+        }
+      }
+    })
+
+    let restWidth = Math.max(maxFitWidth - totalWidth, missedColumnCnt)
+    let avgWidth = Math.floor(restWidth / missedColumnCnt)
+
+    minWidthColumns.forEach(col => {
+      const parsedMinWidth = parseColWidth(totalWidth, col.minWidth)
+
+      if (parsedMinWidth && parsedMinWidth > avgWidth) {
+        widthMap.set(col.key, parsedMinWidth)
+        restWidth -= parsedMinWidth
+        missedColumnCnt--
+        avgWidth = Math.floor(restWidth / missedColumnCnt)
+      }
+    })
+
+    return widthMap
+  })
+}
+
+function parseScrollWidth(scrollWidth: string) {
+  if (scrollWidth.endsWith('px')) {
+    const parsedWidth = parseFloat(scrollWidth)
+    return Number.isNaN(parsedWidth) ? null : parsedWidth
+  }
+
+  return null
+}
+
+function parseColWidth(totalWidth: number, width: string | number = '') {
+  if (typeof width === 'number') {
+    return width
+  }
+
+  if (width.endsWith('%')) {
+    const parsedWidth = (totalWidth * parseFloat(width)) / 100
+    return Number.isNaN(parsedWidth) ? null : parsedWidth
+  }
+  return null
+}

--- a/packages/components/table/src/main/ColGroup.tsx
+++ b/packages/components/table/src/main/ColGroup.tsx
@@ -20,6 +20,7 @@ export default defineComponent({
     const {
       flattedColumns,
       flattedColumnsWithScrollBar,
+      columnWidthMap,
       measuredColumnWidthMap,
       mergedSelectableMenus,
       mergedPrefixCls,
@@ -47,7 +48,9 @@ export default defineComponent({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const { key, type } = column
-        const mergedWidth = props.isFixedHolder ? measuredColumnWidthMap.value[key] ?? column.width : column.width
+        const mergedWidth = props.isFixedHolder
+          ? measuredColumnWidthMap.value[key] ?? columnWidthMap.value.get(key)
+          : columnWidthMap.value.get(key)
         const className = type
           ? normalizeClass({
               [`${prefixCls}-col-${type}`]: true,

--- a/packages/components/table/src/token.ts
+++ b/packages/components/table/src/token.ts
@@ -41,6 +41,7 @@ export interface TableContext
   locale: Locale
   getVirtualColWidth: (rowKey: VKey, colKey: VKey) => number | undefined
   clientWidth: ComputedRef<number>
+  columnWidthMap: ComputedRef<Map<VKey, number | string | undefined>>
   setClientWidth: (clientWidth: number) => void
   mergedPrefixCls: ComputedRef<string>
   mergedAutoHeight: ComputedRef<boolean>

--- a/packages/components/table/src/types.ts
+++ b/packages/components/table/src/types.ts
@@ -96,6 +96,7 @@ export interface TableColumnCommon<T = any> {
   fixed?: TableColumnFixed
   titleColSpan?: number
   width?: string | number
+  minWidth?: number
 }
 
 export interface TableColumnBase<T = any, K = VKey> extends TableColumnCommon<T> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在低版本 chrome 和safari下，列的 minWidth 不生效

## What is the new behavior?
修复以上问题

## Other information
