### PR TITLE
fix(pro:search): input is formatted incorrectly after deselecting last option

### DIFF
--- a/packages/pro/search/src/segments/CreateSelectSegment.tsx
+++ b/packages/pro/search/src/segments/CreateSelectSegment.tsx
@@ -130,10 +130,12 @@ function formatValue(
   const labels = getLabelByKeys(mergedDataSource, values)
 
   if (searchable) {
-    const inputParts = states ? (states[states.length - 1]?.input?.split(_separator) ?? []) : []
+    const currentState = states?.[states.length - 1]
+    const lastLabels = currentState?.value ? getLabelByKeys(mergedDataSource, currentState.value as VKey[]) : []
+    const inputParts = currentState ? (currentState.input?.split(_separator) ?? []) : []
     const lastInputPart = inputParts[inputParts.length - 1]?.trim() as string | undefined
 
-    if (lastInputPart && !labels.includes(lastInputPart)) {
+    if (lastInputPart && !lastLabels.includes(lastInputPart) && lastInputPart !== allSelected) {
       return [...labels, lastInputPart].join(` ${_separator} `)
     }
   }


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当取消选择select field 中 Input 的最后一个选项，input 解析异常，导致选项被异常过滤


## What is the new behavior?
修复以上问题

## Other information
