### PR TITLE
fix(pro:textarea): error tooltip isn't displayed when one row has mul…

### DIFF
--- a/packages/pro/textarea/src/ProTextarea.tsx
+++ b/packages/pro/textarea/src/ProTextarea.tsx
@@ -65,7 +65,7 @@ export default defineComponent({
 
     const { lineHeight, boxSizingData, resizeToFitContent } = ɵUseAutoRows(elementRef, ref(true))
     const rowCounts = useRowCounts(props, elementRef, valueRef, lineHeight, boxSizingData)
-    const errorLinesContext = useErrorLines(props, lineHeight, boxSizingData)
+    const errorLinesContext = useErrorLines(props, lineHeight, rowCounts, boxSizingData)
     const dataCount = useDataCount(props, config, valueRef)
 
     const _handleInput = (evt: Event) => {


### PR DESCRIPTION
…tiple lines

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当输入的内容，出错的文字行跨了多行，只有当悬浮到第一行才会展示错误提示

![image](https://github.com/IDuxFE/idux/assets/28892824/f09dc262-3f94-489c-aaef-363db2fea4dc)


## What is the new behavior?
修复以上问题

## Other information
