### PR TITLE
fix(comp:select): selector input value should be emptied after blur

### DIFF
--- a/packages/components/select/src/Select.tsx
+++ b/packages/components/select/src/Select.tsx
@@ -115,8 +115,11 @@ export default defineComponent({
       callEmit(props.onFocus, evt)
     }
     const onBlur = (evt: FocusEvent) => {
-      if (props.allowInput && inputValue.value) {
-        changeSelected(inputValue.value)
+      if (inputValue.value) {
+        if (props.allowInput) {
+          changeSelected(inputValue.value)
+        }
+
         clearInput()
       }
 

--- a/packages/components/selector/src/contents/Input.tsx
+++ b/packages/components/selector/src/contents/Input.tsx
@@ -25,11 +25,12 @@ export default defineComponent({
       handleEnterDown,
     } = inject(selectorToken)!
 
+    const innerInputValue = computed(() => (props.allowInput || mergedSearchable.value ? inputValue.value : ''))
     const inputReadonly = computed(
       () => props.readonly || !mergedFocused.value || !(props.allowInput || mergedSearchable.value),
     )
     const innerStyle = computed(() => {
-      return { opacity: inputReadonly.value ? 0 : undefined }
+      return { opacity: inputReadonly.value && !innerInputValue.value ? 0 : undefined }
     })
 
     return () => {
@@ -45,7 +46,7 @@ export default defineComponent({
             autofocus={autofocus}
             disabled={disabled}
             readonly={inputReadonly.value}
-            value={inputValue.value}
+            value={innerInputValue.value}
             onCompositionstart={handleCompositionStart}
             onCompositionend={handleCompositionEnd}
             onKeydown={handleEnterDown}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
单选场景下，在配置了searchable之后，在选择框中输入搜索内容，失焦之后输入的内容没有清空并且input元素遮挡了选中的内容

## What is the new behavior?
修复以上问题

## Other information
在失焦之后清空输入，并且仅在input不处于可输入状态且没有输入内容时才隐藏，并且仅当可输入（allowInput, searchable）时才设置输入内容