### PR TITLE
fix(cdk:scroll): simulated scrollbar blinks after data change

### DIFF
--- a/packages/cdk/scroll/style/index.less
+++ b/packages/cdk/scroll/style/index.less
@@ -65,7 +65,7 @@
         top: 0;
         right: 0;
       }
-      .cdk-scrollbar-horizontal {
+      &.cdk-scrollbar-horizontal {
         bottom: 0;
         left: 0;
       }

--- a/packages/cdk/utils/src/dom.ts
+++ b/packages/cdk/utils/src/dom.ts
@@ -167,10 +167,10 @@ export function getMouseClientXY(evt: MouseEvent | TouchEvent): { clientX: numbe
   return { clientX, clientY }
 }
 
-function parseSize(size: string): number {
+export function parseSize(size: string, fallback = 0): number {
   const parsedSize = parseFloat(size)
 
-  return Number.isNaN(parsedSize) ? 0 : parsedSize
+  return Number.isNaN(parsedSize) ? fallback : parsedSize
 }
 
 export function getCssDimensions(element: HTMLElement): Dimensions & { fallback: boolean } {

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -95,7 +95,12 @@ export default defineComponent({
       }
       const { starts, ends } = columnOffsets.value
       const offsets = fixed === 'start' ? starts : ends
-      const fixedOffset = convertCssPixel(offsets[props.column.key].offset)
+      const fixedOffset = convertCssPixel(offsets[props.column.key]?.offset)
+
+      if (isNil(fixedOffset)) {
+        return {}
+      }
+
       return {
         position: 'sticky',
         left: fixed === 'start' ? fixedOffset : undefined,

--- a/packages/components/table/src/main/head/HeadCell.tsx
+++ b/packages/components/table/src/main/head/HeadCell.tsx
@@ -16,7 +16,7 @@ import {
   normalizeClass,
 } from 'vue'
 
-import { isFunction, isObject, isString } from 'lodash-es'
+import { isFunction, isNil, isObject, isString } from 'lodash-es'
 
 import { NoopArray, type VKey, convertCssPixel } from '@idux/cdk/utils'
 
@@ -96,7 +96,11 @@ export default defineComponent({
       }
       const { starts, ends } = columnOffsetsWithScrollBar.value
       const offsets = Object.values(fixed === 'start' ? starts : ends)
-      const offsetIndex = offsetIndexMap[key][fixed === 'start' ? 'colStart' : 'colEnd']
+      const offsetIndex = offsetIndexMap[key]?.[fixed === 'start' ? 'colStart' : 'colEnd']
+
+      if (isNil(offsetIndex)) {
+        return {}
+      }
 
       const fixedOffset = convertCssPixel(offsets.find(offset => offset.index === offsetIndex)?.offset)
       return {

--- a/packages/components/table/style/size.less
+++ b/packages/components/table/style/size.less
@@ -26,7 +26,7 @@
 
     .@{table-prefix}-sortable-trigger,
     .@{table-prefix}-filterable-trigger {
-      height: @head-height;
+      height: calc(@head-height - 1px);
 
       &:last-child {
         margin-right: calc(4px - @padding-horizontal);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
模拟的滚动条，在虚拟滚动数据变更之后，如果内容宽高处于容器宽高附近，横向纵向的溢出状态计算会无限循环，导致滚动条闪烁

## What is the new behavior?
修复以上问题

## Other information
1. 重写实现溢出状态的计算判断逻辑，不再使用计算属性根据渲染的宽高实时判断，而是在更新滚动容器信息时统一根据预先获取的滚动条宽高一次计算，避免渲染后无限触发计算
2. 滚动溢出的计算内置在 `useScroll` API 内部，update 之后自动计算，外部不再计算