### PR TITLE
fix(comp:tree-select): panel shakes after scrolling at bottom

### DIFF
--- a/packages/components/tree-select/src/types.ts
+++ b/packages/components/tree-select/src/types.ts
@@ -88,7 +88,7 @@ export const treeSelectProps = {
     default: undefined,
   },
   virtual: { type: Boolean, default: false },
-  virtualItemHeight: { type: Number, default: undefined },
+  virtualItemHeight: { type: Number, default: 32 },
 
   // events
   'onUpdate:value': [Function, Array] as PropType<MaybeArray<(value: any) => void>>,

--- a/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
@@ -376,7 +376,7 @@ exports[`Tree > height and virtual work 1`] = `
   <div class=\\"cdk-virtual-scroll ix-tree-content\\">
     <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 100px; width: 100%; overflow-x: auto; overflow-y: auto;\\">
       <div class=\\"cdk-virtual-scroll-filler-horizontal\\"></div>
-      <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 308px; width: 0px;\\"></div>
+      <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 352px; width: 0px;\\"></div>
       <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px;\\">
         <div class=\\"ix-tree-node ix-tree-node-expanded\\" aria-label=\\"Node 0\\" aria-selected=\\"false\\" title=\\"Node 0\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"></span>
           <!----><span class=\\"ix-tree-node-expand\\"><!----><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(90deg);\\" role=\\"img\\" aria-label=\\"right\\"></i><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>

--- a/packages/components/tree/src/types.ts
+++ b/packages/components/tree/src/types.ts
@@ -77,7 +77,7 @@ export const treeProps = {
   showLine: { type: Boolean, default: undefined },
   virtual: { type: Boolean, default: false },
   virtualScrollMode: { type: String as PropType<VirtualScrollMode>, default: undefined },
-  virtualItemHeight: { type: Number, default: 28 },
+  virtualItemHeight: { type: Number, default: 32 },
 
   // events
   'onUpdate:checkedKeys': [Function, Array] as PropType<MaybeArray<(keys: any[]) => void>>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
tree-select在开了虚拟滚动时，在滚动到底部会导致面板内抖动

## What is the new behavior?
修复以上问题

## Other information
修改默认的virtualItemHeight为32