### PR TITLE
fix(cdk:virtual): items render incorrectly after datasource change

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useRenderPool.ts
@@ -81,11 +81,7 @@ export function useRenderPool(
     for (const item of items) {
       if (item.index < start || item.index > end || item.isCustomKey) {
         inactiveKeys.add(item.key)
-
-        // pool items with custom key shouldn't be resused
-        if (!item.isCustomKey) {
-          pool.recyclePoolItem(item)
-        }
+        pool.recyclePoolItem(item)
       }
     }
 
@@ -339,7 +335,10 @@ function createPool(): Pool {
   }
 
   const recyclePoolItem = (poolItem: PoolItem) => {
-    pooledItemMap.set(poolItem.itemKey, poolItem)
+    // pool items with custom key shouldn't be resused
+    if (!poolItem.isCustomKey) {
+      pooledItemMap.set(poolItem.itemKey, poolItem)
+    }
   }
 
   const destroy = () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当虚拟滚动传入的dataSource改变后，触发了渲染池元素的全部回收，被渲染的元素会出现重复的情况，并会在某些情况下导致错位

## What is the new behavior?
修复以上问题

## Other information
通过modifier添加的自定义渲染池元素不应该被回收重复利用，会导致key重复