### PR TITLE
fix(comp:tree): optimize tree performance with large data (over 1w)

### DIFF
--- a/packages/cdk/dnd/src/composables/useDndSortable/createTreeStrategyContext.ts
+++ b/packages/cdk/dnd/src/composables/useDndSortable/createTreeStrategyContext.ts
@@ -84,7 +84,7 @@ export function createTreeStrategyContext<C extends keyof V, V extends object>(o
     }
 
     const parentKey = dataContext.value.parentKeyMap.get(key)
-    const dataArray = isNil(parentKey) ? dataSource.value : getData(parentKey)![childrenKey.value] ?? []
+    const dataArray = isNil(parentKey) ? dataSource.value : (getData(parentKey)![childrenKey.value] ?? [])
     const dataIndex = getDataIndex(key)
 
     const isLastInGroup = dataIndex === dataArray.length - 1

--- a/packages/cdk/dnd/src/composables/useDndSortable/useDndSortable.ts
+++ b/packages/cdk/dnd/src/composables/useDndSortable/useDndSortable.ts
@@ -179,8 +179,8 @@ export function useDndSortable(options: DndSortableOptions): DndSortableContext 
 
         const canDragOptions = { sourceKey: key, sourceData, sourceIndex }
 
-        const listCanDrag = canDrag ? canDrag(canDragOptions) ?? true : true
-        const itemCanDrag = innerCanDrag ? innerCanDrag({ ...args, ...canDragOptions }) ?? true : true
+        const listCanDrag = canDrag ? (canDrag(canDragOptions) ?? true) : true
+        const itemCanDrag = innerCanDrag ? (innerCanDrag({ ...args, ...canDragOptions }) ?? true) : true
 
         return listCanDrag && itemCanDrag
       },
@@ -297,8 +297,8 @@ export function useDndSortable(options: DndSortableOptions): DndSortableContext 
 
         const canDropOptions = { sourceKey, sourceData, sourceIndex, targetKey: key, targetData, targetIndex }
 
-        const listCanDrop = canDrop ? canDrop(canDropOptions) ?? true : true
-        const itemCanDrop = innerCanDrop ? innerCanDrop({ ...args, ...canDropOptions }) ?? true : true
+        const listCanDrop = canDrop ? (canDrop(canDropOptions) ?? true) : true
+        const itemCanDrop = innerCanDrop ? (innerCanDrop({ ...args, ...canDropOptions }) ?? true) : true
         return listCanDrop && itemCanDrop
       },
     })

--- a/packages/cdk/scroll/src/virtual/composables/useSizeCollect.ts
+++ b/packages/cdk/scroll/src/virtual/composables/useSizeCollect.ts
@@ -9,7 +9,7 @@ import type { VirtualScrollProps, VirutalDataSizes } from '../types'
 import type { VKey } from '@idux/cdk/utils'
 import type { ComponentPublicInstance, Ref } from 'vue'
 
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 import { isNil } from 'lodash-es'
 
