### PR TITLE
fix(pro:table): check in layout tool after search doesn't work

### DIFF
--- a/packages/pro/table/src/contents/LayoutToolTree.tsx
+++ b/packages/pro/table/src/contents/LayoutToolTree.tsx
@@ -6,10 +6,10 @@
  */
 
 import type { ProTableColumn } from '../types'
-import type { VKey } from '@idux/cdk/utils'
 
-import { type PropType, defineComponent, inject } from 'vue'
+import { type PropType, computed, defineComponent, inject } from 'vue'
 
+import { type VKey, getTreeKeys } from '@idux/cdk/utils'
 import { IxIcon } from '@idux/components/icon'
 import { IxTree, type TreeDragDropOptions, type TreeProps } from '@idux/components/tree'
 
@@ -35,9 +35,21 @@ export default defineComponent({
   setup(props) {
     const { locale, mergedPrefixCls } = inject(proTableToken)!
 
+    const columnKeys = computed(
+      () =>
+        new Set(
+          getTreeKeys(
+            props.columns as (ProTableColumn & { children?: ProTableColumn[] })[],
+            'children',
+            data => data.key!,
+            true,
+          ),
+        ),
+    )
+
     const onCheckedChange = (checkedKeys: VKey[]) => {
       const visibleKeySet = new Set(checkedKeys)
-      const oldVisibleKeys = new Set(props.checkedKeys)
+      const oldVisibleKeys = new Set(props.checkedKeys.filter(key => columnKeys.value.has(key)))
 
       checkedKeys.forEach(key => {
         if (oldVisibleKeys.has(key)) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
布局工具中，在搜索之后，勾选或者取消勾选搜索到的列，会使表格的列显示异常变化

## What is the new behavior?
修复以上问题

## Other information
