### PR TITLE
fix(comp:*): overlay border color token is invalid

### DIFF
--- a/packages/components/back-top/docs/Theme.zh.md
+++ b/packages/components/back-top/docs/Theme.zh.md
@@ -1,7 +1,7 @@
 | 名称 | 描述 | 类型 | default | dark |
 |---|---|---|---|---|
 | `bgColor` |  | `string` | `#ffffff` | `#0A0C0F` |
-| `borderColor` |  | `string` | `none` | `#1F2329` |
+| `borderColor` |  | `string` | `transparent` | `#1F2329` |
 | `borderType` |  | `string` | `solid` | `solid` |
 | `borderWidth` |  | `number` | `0` | `1` |
 | `boxShadow` |  | `string` | `0 2px 8px 0 rgba(0, 0, 0, 0.05)` | `0 2px 8px 0 rgba(0, 0, 0, 0.05)` |

--- a/packages/components/back-top/theme/default.css
+++ b/packages/components/back-top/theme/default.css
@@ -9,5 +9,5 @@
   --ix-back-top-bg-color: #ffffff;
   --ix-back-top-border-width: 0;
   --ix-back-top-border-type: solid;
-  --ix-back-top-border-color: none;
+  --ix-back-top-border-color: transparent;
 }

--- a/packages/components/default.css
+++ b/packages/components/default.css
@@ -246,7 +246,7 @@
   --ix-overlay-arrow-size: 6px;
   --ix-overlay-border-radius: 2px;
   --ix-overlay-border-width: 0;
-  --ix-overlay-border-color: none;
+  --ix-overlay-border-color: transparent;
   --ix-overlay-border-type: solid;
 }
 :root {

--- a/packages/components/default.full.css
+++ b/packages/components/default.full.css
@@ -246,7 +246,7 @@
   --ix-overlay-arrow-size: 6px;
   --ix-overlay-border-radius: 2px;
   --ix-overlay-border-width: 0;
-  --ix-overlay-border-color: none;
+  --ix-overlay-border-color: transparent;
   --ix-overlay-border-type: solid;
 }
 :root {
@@ -316,7 +316,7 @@
   --ix-back-top-bg-color: #ffffff;
   --ix-back-top-border-width: 0;
   --ix-back-top-border-type: solid;
-  --ix-back-top-border-color: none;
+  --ix-back-top-border-color: transparent;
 }
 
 /* ------ badge css variables ------ */
@@ -542,7 +542,7 @@
     0 -9px 28px 0 rgba(0, 0, 0, 0.05), 0 -12px 48px 16px rgba(0, 0, 0, 0.03);
   --ix-drawer-border-width: 0;
   --ix-drawer-border-type: solid;
-  --ix-drawer-border-color: none;
+  --ix-drawer-border-color: transparent;
 }
 
 /* ------ dropdown css variables ------ */
@@ -668,7 +668,7 @@
   --ix-message-font-size: 14px;
   --ix-message-border-width: 0;
   --ix-message-border-type: solid;
-  --ix-message-border-color: none;
+  --ix-message-border-color: transparent;
   --ix-message-content-min-width: 128px;
   --ix-message-content-max-width: 480px;
   --ix-message-content-padding-vertical: 8px;
@@ -697,7 +697,7 @@
   --ix-notification-max-width: calc(100vw - 48px);
   --ix-notification-border-width: 0;
   --ix-notification-border-type: solid;
-  --ix-notification-border-color: none;
+  --ix-notification-border-color: transparent;
   --ix-notification-font-size: 14px;
   --ix-notification-bg-color: #ffffff;
   --ix-notification-border-radius: 2px;

--- a/packages/components/drawer/docs/Theme.zh.md
+++ b/packages/components/drawer/docs/Theme.zh.md
@@ -1,6 +1,6 @@
 | 名称 | 描述 | 类型 | default | dark |
 |---|---|---|---|---|
-| `borderColor` |  | `string` | `none` | `#1F2329` |
+| `borderColor` |  | `string` | `transparent` | `#1F2329` |
 | `borderType` |  | `string` | `solid` | `solid` |
 | `borderWidth` |  | `number` | `0` | `1` |
 | `boxShadowEnd` |  | `string` | `-6px 0 16px -8px rgba(0, 0, 0, 0.08), -9px 0 28px 0 rgba(0, 0, 0, 0.05), -12px 0 48px 16px rgba(0, 0, 0, 0.03)` | `-6px 0 16px -8px rgba(0, 0, 0, 0.08), -9px 0 28px 0 rgba(0, 0, 0, 0.05), -12px 0 48px 16px rgba(0, 0, 0, 0.03)` |

