### PR TITLE
fix(comp:tabs): line type bar offset error after tab title updates

### DIFF
--- a/packages/components/tabs/src/composables/useSelectedNav.ts
+++ b/packages/components/tabs/src/composables/useSelectedNav.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import { type ComputedRef, type ShallowRef, nextTick, onMounted, watch } from 'vue'
+import { type ComputedRef, type Ref, type ShallowRef, nextTick, onMounted, watch } from 'vue'
 
 import { useResizeObserver } from '@idux/cdk/resize'
 import { VKey, useState } from '@idux/cdk/utils'
@@ -22,6 +22,7 @@ export function useSelectedNav(
   selectedNavRef: ShallowRef<HTMLElement | undefined>,
   isHorizontal: ComputedRef<boolean>,
   closedKeys: ComputedRef<VKey[]>,
+  navAttrs: Ref<Record<VKey, { offset: number; size: number } | undefined>>,
 ): SelectedNavContext {
   const [selectedNavSize, setSelectedNavSize] = useState(0)
   const [selectedNavOffset, setSelectedNavOffset] = useState(0)
@@ -44,6 +45,7 @@ export function useSelectedNav(
 
   onMounted(() => {
     watch([() => props.dataSource, closedKeys, selectedNavRef], updateSelectedNavOffset, { immediate: true })
+    watch(navAttrs, updateSelectedNavOffset, { deep: true })
   })
 
   return {

--- a/packages/components/tabs/src/contents/TabNavWrapper.tsx
+++ b/packages/components/tabs/src/contents/TabNavWrapper.tsx
@@ -43,7 +43,13 @@ export default defineComponent({
     const operationsRef = shallowRef<HTMLElement>()
     const selectedNavRef = shallowRef<HTMLElement>()
 
-    const { selectedNavSize, selectedNavOffset } = useSelectedNav(tabsProps, selectedNavRef, isHorizontal, closedKeys)
+    const { selectedNavSize, selectedNavOffset } = useSelectedNav(
+      tabsProps,
+      selectedNavRef,
+      isHorizontal,
+      closedKeys,
+      navAttrs,
+    )
     const { hasScroll, scrolledStart, scrolledEnd, pre, next } = useNavListScroll(
       navListRef,
       navListInnerRef,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
tabs的title在更新的时候，有可能会导致整体tabs导航栏的尺寸发生变化，此时在 line 类型下，下方的横线位置计算不正确

## What is the new behavior?
修复以上问题

## Other information
