### PR TITLE
fix(comp:theme): calculated hash of unhashed tokens should be different

### DIFF
--- a/packages/components/theme/src/composables/useTokenRegister.ts
+++ b/packages/components/theme/src/composables/useTokenRegister.ts
@@ -92,7 +92,7 @@ export function useTokenRegister(
     const getTokens = tokenGettersMap.get(key) as TokenGetter<K>
     const transforms = tokenTransformsMap.get(key)
     const prefix = tokenPrefixMap.get(key)
-    const hashed = tokenHashedMap.get(key)
+    const hashed = tokenHashedMap.get(key) ?? mergedHashed.value
 
     if (!getTokens) {
       return
@@ -106,7 +106,7 @@ export function useTokenRegister(
 
     const mergedCompTokens = getMergedTokens(key, tokens)
 
-    const hashId = existedHashId ?? createTokensHash(key, mergedCompTokens as Record<string, string | number>)
+    const hashId = existedHashId ?? createTokensHash(key, mergedCompTokens as Record<string, string | number>, hashed)
 
     if (record?.hashId === hashId) {
       return hashId
@@ -125,7 +125,7 @@ export function useTokenRegister(
     // if hashId is already provided, we consider the style injected already, no need to inject it again
     if (injectThemeStyle.value && !existedHashId) {
       const cssContent = tokenToCss(
-        { ...record, hashId: (hashed ?? mergedHashed.value) ? record.hashId : '' } as TokenRecord<string>,
+        { ...record, hashId: hashed ? record.hashId : '' } as TokenRecord<string>,
         prefix,
         transforms,
       )

--- a/packages/components/theme/src/utils/createTokensHash.ts
+++ b/packages/components/theme/src/utils/createTokensHash.ts
@@ -9,8 +9,10 @@ import hash from '@emotion/hash'
 
 import { themeTokenPrefix } from '../types'
 
+const unhasedHashSalt = '__unhashed__'
+
 const sequenceCache = new Map<string, string[]>()
-export function createTokensHash(key: string, tokens: Record<string, string | number>): string {
+export function createTokensHash(key: string, tokens: Record<string, string | number>, hashed = true): string {
   let sequence = sequenceCache.get(key)
 
   if (!sequence) {
@@ -18,7 +20,13 @@ export function createTokensHash(key: string, tokens: Record<string, string | nu
     sequenceCache.set(key, sequence)
   }
 
-  return `${themeTokenPrefix}-${key}-${hash(flattenTokens(tokens, sequence))}`
+  let str = flattenTokens(tokens, sequence)
+
+  if (!hashed) {
+    str += unhasedHashSalt
+  }
+
+  return `${themeTokenPrefix}-${key}-${hash(str)}`
 }
 
 function flattenTokens(tokens: Record<string, string | number>, sequence: string[]): string {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
主题中，会通过一个组件的所有token的键值对计算hash，如果hash没有变化，则不会重复添加主题样式

但是，对于hashed: false 和 hashed: true 的两组key value 都相同的token，其并不应该相同，也就是应该添加两份样式

而目前的计算逻辑，并没有区分 hashed: true 和 hashed: false 下的token

导致如果存在两个provider，一个配置了hash，一个没有，后执行的provider不会正确添加主题样式

## What is the new behavior?
修复以上问题

## Other information
