### PR TITLE
fix(cdk:scroll): pool item not recycled index isn't right

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
@@ -91,26 +91,9 @@ export function useRenderPool(
 
     updated = !!inactiveKeys.size
 
-    const poolKeyMap = new Map(items.map(item => [item.itemKey, item.key]))
+    const poolMap = new Map(items.map(item => [item.itemKey, item]))
     const poolKeySet = new Set(items.map(item => item.key))
     const newlyAppendedItems: { item: unknown; index: number; itemKey: VKey }[] = []
-
-    for (let index = start; index <= end; index++) {
-      const item = data[index]
-      if (!item) {
-        continue
-      }
-
-      const itemKey = getKey.value(item)
-      const existedPoolItemKey = poolKeyMap.get(itemKey)
-
-      // item still active, continue
-      if (!isNil(existedPoolItemKey) && !inactiveKeys.has(existedPoolItemKey)) {
-        continue
-      }
-
-      newlyAppendedItems.push({ item, index, itemKey })
-    }
 
     const updatePoolItem = (poolItem: PoolItem, item: unknown, index: number, itemKey: VKey) => {
       poolItem.item = item
@@ -124,6 +107,24 @@ export function useRenderPool(
       if (!poolKeySet.has(poolItem.key)) {
         items.push(poolItem)
       }
+    }
+
+    for (let index = start; index <= end; index++) {
+      const item = data[index]
+      if (!item) {
+        continue
+      }
+
+      const itemKey = getKey.value(item)
+      const existedPoolItem = poolMap.get(itemKey)
+
+      // item still active, continue
+      if (!isNil(existedPoolItem) && !inactiveKeys.has(existedPoolItem.key)) {
+        updatePoolItem(existedPoolItem, item, index, itemKey)
+        continue
+      }
+
+      newlyAppendedItems.push({ item, index, itemKey })
     }
 
     let i = 0


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在下一次渲染时，在上一次渲染过程中已经存在的元素不会被更新，导致其index没有变化
proTable中，勾选某一个默认隐藏的列，在开启虚拟滚动的情况下，向下滚动会导致列的渲染顺序不正常

## What is the new behavior?
即使是重复渲染的元素，也应该重新赋值index和数据，因为其顺序和渲染的数据可能会发生变化

## Other information
