### PR TITLE
fix(comp:table): table selection emptyed after data change and select

### DIFF
--- a/packages/components/utils/src/useTreeCheckState.ts
+++ b/packages/components/utils/src/useTreeCheckState.ts
@@ -70,15 +70,16 @@ export function useTreeCheckState<V extends TreeTypeData<V, C>, C extends keyof 
 
     const mergedData = mergeTree(data ?? [], cachedData ?? [], childrenKey.value, getKey.value)
     const mergedDataMap = new Map(dataMap)
+    const _cachedDataMap = new Map(cachedDataMap)
 
     mergedDataMap.forEach((item, key) => {
-      if (cachedDataMap.has(key)) {
-        const cachedItem = cachedDataMap.get(key)!
+      if (_cachedDataMap.has(key)) {
+        const cachedItem = _cachedDataMap.get(key)!
         mergedDataMap.set(key, mergeTree([item], [cachedItem], childrenKey.value, getKey.value)[0])
-        cachedDataMap.delete(key)
+        _cachedDataMap.delete(key)
       }
     })
-    cachedDataMap.forEach((item, key) => {
+    _cachedDataMap.forEach((item, key) => {
       mergedDataMap.set(key, item)
     })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当datasource改变之后，选中某一行（非全选），会导致之前的选中的行数据被清空

## What is the new behavior?
修复以上问题

## Other information