--- a/packages/components/drawer/theme/default.css
+++ b/packages/components/drawer/theme/default.css
@@ -8,5 +8,5 @@
     0 -9px 28px 0 rgba(0, 0, 0, 0.05), 0 -12px 48px 16px rgba(0, 0, 0, 0.03);
   --ix-drawer-border-width: 0;
   --ix-drawer-border-type: solid;
-  --ix-drawer-border-color: none;
+  --ix-drawer-border-color: transparent;
 }

--- a/packages/components/message/docs/Theme.zh.md
+++ b/packages/components/message/docs/Theme.zh.md
@@ -1,7 +1,7 @@
 | 名称 | 描述 | 类型 | default | dark |
 |---|---|---|---|---|
 | `bgColor` |  | `string` | `#ffffff` | `#0A0C0F` |
-| `borderColor` |  | `string` | `none` | `#1F2329` |
+| `borderColor` |  | `string` | `transparent` | `#1F2329` |
 | `borderRadius` |  | `number` | `4` | `4` |
 | `borderType` |  | `string` | `solid` | `solid` |
 | `borderWidth` |  | `number` | `0` | `1` |

--- a/packages/components/message/theme/default.css
+++ b/packages/components/message/theme/default.css
@@ -4,7 +4,7 @@
   --ix-message-font-size: 14px;
   --ix-message-border-width: 0;
   --ix-message-border-type: solid;
-  --ix-message-border-color: none;
+  --ix-message-border-color: transparent;
   --ix-message-content-min-width: 128px;
   --ix-message-content-max-width: 480px;
   --ix-message-content-padding-vertical: 8px;

--- a/packages/components/notification/docs/Theme.zh.md
+++ b/packages/components/notification/docs/Theme.zh.md
@@ -1,7 +1,7 @@
 | 名称 | 描述 | 类型 | default | dark |
 |---|---|---|---|---|
 | `bgColor` |  | `string` | `#ffffff` | `#0A0C0F` |
-| `borderColor` |  | `string` | `none` | `#1F2329` |
+| `borderColor` |  | `string` | `transparent` | `#1F2329` |
 | `borderRadius` |  | `number` | `2` | `2` |
 | `borderType` |  | `string` | `solid` | `solid` |
 | `borderWidth` |  | `number` | `0` | `1` |

--- a/packages/components/notification/theme/default.css
+++ b/packages/components/notification/theme/default.css
@@ -6,7 +6,7 @@
   --ix-notification-max-width: calc(100vw - 48px);
   --ix-notification-border-width: 0;
   --ix-notification-border-type: solid;
-  --ix-notification-border-color: none;
+  --ix-notification-border-color: transparent;
   --ix-notification-font-size: 14px;
   --ix-notification-bg-color: #ffffff;
   --ix-notification-border-radius: 2px;

--- a/packages/components/theme/src/themeTokens/shared/extendedTokens/getOverlayTokens.ts
+++ b/packages/components/theme/src/themeTokens/shared/extendedTokens/getOverlayTokens.ts
@@ -15,7 +15,7 @@ export function getOverlayTokens(tokens: BasicTokens & DerivedTokens & ExtendedC
     overlayArrowSize: arrowSize,
     overlayBorderRadius: borderRadiusSm,
     overlayBorderWidth: 0,
-    overlayBorderColor: 'none',
+    overlayBorderColor: 'transparent',
     overlayBorderType: lineType,
   }
 }

--- a/packages/site/src/docs/CustomizeTheme.zh.md
+++ b/packages/site/src/docs/CustomizeTheme.zh.md
@@ -547,7 +547,7 @@ token `getter` 只会在第一次注册成功的时候实际执行，因此不�
 | `fontWeightHeader` | 头部字体粗度 | `number` | `600` | `600` |
 | `overlayArrowSize` | 浮层箭头尺寸 | `number` | `6` | `6` |
 | `overlayBgColor` | 浮层背景颜色 | `string` | `#ffffff` | `#0A0C0F` |
-| `overlayBorderColor` | 浮层边框颜色 | `string` | `none` | `#1F2329` |
+| `overlayBorderColor` | 浮层边框颜色 | `string` | `transparent` | `#1F2329` |
 | `overlayBorderRadius` | 浮层边框圆角 | `string | number` | `2` | `2` |
 | `overlayBorderType` | 浮层边框样式 | `string` | `solid` | `solid` |
 | `overlayBorderWidth` | 浮层边框宽度 | `number` | `0` | `1` |


### PR DESCRIPTION
`border-color: none` is invalid，use `transparent` instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
overlayBorderColor 主题token 不正确
borderColor 不能是 `none`，不合法

## What is the new behavior?
修改为 `transparent`

## Other information
