### PR TITLE
fix(cdk:scroll): virtual scroll couldn't scroll under firefox

### DIFF
--- a/packages/cdk/scroll/__tests__/__snapshots__/virtualScroll.spec.ts.snap
+++ b/packages/cdk/scroll/__tests__/__snapshots__/virtualScroll.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`VirtualScroll > basic work > render work 1`] = `
 "<div class=\\"cdk-virtual-scroll\\">
   <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 200px; overflow-x: auto; overflow-y: auto;\\">
     <!---->
-    <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 0px;\\"></div>
+    <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 1px; margin-left: -1px;\\"></div>
     <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px; margin-left: 0px;\\"><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-0 - 0</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-1 - 1</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-2 - 2</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-3 - 3</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-4 - 4</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-5 - 5</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-6 - 6</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-7 - 7</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-8 - 8</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-9 - 9</span><span class=\\"virtual-item\\" style=\\"height: 20px;\\">key-10 - 10</span></div>
   </div>
   <!---->
@@ -16,7 +16,7 @@ exports[`VirtualScroll > basic work > rowRender work 1`] = `
 "<div class=\\"cdk-virtual-scroll\\">
   <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 200px; width: 200px; overflow-x: auto; overflow-y: auto;\\">
     <!---->
-    <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 0px;\\"></div>
+    <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 400px; width: 1px; margin-left: -1px;\\"></div>
     <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px; margin-left: 0px;\\"><span class=\\"virtual-item\\">key-0 - 0</span><span class=\\"virtual-item\\">key-1 - 1</span><span class=\\"virtual-item\\">key-2 - 2</span><span class=\\"virtual-item\\">key-3 - 3</span><span class=\\"virtual-item\\">key-4 - 4</span><span class=\\"virtual-item\\">key-5 - 5</span><span class=\\"virtual-item\\">key-6 - 6</span><span class=\\"virtual-item\\">key-7 - 7</span><span class=\\"virtual-item\\">key-8 - 8</span><span class=\\"virtual-item\\">key-9 - 9</span><span class=\\"virtual-item\\">key-10 - 10</span></div>
   </div>
   <!---->

--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -111,6 +111,7 @@ export default defineComponent({
       verticalOverflowed,
     } = useScroll(holderRef, {
       simulatedScroll: simulatedScroll,
+      syncOnScroll: false,
       setContainerScroll: false,
       onScroll: (top, left) => {
         syncScroll({ top, left }, true)

--- a/packages/cdk/scroll/src/virtual/contents/Holder.tsx
+++ b/packages/cdk/scroll/src/virtual/contents/Holder.tsx
@@ -58,14 +58,14 @@ export default defineComponent({
       if (scrollOffsetTop.value === undefined) {
         return undefined
       }
-      return { height: `${scrollHeight.value}px`, width: 0 }
+      return { height: `${scrollHeight.value}px`, width: '1px', marginLeft: '-1px' }
     })
     const fillerHorizontalStyle = computed<CSSProperties | undefined>(() => {
       if (scrollOffsetLeft.value === undefined) {
         return undefined
       }
 
-      return { width: `${scrollWidth.value}px`, height: 0 }
+      return { width: `${scrollWidth.value}px`, height: '1px', marginTop: '-1px' }
     })
 
     const contentStyle = computed<CSSProperties | undefined>(() => {

--- a/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/packages/components/tree/__tests__/__snapshots__/tree.spec.ts.snap
@@ -376,7 +376,7 @@ exports[`Tree > height and virtual work 1`] = `
   <div class=\\"cdk-virtual-scroll ix-tree-content\\">
     <div class=\\"cdk-virtual-scroll-holder\\" style=\\"max-height: 100px; width: 100%; overflow-x: auto; overflow-y: auto;\\">
       <div class=\\"cdk-virtual-scroll-filler-horizontal\\"></div>
-      <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 352px; width: 0px;\\"></div>
+      <div class=\\"cdk-virtual-scroll-filler-vertical\\" style=\\"height: 352px; width: 1px; margin-left: -1px;\\"></div>
       <div class=\\"cdk-virtual-scroll-content\\" style=\\"margin-top: 0px;\\">
         <div class=\\"ix-tree-node ix-tree-node-expanded\\" aria-label=\\"Node 0\\" aria-selected=\\"false\\" title=\\"Node 0\\"><span aria-hidden=\\"true\\" class=\\"ix-tree-node-indent\\"></span>
           <!----><span class=\\"ix-tree-node-expand\\"><!----><i class=\\"ix-icon ix-icon-right\\" style=\\"transform: rotate(90deg);\\" role=\\"img\\" aria-label=\\"right\\"></i><!----></span><label class=\\"ix-checkbox ix-tree-node-checkbox\\" role=\\"checkbox\\" aria-checked=\\"false\\" aria-disabled=\\"false\\"><span class=\\"ix-checkbox-input\\"><input type=\\"checkbox\\" class=\\"ix-checkbox-input-inner\\" aria-hidden=\\"true\\"><span class=\\"ix-checkbox-input-box\\"><div aria-hidden=\\"true\\" class=\\"ix-wave\\"></div></span></span>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. 虚拟滚动容器，在firefox中，滚轮滚动失效
2. 横向的虚拟滚动，在firefox中，横向滚动条的宽度不正确

## What is the new behavior?
修复以上问题

## Other information
在firefox下，添加一个height: 0 的元素并不能真正撑开容器的scrollHeight，需要设置 height 1px