@@ -34,6 +34,35 @@ export function useSizeCollect(props: VirtualScrollProps): SizeCollectContext {
   const sizeUpdateMark = ref(0)
 
   let sizeUpdateId = 0
+  let rowHeight = props.rowHeight
+  let colWidth = props.colWidth
+  let _getColWidth = props.getColWidth
+  let _getRowHeight = props.getRowHeight
+
+  watch(
+    () => props.rowHeight,
+    () => {
+      rowHeight = props.rowHeight
+    },
+  )
+  watch(
+    () => props.colWidth,
+    () => {
+      colWidth = props.colWidth
+    },
+  )
+  watch(
+    () => props.getColWidth,
+    () => {
+      _getColWidth = props.getColWidth
+    },
+  )
+  watch(
+    () => props.getRowHeight,
+    () => {
+      _getRowHeight = props.getRowHeight
+    },
+  )
 
   const setRowHeight = (rowKey: VKey, height: number | undefined) => {
     if (isNil(height)) {
@@ -161,13 +190,13 @@ export function useSizeCollect(props: VirtualScrollProps): SizeCollectContext {
   }
 
   const getRowHeight = (rowKey: VKey) => {
-    return sizes.get(rowKey)?.height ?? props.getRowHeight?.(rowKey) ?? props.rowHeight
+    return sizes.get(rowKey)?.height ?? _getRowHeight?.(rowKey) ?? rowHeight
   }
   const getColWidth = (rowKey: VKey, colKey: VKey) => {
     return (
       (props.isStrictGrid ? strictGridColSizes.get(colKey) : sizes.get(rowKey)?.colWidths.get(colKey)) ??
-      props.getColWidth?.(rowKey, colKey) ??
-      props.colWidth
+      _getColWidth?.(rowKey, colKey) ??
+      colWidth
     )
   }
 

--- a/packages/cdk/utils/src/convert.ts
+++ b/packages/cdk/utils/src/convert.ts
@@ -45,5 +45,5 @@ export function convertElement<T extends MaybeElement>(
   elementOrInstance: MaybeElementRef<T>,
 ): T extends ComponentPublicInstance ? Exclude<MaybeElement, ComponentPublicInstance> : T | undefined {
   const element = unref(elementOrInstance)
-  return isHTMLElement(element) ? element : element?.$el ?? element
+  return isHTMLElement(element) ? element : (element?.$el ?? element)
 }

--- a/packages/components/breadcrumb/src/BreadcrumbItem.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbItem.tsx
@@ -29,7 +29,7 @@ export default defineComponent({
       <li class={`${mergedPrefixCls.value}-item`}>
         <span class={`${mergedPrefixCls.value}-item-link`}>{slots.default?.()}</span>
         <span class={`${mergedPrefixCls.value}-item-separator`} aria-hidden="true">
-          {slots.separator ? slots.separator() : props.separator ?? separatorRef.value}
+          {slots.separator ? slots.separator() : (props.separator ?? separatorRef.value)}
         </span>
       </li>
     )

--- a/packages/components/select/src/composables/usePanelActiveState.ts
+++ b/packages/components/select/src/composables/usePanelActiveState.ts
@@ -60,7 +60,7 @@ export function usePanelActiveState(
     watch(
       [() => props.activeValue, flattenedOptions],
       ([value, options]) => {
-        const targetIndex = isNil(value) ? -1 : keyIndexMap.value.get(value) ?? -1
+        const targetIndex = isNil(value) ? -1 : (keyIndexMap.value.get(value) ?? -1)
         setActiveIndex(targetIndex !== -1 ? getEnabledActiveIndex(options, targetIndex, 1) : -1)
       },
       {

--- a/packages/components/table/src/composables/useSelectable.ts
+++ b/packages/components/table/src/composables/useSelectable.ts
@@ -78,7 +78,7 @@ export function useSelectable(
     cascaderStrategy,
     isDisabled,
   )
-  const { isCheckDisabled, isChecked, isIndeterminate, toggle, getAllCheckedKeys, getAllUncheckedKeys } =
+  const { isCheckDisabled, isChecked, isIndeterminate, toggle, getAllCheckedKeys, getAllUncheckedKeys, getDataByKeys } =
     checkStateContext
 
   const currentPageRowKeys = computed(() => {
@@ -125,30 +125,12 @@ export function useSelectable(
   const currentPageSomeSelected = computed(
     () => !currentPageAllSelectState.value.allSelected && currentPageAllSelectState.value.someSelected,
   )
-  // 缓存已经被选中的数据，考虑到后端分页的清空，dataMap 中没有全部的数据
-  const cacheSelectedMap = new Map<VKey, MergedData>()
 
   const emitChange = (tempRowKeys: VKey[]) => {
     setSelectedRowKeys(tempRowKeys)
-    const dataMap = mergedMap.value
     const { onChange } = selectable.value || {}
     if (onChange) {
-      const selectedRecords: unknown[] = []
-      // 清理掉缓存中被取消选中的数据
-      cacheSelectedMap.forEach((_, key) => {
-        if (!tempRowKeys.includes(key)) {
-          cacheSelectedMap.delete(key)
-        }
-      })
-      tempRowKeys.forEach(key => {
-        let currData = dataMap.get(key)
-        if (currData) {
-          cacheSelectedMap.set(key, currData)
-        } else {
-          currData = cacheSelectedMap.get(key)
-        }
-        currData && selectedRecords.push(currData.record)
-      })
+      const selectedRecords = getDataByKeys(tempRowKeys).map(data => data.record)
       callEmit(onChange, tempRowKeys, selectedRecords)
     }
   }

--- a/packages/components/table/src/main/ColGroup.tsx
+++ b/packages/components/table/src/main/ColGroup.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const { key, type } = column
-        const mergedWidth = props.isFixedHolder ? measuredColumnWidthMap.value[key] ?? column.width : column.width
+        const mergedWidth = props.isFixedHolder ? (measuredColumnWidthMap.value[key] ?? column.width) : column.width
         const className = type
           ? normalizeClass({
               [`${prefixCls}-col-${type}`]: true,

--- a/packages/components/table/src/main/body/BodyCell.tsx
+++ b/packages/components/table/src/main/body/BodyCell.tsx
@@ -61,7 +61,7 @@ export default defineComponent({
     const mergedEllipsis = computed(() => {
       // tableProps 的 ellipsis 对特殊(带有 type )的列不生效
       const { type, ellipsis } = props.column as BodyColumn
-      return type ? ellipsis : ellipsis ?? tableProps.ellipsis
+      return type ? ellipsis : (ellipsis ?? tableProps.ellipsis)
     })
 
     const classes = computed(() => {

--- a/packages/components/table/src/main/head/HeadCell.tsx
+++ b/packages/components/table/src/main/head/HeadCell.tsx
@@ -58,7 +58,7 @@ export default defineComponent({
     const mergedEllipsis = computed(() => {
       // tableProps 的 ellipsis 对特殊(带有 type )的列不生效
       const { type, ellipsis } = props.column as HeadColumn
-      const _ellipsis = type ? ellipsis : ellipsis ?? tableProps.ellipsis
+      const _ellipsis = type ? ellipsis : (ellipsis ?? tableProps.ellipsis)
       return isObject(_ellipsis) && _ellipsis.head === false ? undefined : _ellipsis
     })
 

--- a/packages/components/theme/src/composables/useTokenMerge.ts
+++ b/packages/components/theme/src/composables/useTokenMerge.ts
@@ -53,7 +53,7 @@ export function useTokenMerge(
     const configComponentTokens = config.components
 
     const overwrittenTokens = merge(
-      { ...(props?.inherit && !props.presetTheme ? supperContext?.mergedTokens.value.global ?? {} : {}) },
+      { ...(props?.inherit && !props.presetTheme ? (supperContext?.mergedTokens.value.global ?? {}) : {}) },
       { ...configGlobalTokens },
       props?.tokens?.global,
     ) as GlobalThemeTokens
@@ -61,7 +61,7 @@ export function useTokenMerge(
     const mergedGlobalTokens = getThemeTokens(mergedPresetTheme.value, overwrittenTokens, mergedAlgorithms.value)
 
     const mergedComponentTokens = merge(
-      { ...(props?.inherit ? supperContext?.mergedTokens.value.components ?? {} : {}) },
+      { ...(props?.inherit ? (supperContext?.mergedTokens.value.components ?? {}) : {}) },
       { ...configComponentTokens },
       props?.tokens?.components,
     )

--- a/packages/components/theme/src/composables/useTokenRegister.ts
+++ b/packages/components/theme/src/composables/useTokenRegister.ts
@@ -125,7 +125,7 @@ export function useTokenRegister(
     // if hashId is already provided, we consider the style injected already, no need to inject it again
     if (injectThemeStyle.value && !existedHashId) {
       const cssContent = tokenToCss(
-        { ...record, hashId: hashed ?? mergedHashed.value ? record.hashId : '' } as TokenRecord<string>,
+        { ...record, hashId: (hashed ?? mergedHashed.value) ? record.hashId : '' } as TokenRecord<string>,
         prefix,
         transforms,
       )

--- a/packages/components/theme/src/useThemeToken.ts
+++ b/packages/components/theme/src/useThemeToken.ts
@@ -91,7 +91,7 @@ export function useThemeToken<Ext extends object, K extends UseThemeTokenScope |
 
   const context = getSharedContext(key, useThemeTokenContextMap, () => {
     const globalHashId = globalContext.globalHashId
-    const hashId = computed(() => (hashed.value ? getThemeHashId(key) ?? '' : ''))
+    const hashId = computed(() => (hashed.value ? (getThemeHashId(key) ?? '') : ''))
     const themeTokens = computed(() => getThemeTokens(key))
 
     const registerToken = (

--- a/packages/components/tree/demo/CascaderStrategy.vue
+++ b/packages/components/tree/demo/CascaderStrategy.vue
@@ -16,11 +16,12 @@
       @check="onCheck"
     >
     </IxTree>
+    {{ checkedKeys }}
   </IxSpace>
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { ref, watch, watchEffect } from 'vue'
 
 import { CascaderStrategy } from '@idux/components/cascader'
 import { TreeNode } from '@idux/components/tree'
@@ -72,13 +73,14 @@ const treeData: TreeNode[] = [
   },
 ]
 
-const checkedKeys = ref(['0'])
+const checkedKeys = ref([])
 const expandedKeys = ref(['0', '0-0', '0-1'])
 const selectedKeys = ref(['0-1'])
 
 const cascaderStrategy = ref<CascaderStrategy>('all')
 
 watchEffect(() => console.log('checkedKeys:', checkedKeys.value))
+watch(cascaderStrategy, () => (checkedKeys.value = []))
 
 const onCheck = (checked: boolean, node: TreeNode) => console.log('checked', checked, node)
 </script>

--- a/packages/components/tree/demo/Virtual.vue
+++ b/packages/components/tree/demo/Virtual.vue
@@ -1,5 +1,12 @@
 <template>
-  <IxTree v-model:expandedKeys="expandedKeys" :dataSource="treeData" :height="200" virtual></IxTree>
+  <IxTree
+    v-model:expandedKeys="expandedKeys"
+    cascaderStrategy="all"
+    checkable
+    :dataSource="treeData"
+    :height="400"
+    virtual
+  ></IxTree>
 </template>
 
 <script setup lang="ts">
@@ -8,16 +15,17 @@ import type { TreeNode } from '@idux/components/tree'
 
 import { ref } from 'vue'
 
-const expandedKeys = ref<VKey[]>([])
+const expandedKeys = ref<VKey[]>(['root'])
 
-function genData(path = '0', level = 3) {
+function genData(path = '0', level = 1) {
   const data = []
 
-  for (let index = 0; index < 10; index++) {
+  for (let index = 0; index < 100; index++) {
     const key = `${path}-${index}`
     const node: TreeNode = {
       key,
       label: key,
+      disabled: level === 0 && index === 5,
     }
 
     if (level > 0) {
@@ -30,5 +38,11 @@ function genData(path = '0', level = 3) {
   return data
 }
 
-const treeData = genData()
+const treeData = [
+  {
+    key: 'root',
+    label: '全部',
+    children: genData(),
+  },
+]
 </script>

--- a/packages/components/tree/src/Tree.tsx
+++ b/packages/components/tree/src/Tree.tsx
@@ -77,7 +77,7 @@ export default defineComponent({
       searchedKeys,
       setLoadedNodes,
     )
-    const flattedNodes = useFlattedNodes(mergedNodes, expandableContext, props, searchedKeys)
+    const { flattedNodes, flattenedNodeMap } = useFlattedNodes(mergedNodes, expandableContext, props, searchedKeys)
     const checkableContext = useCheckable(props, mergedNodes, mergedNodeMap, parentKeyMap, depthMap)
     const dragDropContext = useDragDrop(props, config, expandableContext)
     const selectableContext = useSelectable(props, mergedNodeMap)
@@ -87,6 +87,7 @@ export default defineComponent({
       props,
       config,
       flattedNodes,
+      flattenedNodeMap,
       mergedPrefixCls,
       mergedNodeMap,
       mergedGetKey,

--- a/packages/components/tree/src/node/TreeNode.tsx
+++ b/packages/components/tree/src/node/TreeNode.tsx
@@ -5,9 +5,6 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { MergedNode } from '../composables/useDataSource'
-import type { VKey } from '@idux/cdk/utils'
-
 import { computed, defineComponent, inject } from 'vue'
 
 import { IxIcon } from '@idux/components/icon'
@@ -26,7 +23,7 @@ export default defineComponent({
   setup(props, { slots }) {
     const {
       props: treeProps,
-      flattedNodes,
+      flattenedNodeMap,
       mergedPrefixCls,
       mergedShowLine,
       activeKey,
@@ -116,10 +113,7 @@ export default defineComponent({
     }
 
     return () => {
-      const nodeMap = new Map<VKey, MergedNode>()
-      flattedNodes.value.forEach(node => {
-        nodeMap.set(node.key, node)
-      })
+      const nodeMap = flattenedNodeMap.value
 
       const { isLeaf, label, level, rawNode, expanded, checkDisabled, dragDisabled, dropDisabled, node } = props
       const { checkable, draggable } = treeProps

--- a/packages/components/tree/src/token.ts
+++ b/packages/components/tree/src/token.ts
@@ -20,6 +20,7 @@ export interface TreeContext extends CheckableContext, DragDropContext, Expandab
   props: TreeProps
   config: TreeConfig
   flattedNodes: ComputedRef<MergedNode[]>
+  flattenedNodeMap: ComputedRef<Map<VKey, MergedNode>>
   mergedPrefixCls: ComputedRef<string>
   mergedNodeMap: ComputedRef<Map<VKey, MergedNode>>
   mergedGetKey: ComputedRef<GetKeyFn>

--- a/packages/components/upload/src/component/Selector.tsx
+++ b/packages/components/upload/src/component/Selector.tsx
@@ -86,7 +86,7 @@ function useSelectorClasses(
 
 function useDir(props: UploadProps, config: UploadConfig) {
   const directoryCfg = { directory: 'directory', webkitdirectory: 'webkitdirectory' }
-  return computed(() => (props.directory ?? config.directory ? directoryCfg : {}))
+  return computed(() => ((props.directory ?? config.directory) ? directoryCfg : {}))
 }
 
 function useMultiple(props: UploadProps, config: UploadConfig) {

--- a/packages/components/upload/src/composables/useRequest.ts
+++ b/packages/components/upload/src/composables/useRequest.ts
@@ -184,5 +184,5 @@ async function getAction(props: UploadProps, file: UploadFile) {
 }
 
 async function getRequestData(props: UploadProps, file: UploadFile) {
-  return isFunction(props.requestData) ? await props.requestData(file) : props.requestData ?? {}
+  return isFunction(props.requestData) ? await props.requestData(file) : (props.requestData ?? {})
 }

--- a/packages/components/utils/src/useTreeCheckState.ts
+++ b/packages/components/utils/src/useTreeCheckState.ts
@@ -121,7 +121,7 @@ export function useTreeCheckState<V extends TreeTypeData<V, C>, C extends keyof 
       }
     }
 
-    const children = cascaderStrategy.value !== 'off' ? data[childrenKey.value] ?? [] : []
+    const children = cascaderStrategy.value !== 'off' ? (data[childrenKey.value] ?? []) : []
     const checked =
       isChecked(currKey) ||
       (!!children.length &&

--- a/packages/components/utils/src/useTreeCheckStateResolver.ts
+++ b/packages/components/utils/src/useTreeCheckStateResolver.ts
@@ -253,12 +253,18 @@ export function useTreeCheckStateResolver<V extends TreeTypeData<V, C>, C extend
   const getAllCheckedKeys = (data?: V[] | VKey[], defaultUnCheckedKeys?: VKey[]) => {
     const dataProvided = ((data?: V[] | VKey[]): data is V[] => isObject(data?.[0]))(data)
 
-    return _getAllCheckedKeys(dataProvided ? data : undefined, defaultUnCheckedKeys ?? (dataProvided ? [] : data ?? []))
+    return _getAllCheckedKeys(
+      dataProvided ? data : undefined,
+      defaultUnCheckedKeys ?? (dataProvided ? [] : (data ?? [])),
+    )
   }
   const getAllUncheckedKeys = (data?: V[] | VKey[], defaultCheckedKeys?: VKey[]) => {
     const dataProvided = ((data?: V[] | VKey[]): data is V[] => isObject(data?.[0]))(data)
 
-    return _getAllUncheckedKeys(dataProvided ? data : undefined, defaultCheckedKeys ?? (dataProvided ? [] : data ?? []))
+    return _getAllUncheckedKeys(
+      dataProvided ? data : undefined,
+      defaultCheckedKeys ?? (dataProvided ? [] : (data ?? [])),
+    )
   }
 
   return {

--- a/packages/pro/search/src/components/segment/Segment.tsx
+++ b/packages/pro/search/src/components/segment/Segment.tsx
@@ -107,7 +107,7 @@ export default defineComponent({
             if (active) {
               segmentInputRef.value?.getInputElement().focus()
               updateSelectionStart(
-                (props.selectionStart ?? -1) === -1 ? props.input?.length ?? 0 : props.selectionStart ?? 0,
+                (props.selectionStart ?? -1) === -1 ? (props.input?.length ?? 0) : (props.selectionStart ?? 0),
               )
             }
           })

--- a/packages/pro/search/src/segments/CreateCascaderSegment.tsx
+++ b/packages/pro/search/src/segments/CreateCascaderSegment.tsx
@@ -73,7 +73,7 @@ export function createCascaderSegment(
     const { panelValue, searchInput, handleChange } = getSelectableCommonParams<VKey | VKey[]>(
       context,
       !!multiple,
-      renderLocation === 'individual' ? separator ?? defaultSeparator : undefined,
+      renderLocation === 'individual' ? (separator ?? defaultSeparator) : undefined,
       !multiple || renderLocation === 'quick-select-panel',
     )
     const cascaderPanelSlots = {
@@ -130,7 +130,7 @@ function parseInput(
     trimedInput.split(separator ?? defaultSeparator),
     checkedKeysResolver,
     parentKeyMap,
-    fullPath ?? defaultFullPath ? pathSeparator ?? defaultPathSeparator : undefined,
+    (fullPath ?? defaultFullPath) ? (pathSeparator ?? defaultPathSeparator) : undefined,
   )
 
   return multiple ? (keys.length > 0 ? keys : undefined) : keys[0]
@@ -151,11 +151,11 @@ function formatValue(
   const labels = getLabelByKeys(
     nodeKeyMap,
     (multiple ? value : [value]) as VKey[] | VKey[][],
-    fullPath ?? defaultFullPath ? pathSeparator ?? defaultPathSeparator : undefined,
+    (fullPath ?? defaultFullPath) ? (pathSeparator ?? defaultPathSeparator) : undefined,
   )
 
   if (searchable) {
-    const inputParts = states ? states[states.length - 1]?.input?.split(_separator) ?? [] : []
+    const inputParts = states ? (states[states.length - 1]?.input?.split(_separator) ?? []) : []
     const lastInputPart = inputParts[inputParts.length - 1]?.trim() as string | undefined
 
     if (lastInputPart && !labels.includes(lastInputPart)) {

--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -33,7 +33,7 @@ export function createSelectSegment(
     const { panelValue, searchInput, handleChange } = getSelectableCommonParams(
       context,
       !!multiple,
-      renderLocation === 'individual' ? separator ?? defaultSeparator : undefined,
+      renderLocation === 'individual' ? (separator ?? defaultSeparator) : undefined,
       !multiple || renderLocation === 'quick-select-panel',
     )
 
@@ -130,7 +130,7 @@ function formatValue(
   const labels = getLabelByKeys(mergedDataSource, values)
 
   if (searchable) {
-    const inputParts = states ? states[states.length - 1]?.input?.split(_separator) ?? [] : []
+    const inputParts = states ? (states[states.length - 1]?.input?.split(_separator) ?? []) : []
     const lastInputPart = inputParts[inputParts.length - 1]?.trim() as string | undefined
 
     if (lastInputPart && !labels.includes(lastInputPart)) {

--- a/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateTreeSelectSegment.tsx
@@ -61,7 +61,7 @@ export function createTreeSelectSegment(
     const { panelValue, searchInput, handleChange } = getSelectableCommonParams(
       context,
       !!multiple,
-      renderLocation === 'individual' ? separator ?? defaultSeparator : undefined,
+      renderLocation === 'individual' ? (separator ?? defaultSeparator) : undefined,
       !multiple || renderLocation === 'quick-select-panel',
     )
 
@@ -145,7 +145,7 @@ function formatValue(
   const labels = getLabelByKeys(nodeKeyMap, convertArray(value))
 
   if (searchable) {
-    const inputParts = states ? states[states.length - 1]?.input?.split(_separator) ?? [] : []
+    const inputParts = states ? (states[states.length - 1]?.input?.split(_separator) ?? []) : []
     const lastInputPart = inputParts[inputParts.length - 1]?.trim() as string | undefined
 
     if (lastInputPart && !getKeyByLabels(nodeLabelMap, [lastInputPart]).length) {

--- a/packages/pro/search/src/utils/getSelectableCommonParams.ts
+++ b/packages/pro/search/src/utils/getSelectableCommonParams.ts
@@ -42,7 +42,7 @@ export function getSelectableCommonParams<T>(
     searchInput = trimedInput
   } else {
     const inputParts = trimedInput.split(separator)
-    searchInput = inputParts.length > panelValue.length ? inputParts.pop()?.trim() ?? '' : ''
+    searchInput = inputParts.length > panelValue.length ? (inputParts.pop()?.trim() ?? '') : ''
   }
 
   const handleChange = (v: T[] | undefined) => {

--- a/packages/pro/tag-select/src/composables/usePanelActiveState.ts
+++ b/packages/pro/tag-select/src/composables/usePanelActiveState.ts
@@ -72,7 +72,7 @@ export function usePanelActiveState(
     watch(
       mergedOptions,
       options => {
-        const targetIndex = isNil(activeValue.value) ? -1 : keyIndexMap.value.get(activeValue.value) ?? -1
+        const targetIndex = isNil(activeValue.value) ? -1 : (keyIndexMap.value.get(activeValue.value) ?? -1)
         setActiveIndex(targetIndex !== -1 ? getEnabledActiveIndex(options, targetIndex, 1) : 0)
       },
       {

--- a/packages/pro/tag-select/src/composables/useTagData.ts
+++ b/packages/pro/tag-select/src/composables/useTagData.ts
@@ -102,7 +102,7 @@ export function useTagData(props: ProTagSelectProps, tagColorContext: TagColorCo
       ...modifiedData,
       color: isObject(modifiedData.color)
         ? modifiedData.color
-        : getTagSelectColorByKey(modifiedData.color) ?? randomColor,
+        : (getTagSelectColorByKey(modifiedData.color) ?? randomColor),
     }
   }
   const removeData = (data: TagSelectData) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
大数据量下（1w+），树在开启虚拟滚动是，滚动后的渲染卡顿，勾选卡顿

## What is the new behavior?
大幅度优化以上场景，提升90%

## Other information
1. 修改虚拟滚动的元素尺寸收集和获取逻辑，在内部将响应式变量缓存不可响应的简单变量，减少不必要的响应式变量get的性能消耗
2. 原先树节点的渲染逻辑中存在一个遍历当前数据的过程，消耗了大量的性能，将该遍历提前
3. 优化通用的树勾选状态逻辑，减少不必要的响应式更新频率，尽量将耗时的计算聚合
4. 优化树勾选处理方法，减少不必要的循环
5. 由于这部分逻辑同时影响了表格的勾选，同步修改表格引用树勾选逻辑的代码，将缓存节点数据的逻辑去掉，改由通用的树勾选逻辑统一处理