### PR TITLE
fix(comp:tree-select): removing item in selector doesn't work

### DIFF
--- a/packages/components/_private/overlay/src/Overlay.tsx
+++ b/packages/components/_private/overlay/src/Overlay.tsx
@@ -151,7 +151,7 @@ export default defineComponent({
       return (
         <>
           {trigger}
-          <CdkPortal target={mergedContainer.value} load={visibility.value}>
+          <CdkPortal target={mergedContainer.value} load={props.lazy ? visibility.value : true}>
             <Transition appear name={props.transitionName} onAfterLeave={onAfterLeave}>
               {content}
             </Transition>

--- a/packages/components/_private/overlay/src/types.ts
+++ b/packages/components/_private/overlay/src/types.ts
@@ -50,6 +50,10 @@ export const overlayProps = {
     type: Boolean,
     default: undefined,
   },
+  lazy: {
+    type: Boolean,
+    default: true,
+  },
   offset: Array as unknown as PropType<[number, number]>,
   showArrow: {
     type: Boolean,

--- a/packages/components/control-trigger/src/ControlTrigger.tsx
+++ b/packages/components/control-trigger/src/ControlTrigger.tsx
@@ -174,6 +174,7 @@ export default defineComponent({
         class={overlayClasses.value}
         style={overlayStyle.value}
         visible={overlayOpened.value}
+        lazy={props.overlayLazy}
         trigger="manual"
         v-slots={{ default: renderTrigger, content: renderContent }}
       />

--- a/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
+++ b/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
@@ -37,6 +37,7 @@ export default defineComponent({
         containerFallback:
           controlTriggerProps.overlayContainerFallback ?? `.${mergedPrefixCls.value}-overlay-container`,
         disabled: controlTriggerProps.disabled || controlTriggerProps.readonly,
+        lazy: props.lazy ?? controlTriggerProps.overlayLazy,
         offset: controlTriggerProps.offset ?? defaultOffset,
         placement: props.placement ?? 'bottomStart',
         showArrow: props.showArrow,

--- a/packages/components/control-trigger/src/types.ts
+++ b/packages/components/control-trigger/src/types.ts
@@ -24,6 +24,7 @@ export const controlTriggerProps = {
     default: undefined,
   },
   overlayContainerFallback: String,
+  overlayLazy: { type: Boolean, default: true },
   overlayMatchWidth: { type: [Boolean, String] as PropType<boolean | 'minWidth'>, default: undefined },
 
   // events
@@ -35,6 +36,10 @@ export const controlTriggerProps = {
 
 export const controlTrigglerOverlayProps = {
   visible: {
+    type: Boolean,
+    default: undefined,
+  },
+  lazy: {
     type: Boolean,
     default: undefined,
   },

--- a/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
+++ b/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
@@ -67,7 +67,9 @@ exports[`TreeSelect > single work > searchFn work 1`] = `
   </div>
   <div class=\\"ix-trigger-suffix\\"><i class=\\"ix-icon ix-icon-down\\" role=\\"img\\" aria-label=\\"down\\"></i></div>
   <!---->
-</div>"
+</div>
+<!--teleport start-->
+<!--teleport end-->"
 `;
 
 exports[`TreeSelect > single work > searchFn work 2`] = `
@@ -85,7 +87,9 @@ exports[`TreeSelect > single work > searchFn work 2`] = `
         <path d=\\"M503.234 694.123 249.575 440.464c-4.998-4.998-5.001-12.869-.003-17.867l27.39-27.39c5-5 12.927-4.939 17.926.06l217.281 217.281 217.281-217.28c4.999-5 12.927-5.06 17.925-.062l27.39 27.39c5 5 4.996 12.87-.002 17.868L521.104 694.123c-4.998 4.998-12.872 4.998-17.87 0Z\\"></path>
       </svg></i></div>
   <!---->
-</div>"
+</div>
+<!--teleport start-->
+<!--teleport end-->"
 `;
 
 exports[`TreeSelect > single work > searchFn work 3`] = `
@@ -103,7 +107,9 @@ exports[`TreeSelect > single work > searchFn work 3`] = `
         <path d=\\"M503.234 694.123 249.575 440.464c-4.998-4.998-5.001-12.869-.003-17.867l27.39-27.39c5-5 12.927-4.939 17.926.06l217.281 217.281 217.281-217.28c4.999-5 12.927-5.06 17.925-.062l27.39 27.39c5 5 4.996 12.87-.002 17.868L521.104 694.123c-4.998 4.998-12.872 4.998-17.87 0Z\\"></path>
       </svg></i></div>
   <!---->
-</div>"
+</div>
+<!--teleport start-->
+<!--teleport end-->"
 `;
 
 exports[`TreeSelect > single work > searchable work 1`] = `

--- a/packages/components/tree-select/src/TreeSelect.tsx
+++ b/packages/components/tree-select/src/TreeSelect.tsx
@@ -190,6 +190,7 @@ export default defineComponent({
         clearable: props.clearable,
         clearIcon: props.clearIcon,
         disabled: accessor.disabled || props.readonly,
+        overlayLazy: false,
         readonly: props.readonly,
         value: selectedValue.value,
         open: overlayOpened.value,


### PR DESCRIPTION
when tree in overlay isn't rendered yet, removing item in selector doesn't work

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在tree-select的浮层还没有渲染时，点击删除选择框中的选中标签不会生效

## What is the new behavior?
修复以上问题

## Other information
overlay增加了lazy配置，可以配置是否懒渲染浮层内容