### PR TITLE
fix(comp:*): focusing in control overlay causes it to close unexpectedly

### DIFF
--- a/packages/pro/search/src/composables/useFocusedState.ts
+++ b/packages/pro/search/src/composables/useFocusedState.ts
@@ -8,10 +8,11 @@
 import type { ProSearchProps } from '../types'
 import type { ɵOverlayInstance } from '@idux/components/_private/overlay'
 
-import { type ComputedRef, type Ref, onBeforeUnmount, watch } from 'vue'
+import { type ComputedRef, type Ref, onBeforeUnmount } from 'vue'
 
-import { type FocusOrigin, useSharedFocusMonitor } from '@idux/cdk/a11y'
-import { type MaybeElement, type MaybeElementRef, callEmit, useState } from '@idux/cdk/utils'
+import { type FocusOrigin } from '@idux/cdk/a11y'
+import { type MaybeElement, type MaybeElementRef, callEmit } from '@idux/cdk/utils'
+import { useOverlayFocusMonitor } from '@idux/components/utils'
 
 type FocusHandler = (evt: FocusEvent, origin?: FocusOrigin) => void
 type BlurHandler = (evt: FocusEvent) => void
@@ -22,215 +23,38 @@ export interface FocusStateContext {
   bindOverlayMonitor: (overlayRef: Ref<ɵOverlayInstance | undefined>, overlayOpened: Ref<boolean>) => void
   focusVia: (elRef: MaybeElementRef<MaybeElement>, origin?: FocusOrigin, options?: FocusOptions) => void
   blurVia: (elRef: MaybeElementRef<MaybeElement>) => void
-  onFocus: (handler: FocusHandler, deep?: boolean) => void
-  onBlur: (handler: BlurHandler, deep?: boolean) => void
+  onFocus: (handler: FocusHandler) => void
+  onBlur: (handler: BlurHandler) => void
 }
 
 export function useFocusedState(props: ProSearchProps): FocusStateContext {
-  const [focused, setFocused] = useState(false)
-  const { handleFocus, handleBlur } = useFocusHandlers(props, focused, setFocused)
-
   const focusHandlerSet = new Set<FocusHandler>()
   const blurHandlerSet = new Set<BlurHandler>()
-  const deepFocusHandlerSet = new Set<FocusHandler>()
-  const deepBlurHandlerSet = new Set<BlurHandler>()
-  const onFocus = (handler: FocusHandler, deep = false) => {
-    ;(deep ? deepFocusHandlerSet : focusHandlerSet).add(handler)
+  const onFocus = (handler: FocusHandler) => {
+    focusHandlerSet.add(handler)
   }
-  const onBlur = (handler: BlurHandler, deep = false) => {
-    ;(deep ? deepBlurHandlerSet : blurHandlerSet).add(handler)
+  const onBlur = (handler: BlurHandler) => {
+    blurHandlerSet.add(handler)
+  }
+
+  const focusHandler = (evt: FocusEvent, origin: FocusOrigin) => {
+    focusHandlerSet.forEach(handler => handler(evt, origin))
+    callEmit(props.onFocus, evt)
+  }
+  const blurHandler = (evt: FocusEvent) => {
+    blurHandlerSet.forEach(handler => handler(evt))
+    callEmit(props.onBlur, evt)
   }
 
   onBeforeUnmount(() => {
     focusHandlerSet.clear()
     blurHandlerSet.clear()
-    deepFocusHandlerSet.clear()
-    deepBlurHandlerSet.clear()
   })
 
-  const _handleFocus = (evt: FocusEvent, origin: FocusOrigin) => {
-    if (props.disabled) {
-      return
-    }
-
-    deepFocusHandlerSet.forEach(handler => handler(evt, origin))
-
-    handleFocus(evt, () => {
-      focusHandlerSet.forEach(handler => handler(evt, origin))
-    })
-  }
-  const _handleBlur = (evt: FocusEvent) => {
-    if (props.disabled) {
-      return
-    }
-
-    deepBlurHandlerSet.forEach(handler => handler(evt))
-
-    handleBlur(evt, () => {
-      blurHandlerSet.forEach(handler => handler(evt))
-    })
-  }
-
-  const { bindMonitor, bindOverlayMonitor, focusVia, blurVia } = useMonitor(_handleFocus, _handleBlur)
+  const { focused, bindMonitor, bindOverlayMonitor, focusVia, blurVia } = useOverlayFocusMonitor(
+    focusHandler,
+    blurHandler,
+  )
 
   return { focused, bindMonitor, bindOverlayMonitor, focusVia, blurVia, onFocus, onBlur }
-}
-
-function useFocusHandlers(
-  props: ProSearchProps,
-  focused: ComputedRef<boolean>,
-  setFocused: (focused: boolean) => void,
-): {
-  handleFocus: (evt: FocusEvent, cb?: () => void) => void
-  handleBlur: (evt: FocusEvent, cb?: () => void) => void
-} {
-  let lastFocusEvtTime = 0
-
-  // check if the next focus event within the monitored elements
-  // is triggered right away
-  const checkSubsequentFocus = async (evt: FocusEvent) => {
-    await new Promise<void>(resolve => setTimeout(resolve))
-
-    // if last focus evt triggered time is after current blur event
-    // we treat it as a subsquent focus event
-    return lastFocusEvtTime > evt.timeStamp
-  }
-  const handleBlur = async (evt: FocusEvent, cb?: () => void) => {
-    // if a subsequent focus event is triggered within the monitored elements
-    // we considered the pro search component is still focused
-    // then we skip the blur handler for this time
-    if (await checkSubsequentFocus(evt)) {
-      return
-    }
-
-    cb?.()
-
-    setFocused(false)
-
-    callEmit(props.onBlur, evt)
-  }
-
-  const handleFocus = (evt: FocusEvent, cb?: () => void) => {
-    // record focus evt time stamp
-    lastFocusEvtTime = evt.timeStamp
-
-    if (focused.value) {
-      return
-    }
-
-    cb?.()
-
-    setFocused(true)
-    callEmit(props.onFocus, evt)
-  }
-
-  return {
-    handleFocus,
-    handleBlur,
-  }
-}
-
-function useMonitor(
-  handleFocus: (evt: FocusEvent, origin: FocusOrigin) => void,
-  handleBlur: (evt: FocusEvent) => void,
-): {
-  bindMonitor: (elRef: Ref<MaybeElement>) => void
-  bindOverlayMonitor: (overlayRef: Ref<ɵOverlayInstance | undefined>, overlayOpened: Ref<boolean>) => void
-  focusVia: (elRef: MaybeElementRef<MaybeElement>, origin?: FocusOrigin, options?: FocusOptions) => void
-  blurVia: (elRef: MaybeElementRef<MaybeElement>) => void
-} {
-  const { monitor, stopMonitoring, focusVia: _focusVia, blurVia } = useSharedFocusMonitor()
-
-  const monitorStops = new Set<() => void>()
-  const _bindMonitor = (el: MaybeElement) => {
-    const stop = watch(monitor(el, true), evt => {
-      const { origin, event } = evt
-      if (event) {
-        if (origin) {
-          handleFocus(event, origin)
-        } else {
-          handleBlur(event)
-        }
-      }
-    })
-
-    return () => {
-      stop()
-      stopMonitoring(el)
-    }
-  }
-
-  const bindMonitor = (elRef: Ref<MaybeElement>) => {
-    let stop: () => void | undefined
-    const stopWatch = watch(
-      elRef,
-      el => {
-        stop?.()
-
-        if (!el) {
-          return
-        }
-
-        stop = _bindMonitor(el)
-      },
-      {
-        immediate: true,
-      },
-    )
-
-    const stopMonitor = () => {
-      stop?.()
-      stopWatch()
-    }
-    monitorStops.add(stopMonitor)
-
-    return stopMonitor
-  }
-  const bindOverlayMonitor = (overlayRef: Ref<ɵOverlayInstance | undefined>, overlayOpened: Ref<boolean>) => {
-    let stop: () => void | undefined
-
-    const stopWatch = watch(
-      [() => overlayRef.value?.getPopperElement(), overlayOpened],
-      ([el, opened], [formerEl]) => {
-        stop?.()
-        formerEl && stopMonitoring(formerEl)
-        if (!opened || !el) {
-          return
-        }
-
-        _bindMonitor(el)
-      },
-      {
-        immediate: true,
-      },
-    )
-
-    const stopMonitor = () => {
-      stop?.()
-      stopWatch()
-    }
-
-    monitorStops.add(stopMonitor)
-
-    return stopMonitor
-  }
-
-  const unbindAllMonitor = () => {
-    monitorStops.forEach(stop => stop())
-  }
-
-  onBeforeUnmount(() => {
-    unbindAllMonitor()
-  })
-
-  const focusVia = (elRef: MaybeElementRef<MaybeElement>, origin?: FocusOrigin, options?: FocusOptions) => {
-    _focusVia(elRef, origin ?? 'program', options)
-  }
-
-  return {
-    bindMonitor,
-    bindOverlayMonitor,
-    focusVia,
-    blurVia,
-  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
在火狐浏览器下，控件（包括proSearch）的浮层中触发了聚焦，会有概率导致浮层关闭

## What is the new behavior?
修复以上问题

## Other information
内部逻辑，判断浮层以及关联元素中，当blur触发之后，如果在一个setTimeout之后存在这些元素中的一个focus事件并且事件触发的时间在blur之后，则认为是组件内部的焦点转移

原本逻辑，认为后触发的focus事件的触发时间一定晚于blur事件，而实际在火狐浏览器中两个时间戳可能完全相等

另外，使用统一的 useOverlayFocusMonitor 重构 proSearch 中的 useFocusState，所有组件内部相关的逻辑全部统一处理