### PR TITLE
fix(cdk:scroll): virtual list render error after dataSource change

### DIFF
--- a/packages/cdk/scroll/src/virtual/composables/useScrollState.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useScrollState.ts
@@ -83,13 +83,17 @@ export function useScrollState(
     ],
     (
       [enabled, dataSource, bufferSize, rowHeight, colWidth, height, width, getKey, scroll],
-      [, , , , , oldHeight, oldWidth],
+      [, oldDataSource, , , , oldHeight, oldWidth],
     ) => {
       // to ensure that the rendered size is stable between render cycles
       // the rendered size should be at least the size of that in last render tick
       // we do this to maximize render pool reusage
       let minHorizontalLength: number[] | undefined
       let minVerticalLength: number | undefined
+      if (oldDataSource !== dataSource || oldDataSource.length !== dataSource.length) {
+        calculated = false
+      }
+
       if (oldWidth === width) {
         minHorizontalLength = rightIndex.value.map((_rightIndex, index) => _rightIndex - leftIndex.value[index])
       }
@@ -155,7 +159,7 @@ export function useScrollState(
         calculated = true
       }
     },
-    { immediate: true },
+    { immediate: true, flush: 'pre' },
   )
 
   return { scrollHeight, scrollWidth, scrollOffsetTop, scrollOffsetLeft, topIndex, bottomIndex, leftIndex, rightIndex }
@@ -213,7 +217,7 @@ function calcVerticalState(
   let _renderedHeight = 0
 
   for (let index = 0; index < dataLength; index += 1) {
-    const rowHeight = getRowHeight(index)
+    const rowHeight = getRowHeight(getKey(rows[index]))
     const currentItemBottom = scrollHeight + rowHeight
 
     if (currentItemBottom >= scrollTop && topIndex === undefined) {
@@ -246,14 +250,14 @@ function calcVerticalState(
   for (let index = 0; index < bufferSize; index += 1) {
     if (topIndex !== 0) {
       topIndex -= 1
-      const appendedRowHeight = getRowHeight(topIndex)
+      const appendedRowHeight = getRowHeight(getKey(rows[topIndex]))
       offsetTop! -= appendedRowHeight
       _renderedHeight += appendedRowHeight
     }
 
     if (bottomIndex !== dataLength - 1) {
       bottomIndex += 1
-      _renderedHeight += getRowHeight(bottomIndex)
+      _renderedHeight += getRowHeight(getKey(rows[bottomIndex]))
     }
   }
 
@@ -265,7 +269,7 @@ function calcVerticalState(
   ) {
     if (bottomIndex !== dataLength - 1) {
       bottomIndex += 1
-      _renderedHeight += getRowHeight(bottomIndex)
+      _renderedHeight += getRowHeight(getKey(rows[bottomIndex]))
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
虚拟滚动，当数据更新时，有几率导致某行的列数据渲染没有正常更新到新的数据

出现于：proTable 开启双向虚拟滚动，并取消勾选某几列的显示（无横向滚动条状态），向下滚动，会出现某行的列并没有改变，而导致整个表格的列错位

## What is the new behavior?
修复以上问题

## Other information
问题原因：
在渲染池计算的过程中，如果有某行的渲染池元素被回收且没有被立刻复用，其中的列就并不会在数据更新的时候全回收，导致该元素被复用的时候列数据出现错误

修改方法：
在一次行更新的过程中，找到没有被当次更新直接复用并退回到渲染池中的元素，回收该元素中所有的列数据