### PR TITLE
fix(comp:control-trigger): add suffix size to padding right

### DIFF
--- a/packages/components/_private/trigger/src/Trigger.tsx
+++ b/packages/components/_private/trigger/src/Trigger.tsx
@@ -89,6 +89,7 @@ export default defineComponent({
         [`${prefixCls}-${status}`]: !!status,
         [`${prefixCls}-borderless`]: borderless,
         [`${prefixCls}-paddingless`]: paddingless,
+        [`${prefixCls}-with-suffix`]: slots.suffix || props.suffix || mergedClearable.value,
         [`${prefixCls}-disabled`]: disabled,
         [`${prefixCls}-focused`]: mergedFocused.value,
         [`${prefixCls}-readonly`]: readonly,

--- a/packages/components/_private/trigger/style/index.less
+++ b/packages/components/_private/trigger/style/index.less
@@ -13,6 +13,10 @@
   &:not(.@{trigger-prefix}-paddingless) {
     padding: @vertical-padding calc(var(--ix-padding-size-xs) + var(--ix-padding-size-sm)) @vertical-padding
       @horizontal-padding;
+
+    &.@{trigger-prefix}-with-suffix {
+      padding-right: calc(var(--ix-padding-size-xs) + var(--ix-padding-size-sm) + var(--ix-font-size-icon));
+    }
   }
 
   .@{trigger-prefix}-suffix,

--- a/packages/components/cascader/__tests__/__snapshots__/cascader.spec.ts.snap
+++ b/packages/components/cascader/__tests__/__snapshots__/cascader.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`Cascader > multiple work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-selector ix-selector-md ix-selector-multiple ix-selector-opened ix-cascader ix-control-trigger ix-cascader\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-multiple ix-selector-opened ix-cascader ix-control-trigger ix-cascader\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-overflow ix-selector-overflow \\">
@@ -25,7 +25,7 @@ exports[`Cascader > multiple work > render work 1`] = `
 `;
 
 exports[`Cascader > single work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-cascader ix-control-trigger ix-cascader\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-cascader ix-control-trigger ix-cascader\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Components/General/Button</span>

--- a/packages/components/date-picker/__tests__/__snapshots__/datePicker.spec.ts.snap
+++ b/packages/components/date-picker/__tests__/__snapshots__/datePicker.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`DatePicker > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-control-trigger ix-date-picker\\" tabindex=\\"-1\\" opened=\\"false\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-control-trigger ix-date-picker\\" tabindex=\\"-1\\" opened=\\"false\\">
   <!---->
   <div class=\\"ix-date-picker-input\\"><input class=\\"ix-date-picker-input-inner\\" autocomplete=\\"off\\" placeholder=\\"请选择日期\\" readonly=\\"\\" size=\\"12\\" value=\\"\\"></div>
   <div class=\\"ix-trigger-suffix\\"><i class=\\"ix-icon ix-icon-calendar\\" role=\\"img\\" aria-label=\\"calendar\\"></i></div>

--- a/packages/components/date-picker/__tests__/__snapshots__/dateRangePicker.spec.ts.snap
+++ b/packages/components/date-picker/__tests__/__snapshots__/dateRangePicker.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`DateRangePicker > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-control-trigger ix-date-range-picker\\" tabindex=\\"-1\\" opened=\\"false\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-control-trigger ix-date-range-picker\\" tabindex=\\"-1\\" opened=\\"false\\">
   <!---->
   <div class=\\"ix-date-range-picker-input\\"><input class=\\"ix-date-range-picker-input-inner\\" autocomplete=\\"off\\" placeholder=\\"开始日期\\" readonly=\\"\\" size=\\"12\\" value=\\"\\"><span class=\\"ix-date-range-picker-input-separator\\">至</span><input class=\\"ix-date-range-picker-input-inner\\" autocomplete=\\"off\\" placeholder=\\"结束日期\\" readonly=\\"\\" size=\\"12\\" value=\\"\\"></div>
   <div class=\\"ix-trigger-suffix\\"><i class=\\"ix-icon ix-icon-calendar\\" role=\\"img\\" aria-label=\\"calendar\\"></i></div>

--- a/packages/components/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/packages/components/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`Pagination > render work 3`] = `
   <li class=\\"ix-pagination-item ix-pagination-item-next5\\" tabindex=\\"0\\" title=\\"向后 5 页\\"><span class=\\"ix-pagination-item-content\\"><span class=\\" ix-pagination-item-jumper\\"><i class=\\"ix-icon ix-icon-double-right\\" role=\\"img\\" aria-label=\\"double-right\\"></i><i class=\\"ix-icon ix-icon-ellipsis ix-pagination-item-ellipsis\\" role=\\"img\\" aria-label=\\"ellipsis\\"></i></span></span></li>
   <li class=\\"ix-pagination-item ix-pagination-item-page\\" tabindex=\\"0\\" title=\\"50\\"><span class=\\"ix-pagination-item-content\\">50</span></li>
   <li class=\\"ix-pagination-item ix-pagination-item-next\\" tabindex=\\"0\\" title=\\"下一页\\"><span class=\\"ix-pagination-item-content\\"><i class=\\"ix-icon ix-icon-right\\" role=\\"img\\" aria-label=\\"right\\"></i></span></li>
-  <li class=\\"ix-pagination-sizes\\">每页<div class=\\"ix-trigger ix-trigger-sm ix-selector ix-selector-sm ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+  <li class=\\"ix-pagination-sizes\\">每页<div class=\\"ix-trigger ix-trigger-sm ix-trigger-with-suffix ix-selector ix-selector-sm ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
       <!---->
       <div class=\\"ix-selector-content\\">
         <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">10</span>

--- a/packages/components/select/__tests__/__snapshots__/select.spec.ts.snap
+++ b/packages/components/select/__tests__/__snapshots__/select.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`Select > multiple work > maxLabel responsive work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-overflow ix-selector-overflow \\">
@@ -38,7 +38,7 @@ exports[`Select > multiple work > maxLabel responsive work 1`] = `
 `;
 
 exports[`Select > multiple work > maxLabel responsive work 2`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-overflow ix-selector-overflow \\">
@@ -66,7 +66,7 @@ exports[`Select > multiple work > maxLabel responsive work 2`] = `
 `;
 
 exports[`Select > multiple work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-paddingless ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-multiple ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-overflow ix-selector-overflow \\">
@@ -91,7 +91,7 @@ exports[`Select > multiple work > render work 1`] = `
 `;
 
 exports[`Select > single work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Tom</span>
@@ -107,7 +107,7 @@ exports[`Select > single work > render work 1`] = `
 `;
 
 exports[`Select > template work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-single ix-select ix-control-trigger ix-select\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Tom</span>

--- a/packages/components/time-picker/__tests__/__snapshots__/timePicker.spec.ts.snap
+++ b/packages/components/time-picker/__tests__/__snapshots__/timePicker.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`TimePicker > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-control-trigger ix-time-picker\\" tabindex=\\"-1\\" opened=\\"true\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-control-trigger ix-time-picker\\" tabindex=\\"-1\\" opened=\\"true\\">
   <!----><input class=\\"ix-time-picker-input\\" autocomplete=\\"off\\" placeholder=\\"请选择时间\\" size=\\"12\\" value=\\"\\">
   <div class=\\"ix-trigger-suffix\\"><i class=\\"ix-icon ix-icon-clock-circle\\" role=\\"img\\" aria-label=\\"clock-circle\\"></i></div>
   <!---->

--- a/packages/components/time-picker/__tests__/__snapshots__/timeRangePicker.spec.ts.snap
+++ b/packages/components/time-picker/__tests__/__snapshots__/timeRangePicker.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`TimePicker > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-control-trigger ix-time-range-picker\\" tabindex=\\"-1\\" opened=\\"true\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-control-trigger ix-time-range-picker\\" tabindex=\\"-1\\" opened=\\"true\\">
   <!----><span class=\\"ix-time-range-picker-input\\"><input class=\\"ix-time-range-picker-input-inner\\" autocomplete=\\"off\\" placeholder=\\"起始时间\\" value=\\"\\"><span class=\\"ix-time-range-picker-input-separator\\">至</span><input class=\\"ix-time-range-picker-input-inner\\" autocomplete=\\"off\\" placeholder=\\"结束时间\\" value=\\"\\"></span>
   <div class=\\"ix-trigger-suffix\\"><i class=\\"ix-icon ix-icon-clock-circle\\" role=\\"img\\" aria-label=\\"clock-circle\\"></i></div>
   <!---->

--- a/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
+++ b/packages/components/tree-select/__tests__/__snapshots__/treeSelect.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`TreeSelect > multiple work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -19,7 +19,7 @@ exports[`TreeSelect > multiple work > render work 1`] = `
 `;
 
 exports[`TreeSelect > single work > custom keys work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -37,7 +37,7 @@ exports[`TreeSelect > single work > custom keys work 1`] = `
 `;
 
 exports[`TreeSelect > single work > render work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -55,7 +55,7 @@ exports[`TreeSelect > single work > render work 1`] = `
 `;
 
 exports[`TreeSelect > single work > searchFn work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -73,7 +73,7 @@ exports[`TreeSelect > single work > searchFn work 1`] = `
 `;
 
 exports[`TreeSelect > single work > searchFn work 2`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -93,7 +93,7 @@ exports[`TreeSelect > single work > searchFn work 2`] = `
 `;
 
 exports[`TreeSelect > single work > searchFn work 3`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\" searchvalue=\\"node\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -113,7 +113,7 @@ exports[`TreeSelect > single work > searchFn work 3`] = `
 `;
 
 exports[`TreeSelect > single work > searchable work 1`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-allow-input ix-selector-opened ix-selector-searchable ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-allow-input ix-selector-opened ix-selector-searchable ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-item\\"><span class=\\"ix-selector-item-label\\">Node 0</span>
@@ -131,7 +131,7 @@ exports[`TreeSelect > single work > searchable work 1`] = `
 `;
 
 exports[`TreeSelect > single work > searchable work 2`] = `
-"<div class=\\"ix-trigger ix-trigger-md ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
+"<div class=\\"ix-trigger ix-trigger-md ix-trigger-with-suffix ix-selector ix-selector-md ix-selector-opened ix-selector-single ix-tree-select ix-control-trigger\\" tabindex=\\"-1\\">
   <!---->
   <div class=\\"ix-selector-content\\">
     <div class=\\"ix-selector-input\\"><input class=\\"ix-selector-input-inner\\" style=\\"opacity: 0;\\" autocomplete=\\"off\\" readonly=\\"\\" value=\\"\\">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
时间选择，日期选择等具有后缀的控件，padding没有遮住后缀图标，显示的文字和图标重合了

## What is the new behavior?
修复以上问题，对有后缀的trigger，padding-right 增加一个图标的尺寸

## Other information
