### PR TITLE
fix(pro:table): table has horizontal scroll when last column is resiz…

### DIFF
--- a/packages/pro/table/style/index.less
+++ b/packages/pro/table/style/index.less
@@ -195,13 +195,15 @@
     }
   }
 
-  .cdk-resizable {
-    &-preview {
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: 11;
-      border-right: 2px var(--ix-line-type) var(--ix-color-border);
-    }
+  .cdk-resizable-preview {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 11;
+    border-right: 2px var(--ix-line-type) var(--ix-color-border);
+  }
+
+  table > thead th:last-child .cdk-resizable-handle {
+    right: 0;
   }
 }


### PR DESCRIPTION
…able

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
proTable 当最后一列配置了 resizable 的时候，cdk-resize-handle 具有 right : -5px 的样式，导致固定出现横向滚动条

## What is the new behavior?
proTable 中 最后一列的 cdk-resize-handle 的 right 改为 0，修复以上问题

## Other information
