### PR TITLE
fix(pro:textarea): optimize performance of row height collecting

### DIFF
--- a/packages/pro/textarea/src/composables/useLineRender.ts
+++ b/packages/pro/textarea/src/composables/useLineRender.ts
@@ -9,6 +9,7 @@ import type { ProTextareaProps, TextareaError } from '../types'
 
 import { type ComputedRef, type Ref, onMounted, watch } from 'vue'
 
+import { useResizeObserver } from '@idux/cdk/resize'
 import { cancelRAF, rAF, useEventListener, useState } from '@idux/cdk/utils'
 
 export interface LineRenderContext {
@@ -25,6 +26,8 @@ export function useErrorLineRender(
   const [renderedErrors, setRenderedErrors] = useState<TextareaError[]>([])
   const [renderedLinesIndex, setRenderedLinesIndex] = useState<{ start: number; end: number }>({ start: 0, end: 0 })
   const [renderedTopOffset, setRenderedTopOffset] = useState<number>(0)
+
+  let scrollHolderHeight = 0
 
   const calcErrorRenderState = () => {
     if (!scrollHolderRef.value) {
@@ -102,6 +105,13 @@ export function useErrorLineRender(
       calcErrorRenderState()
       rafId = null
     })
+  })
+  useResizeObserver(scrollHolderRef, ({ contentRect: { height } }) => {
+    if (scrollHolderHeight && scrollHolderHeight !== height) {
+      calcErrorRenderState()
+    }
+
+    scrollHolderHeight = height
   })
 
   return {

--- a/packages/pro/textarea/src/composables/useRowsCounts.ts
+++ b/packages/pro/textarea/src/composables/useRowsCounts.ts
@@ -29,6 +29,7 @@ export function useRowCounts(
   const [rowHeights, setRowHeights] = useState<number[]>([])
 
   let cachedRowCharLength: number[] = []
+  let textareaWidth = 0
 
   const calcRowCounts = () => {
     const textarea = textareaRef.value!
@@ -77,9 +78,13 @@ export function useRowCounts(
   }
 
   watch([valueRef, () => props.rows], calcRowCounts)
-  useResizeObserver(textareaRef, () => {
-    cachedRowCharLength = []
-    calcRowCounts()
+  useResizeObserver(textareaRef, ({ contentRect: { width } }) => {
+    if (textareaWidth && textareaWidth !== width) {
+      cachedRowCharLength = []
+      calcRowCounts()
+    }
+
+    textareaWidth = width
   })
 
   return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
每次输入内容导致内容的高度撑开时，都会触发所有行的重新计算

## What is the new behavior?
只有当内容区域的宽度变化时，才应该重新计算所有行的高度，仅仅高度变化时不重新计算

## Other information
