### PR TITLE
fix(comp:modal): draggable of modal with custom header slot doesn't work

### DIFF
--- a/packages/components/_private/header/src/Header.tsx
+++ b/packages/components/_private/header/src/Header.tsx
@@ -10,12 +10,12 @@ import type { FunctionalComponent } from 'vue'
 
 import { isString } from 'lodash-es'
 
-import { convertArray } from '@idux/cdk/utils'
+import { convertArray, getFirstValidNode } from '@idux/cdk/utils'
 import { IxHeader } from '@idux/components/header'
 
 const Header: FunctionalComponent<HeaderProps> = (props, { slots }) => {
   if (slots.header) {
-    return slots.header(props)
+    return getFirstValidNode(slots.header(props))
   }
 
   if (!props.header && !props.closable) {

--- a/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
+++ b/packages/pro/transfer/__tests__/__snapshots__/proTransfer.spec.ts.snap
@@ -50,9 +50,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
             class="ix-table ix-table-auto-height ix-table-borderless ix-table-md ix-pro-table ix-pro-transfer-table-content"
           >
             
-            
             <!---->
-            
             <div
               class="ix-table-container ix-table-fixed-layout ix-table-inset-shadow"
             >
@@ -1208,9 +1206,7 @@ exports[`ProTransfer > table transfer render work 1`] = `
             class="ix-table ix-table-auto-height ix-table-borderless ix-table-md ix-pro-table ix-pro-transfer-table-content"
           >
             
-            
             <!---->
-            
             <div
               class="ix-table-container ix-table-fixed-layout ix-table-inset-shadow"
             >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
具有 header 插槽的modal 组件，开启 draggable，拖拽不生效

## What is the new behavior?
修复以上问题

## Other information
1. 私有的 header 组件返回的vnode可能不是最终渲染的vnode，改用 getFirstValidVnode 获取第一个可用的vnode
2. header 组件的 header 插槽不再支持多节点组件