### PR TITLE
fix(pro:search): selecting option after remote search overides value

### DIFF
--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -70,7 +70,7 @@ export function createSelectSegment(
     name: 'select',
     inputClassName: [`${prefixCls}-select-segment-input`],
     containerClassName: [`${prefixCls}-select-segment-container`],
-    parse: input => parseInput(input, config, locale.allSelected),
+    parse: (input, _, getCacheData) => parseInput(input, config, locale.allSelected, getCacheData),
     format: (value, states, getCacheData, setCacheData) =>
       formatValue(value, states, getCacheData, setCacheData, config, locale.allSelected),
     panelRenderer,
@@ -81,14 +81,18 @@ function parseInput(
   input: string,
   config: SelectSearchField['fieldConfig'],
   allSelected: string,
+  getCacheData: (dataKey: string) => any,
 ): VKey | VKey[] | undefined {
   const { concludeAllSelected, separator, dataSource, multiple } = config
   const trimedInput = input.trim()
 
+  const cachedData = getCacheData(dataSourceCacheKey)
+  const mergedDataSource = cachedData ? mergeData(cachedData, dataSource) : dataSource
+
   const keys =
     concludeAllSelected && trimedInput === allSelected
-      ? dataSource.map(data => data.key)
-      : getKeyByLabels(dataSource, trimedInput.split(separator ?? defaultSeparator))
+      ? mergedDataSource.map(data => data.key)
+      : getKeyByLabels(mergedDataSource, trimedInput.split(separator ?? defaultSeparator))
 
   return multiple ? (keys.length > 0 ? keys : undefined) : keys[0]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
高级搜索组件，select 搜索项在使用远程搜索时，选中新的选项会覆盖掉之前的选中项

## What is the new behavior?
修复以上问题

## Other information
