### PR TITLE
fix(cdk:scroll): virtual scroll start offset should add size of prepended items

### DIFF
--- a/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
+++ b/packages/cdk/scroll/src/virtual/VirtualScroll.tsx
@@ -146,7 +146,11 @@ export default defineComponent({
       syncContainerScroll,
     )
 
-    const pool = useRenderPool(props, topIndex, bottomIndex, leftIndex, rightIndex, getKey)
+    const {
+      renderedItems: pool,
+      prependedRowKeys,
+      prependedColKeys,
+    } = useRenderPool(props, topIndex, bottomIndex, leftIndex, rightIndex, getKey)
     const mergedData = computed(() => {
       return pool.value.map(row => {
         if (!isRowData(row.item)) {
@@ -177,6 +181,10 @@ export default defineComponent({
       fillerVerticalRef,
       useVirtual,
       collectSize,
+      getColWidth,
+      getRowHeight,
+      prependedRowKeys,
+      prependedColKeys,
       scroll,
       scrollHeight,
       scrollWidth,

--- a/packages/cdk/scroll/src/virtual/token.ts
+++ b/packages/cdk/scroll/src/virtual/token.ts
@@ -7,6 +7,7 @@
 
 import type { Scroll, SyncScroll } from './composables/useScrollPlacement'
 import type { VirtualScrollEnabled, VirtualScrollProps } from './types'
+import type { VKey } from '@idux/cdk/utils'
 import type { ComputedRef, InjectionKey, Ref, Slots } from 'vue'
 
 export interface VirtualScrollContext {
@@ -22,11 +23,15 @@ export interface VirtualScrollContext {
   fillerVerticalRef: Ref<HTMLElement | undefined>
   useVirtual: ComputedRef<boolean>
   collectSize: () => void
+  getRowHeight: (rowKey: VKey) => number
+  getColWidth: (rowKey: VKey, colKey: VKey) => number
   scroll: Ref<Scroll>
   scrollHeight: Ref<number>
   scrollWidth: Ref<number>
   scrollOffsetTop: Ref<number | undefined>
   scrollOffsetLeft: Ref<number | undefined>
+  prependedRowKeys: Ref<VKey[]>
+  prependedColKeys: Ref<Map<VKey, VKey[]>>
   syncScroll: SyncScroll
   handleScroll: (evt: Event) => void
   topIndex: Ref<number>


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当虚拟滚动传入了 colModifier 和 rowModifier 时，滚动的offset值应当加上被添加到行首或者列首的元素尺寸，保证滚动的内容区的offset正确，否则会造成滚动位置跳跃的情况

## What is the new behavior?
修复以上问题

## Other information
