### PR TITLE
fix(comp:table): selection should not be emptied after dataSource change

### DIFF
--- a/packages/components/table/demo/Server.vue
+++ b/packages/components/table/demo/Server.vue
@@ -26,13 +26,27 @@ const pagination = reactive<TablePagination>({
 })
 
 const loading = ref(false)
+const loadedData = new Map()
 
 const fetchData = async (pageIndex: number, pageSize: number) => {
+  const key = `${pageIndex}-${pageSize}`
+  let results
+
   loading.value = true
 
-  const { results } = await fetch(`https://randomuser.me/api?page=${pageIndex}&results=${pageSize}`).then(res =>
-    res.json(),
-  )
+  if (loadedData.has(key)) {
+    results = await new Promise(resolve => {
+      setTimeout(() => {
+        resolve(loadedData.get(key))
+      }, 200)
+    })
+  } else {
+    ;({ results } = await fetch(`https://randomuser.me/api?page=${pageIndex}&results=${pageSize}`).then(res =>
+      res.json(),
+    ))
+
+    loadedData.set(`${pageIndex}-${pageSize}`, results)
+  }
 
   dataSource.value = results
   pagination.total = 200 // mock the total data here

--- a/packages/components/table/src/composables/useSelectable.ts
+++ b/packages/components/table/src/composables/useSelectable.ts
@@ -78,7 +78,8 @@ export function useSelectable(
     cascaderStrategy,
     isDisabled,
   )
-  const { checkStateResolver, isCheckDisabled, isChecked, isIndeterminate, toggle } = checkStateContext
+  const { isCheckDisabled, isChecked, isIndeterminate, toggle, getAllCheckedKeys, getAllUncheckedKeys } =
+    checkStateContext
 
   const currentPageRowKeys = computed(() => {
     const enabledRowKeys: VKey[] = []
@@ -182,14 +183,16 @@ export function useSelectable(
     const { disabledRowKeys } = currentPageRowKeys.value
     let newSelectedKeys: VKey[]
     if (currentPageAllSelected.value) {
-      newSelectedKeys = checkStateResolver.getAllUncheckedKeys(
+      newSelectedKeys = getAllUncheckedKeys(
         paginatedData.value,
         disabledRowKeys.filter(key => isChecked(key)),
+        true,
       )
     } else {
-      newSelectedKeys = checkStateResolver.getAllCheckedKeys(
+      newSelectedKeys = getAllCheckedKeys(
         paginatedData.value,
         disabledRowKeys.filter(key => !isChecked(key)),
+        true,
       )
     }
 
@@ -263,12 +266,10 @@ function useMenuClickHandle(
   selectedRowKeys: ComputedRef<VKey[]>,
   emitChange: (tempRowKeys: VKey[]) => void,
 ) {
-  const { checkDisabledKeySet, checkStateResolver, isChecked, isCheckDisabled } = checkStateContext
+  const { checkDisabledKeySet, checkStateResolver, getAllCheckedKeys, isChecked, isCheckDisabled } = checkStateContext
   const handleSelectAll = () => {
     const { onSelectAll } = selectable.value || {}
-    const newSelectedKeys = checkStateResolver.getAllCheckedKeys(
-      [...checkDisabledKeySet.value].filter(key => !isChecked(key)),
-    )
+    const newSelectedKeys = getAllCheckedKeys([...checkDisabledKeySet.value].filter(key => !isChecked(key)))
     callEmit(onSelectAll, newSelectedKeys)
     emitChange(newSelectedKeys)
   }

--- a/packages/components/utils/src/useTreeCheckStateResolver.ts
+++ b/packages/components/utils/src/useTreeCheckStateResolver.ts
@@ -62,27 +62,7 @@ export function useTreeCheckStateResolver<V extends TreeTypeData<V, C>, C extend
       return dataOrContext
     }
 
-    const dataMap = new Map<VKey, V>()
-    const parentKeyMap = new Map<VKey, VKey>()
-    const depthMap = new Map<VKey, number>()
-
-    traverseTree(dataOrContext, childrenKey.value, (item, parents) => {
-      const key = getKey.value(item)
-      const parent = parents[0]
-      dataMap.set(key, item)
-      depthMap.set(key, parents.length)
-
-      if (parent) {
-        parentKeyMap.set(key, getKey.value(parent))
-      }
-    })
-
-    return {
-      data: dataOrContext,
-      dataMap,
-      parentKeyMap,
-      depthMap,
-    }
+    return getTreeCheckStateResolverContext(dataOrContext, childrenKey.value, getKey.value)
   }
 
   const mergedCascadeStrategy = computed(() => cascadeStrategy?.value ?? 'all')
@@ -278,5 +258,33 @@ export function useTreeCheckStateResolver<V extends TreeTypeData<V, C>, C extend
     removeKeys,
     getAllCheckedKeys,
     getAllUncheckedKeys,
+  }
+}
+
+export function getTreeCheckStateResolverContext<V extends TreeTypeData<V, C>, C extends keyof V>(
+  data: V[],
+  childrenKey: C,
+  getKey: (item: V) => VKey,
+): TreeCheckStateResolverContext<V, C> {
+  const dataMap = new Map<VKey, V>()
+  const parentKeyMap = new Map<VKey, VKey>()
+  const depthMap = new Map<VKey, number>()
+
+  traverseTree(data, childrenKey, (item, parents) => {
+    const key = getKey(item)
+    const parent = parents[0]
+    dataMap.set(key, item)
+    depthMap.set(key, parents.length)
+
+    if (parent) {
+      parentKeyMap.set(key, getKey(parent))
+    }
+  })
+
+  return {
+    data,
+    dataMap,
+    parentKeyMap,
+    depthMap,
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格在dataSource改变后（远程搜索或分页的场景），原本选中的项目被清空了

## What is the new behavior?
修改以上问题

## Other information
在 useTreeCheckState 中，每当选中的key变化后，缓存当前选中的数据，避免在下次处理选中项时数据不存在
