### PR TITLE
fix(comp:table): initial selectedRowKeys absent from dataSource is re…

### DIFF
--- a/packages/components/table/demo/Server.vue
+++ b/packages/components/table/demo/Server.vue
@@ -1,5 +1,11 @@
 <template>
-  <IxTable :columns="columns" :dataSource="dataSource" :getKey="getKey" :pagination="pagination" :spin="loading">
+  <IxTable
+    v-model:selectedRowKeys="selectedRowKeys"
+    :columns="columns"
+    :dataSource="dataSource"
+    :pagination="pagination"
+    :spin="loading"
+  >
   </IxTable>
 </template>
 
@@ -17,8 +23,10 @@ const setPagination = (pageIndex: number, pageSize: number) => {
     pagination.pageIndex = pageIndex
   }
 
-  fetchData(pagination.pageIndex, pagination.pageSize)
+  fetchData(pagination.pageIndex!, pagination.pageSize!)
 }
+
+const selectedRowKeys = ref(['2-1', '2-2'])
 
 const pagination = reactive<TablePagination>({
   showSizeChanger: true,
@@ -26,29 +34,29 @@ const pagination = reactive<TablePagination>({
 })
 
 const loading = ref(false)
-const loadedData = new Map()
 
 const fetchData = async (pageIndex: number, pageSize: number) => {
-  const key = `${pageIndex}-${pageSize}`
-  let results
-
   loading.value = true
 
-  if (loadedData.has(key)) {
-    results = await new Promise(resolve => {
-      setTimeout(() => {
-        resolve(loadedData.get(key))
-      }, 200)
-    })
-  } else {
-    ;({ results } = await fetch(`https://randomuser.me/api?page=${pageIndex}&results=${pageSize}`).then(res =>
-      res.json(),
-    ))
+  const results = await new Promise(resolve => {
+    setTimeout(() => {
+      resolve(
+        Array.from({ length: pageSize }).map((_, idx) => {
+          return {
+            key: `${pageIndex}-${idx}`,
+            gender: 'male',
+            email: 'ssss',
+            name: {
+              first: 'saller',
+              last: 'li',
+            },
+          }
+        }),
+      )
+    }, 200)
+  })
 
-    loadedData.set(`${pageIndex}-${pageSize}`, results)
-  }
-
-  dataSource.value = results
+  dataSource.value = results as RandomUser[]
   pagination.total = 200 // mock the total data here
 
   loading.value = false
@@ -57,14 +65,12 @@ const fetchData = async (pageIndex: number, pageSize: number) => {
 onMounted(() => setPagination(1, 10))
 
 interface RandomUser {
+  key: string
   gender: string
   email: string
   name: {
     first: string
     last: string
-  }
-  login: {
-    uuid: string
   }
 }
 
@@ -101,6 +107,4 @@ const columns: TableColumn<RandomUser>[] = [
 ]
 
 const dataSource = ref<RandomUser[]>([])
-
-const getKey = (record: RandomUser) => record.login.uuid
 </script>

--- a/packages/pro/table/demo/MasiveColumns.vue
+++ b/packages/pro/table/demo/MasiveColumns.vue
@@ -1,21 +1,26 @@
 <template>
-  <IxProTable
-    :columns="columns"
-    :dataSource="data"
-    header="Pro Table"
-    :toolbar="toolbar"
-    virtualHorizontal
-    :virtualColWidth="200"
-    @columnsChange="onColumnsChange"
-  >
-    <template #name="{ value }">
-      <a>{{ value }}</a>
-    </template>
-    <template #action="{ record }">
-      <a style="margin-right: 8px">Invite {{ record.name }}</a>
-      <a>Delete</a>
-    </template>
-  </IxProTable>
+  <div style="height: 600px">
+    <IxProTable
+      autoHeight
+      :columns="columns"
+      :dataSource="data"
+      :pagination="false"
+      header="Pro Table"
+      :toolbar="toolbar"
+      virtual
+      virtualHorizontal
+      :virtualColWidth="150"
+      @columnsChange="onColumnsChange"
+    >
+      <template #name="{ value }">
+        <a>{{ value }}</a>
+      </template>
+      <template #action="{ record }">
+        <a style="margin-right: 8px">Invite {{ record.name }}</a>
+        <a>Delete</a>
+      </template>
+    </IxProTable>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -37,18 +42,18 @@ interface Data {
 }
 
 const toolbar = [
-  h(IxButton, { size: 'xs' }, () => 'Load'),
-  h(IxButton, { icon: 'reload', size: 'xs', title: 'reload', onClick: () => console.log('reload data') }),
+  h(IxButton, { props: { size: 'xs' } }, 'Load'),
+  h(IxButton, { props: { icon: 'reload', size: 'xs', title: 'reload', onClick: () => console.log('reload data') } }),
 ]
 
 const onColumnsChange = console.log
 
-const dataColumns = Array.from(new Array(1000)).map((_, idx) => ({
+const dataColumns = Array.from(new Array(100)).map((_, idx) => ({
   title: `data${idx}`,
   dataKey: `data${idx}`,
   changeVisible: true,
-  visible: idx < 100,
-  width: 200,
+  visible: idx % 3 === 1 && idx < 5,
+  width: idx % 2 === 1 ? 200 : 300,
 }))
 
 const columns: ProTableColumn<Data>[] = [
@@ -97,7 +102,7 @@ const columns: ProTableColumn<Data>[] = [
         if (tag === 'loser') {
           color = 'error'
         }
-        return h(IxTag, { color }, { default: () => tag.toUpperCase() })
+        return h(IxTag, { props: { color } }, tag.toUpperCase())
       }),
   },
   {


### PR DESCRIPTION
…moved after check change

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
表格初始的 selectedRowKeys，如果并不在当前的dataSource中，则会在勾选变化后，被异常移除掉

## What is the new behavior?
修复以上问题

## Other information
