### PR TITLE
fix(comp:popconfirm): content padding should be different when no header icon rendered

### DIFF
--- a/packages/components/popconfirm/src/PopconfirmContent.tsx
+++ b/packages/components/popconfirm/src/PopconfirmContent.tsx
@@ -36,6 +36,7 @@ export default defineComponent({
       const contentNode = slots.content ? slots.content() : props.content
       const classes = normalizeClass({
         [`${prefixCls}-wrapper`]: true,
+        [`${prefixCls}-with-icon`]: !!iconNode,
         [`${prefixCls}-with-content`]: !!contentNode,
       })
       return (

--- a/packages/components/popconfirm/style/index.less
+++ b/packages/components/popconfirm/style/index.less
@@ -21,7 +21,7 @@
     min-height: var(--ix-header-height-sm);
     .reset-font-size(var(--ix-popconfirm-title-font-size));
 
-    padding: 16px 16px 8px;
+    padding: var(--ix-padding-size-lg) var(--ix-padding-size-lg) var(--ix-padding-size-sm);
 
     .@{icon-prefix} {
       font-size: var(--ix-font-size-icon);
@@ -30,8 +30,12 @@
     }
   }
 
+  &-with-icon &-content  {
+    padding-left: calc(var(--ix-font-size-icon) + var(--ix-margin-size-sm) + var(--ix-padding-size-lg));
+  }
+
   &-content {
-    padding: 16px 16px 8px calc(var(--ix-font-size-icon) + var(--ix-margin-size-sm) + 16px);
+    padding: var(--ix-padding-size-lg) var(--ix-padding-size-lg) var(--ix-padding-size-sm) var(--ix-padding-size-lg);
   }
 
   &-title + &-content {
@@ -43,10 +47,10 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: 8px 16px;
+    padding: var(--ix-padding-size-sm) var(--ix-padding-size-lg);
 
     .@{button-prefix} + .@{button-prefix} {
-      margin-left: 8px;
+      margin-left: var(--ix-padding-size-sm);
     }
   }
 }


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
popconfim 的header 中没有渲染图标或者没有header的时候，内容区域的左padding依然留出了图标的位置

## What is the new behavior?
在没有图标或者没有header的时候，内容区域的左padding不应该留出图标的位置

## Other information
