### PR TITLE
fix(pro:table): layout tool btn covers column trigger when has scroll

### DIFF
--- a/packages/pro/table/style/index.less
+++ b/packages/pro/table/style/index.less
@@ -126,7 +126,8 @@
     }
 
     &:not(.@{table-prefix}-scroll-vertical) {
-      .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-content {
+      .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-content,
+      .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-fixed-holder {
         table > thead > tr:first-child {
           th:last-child > .@{table-prefix}-cell-triggers {
             padding-right: 38px;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
proTable 在表格存在竖向滚动，且最后一列存在筛选或者排序时，布局工具的按钮会遮盖住筛选或者排序的触发按钮

## What is the new behavior?
修复以上问题

## Other information
