### PR TITLE
fix(comp:contro-trigger): overlay closes when scrolling with virtual scroll

### DIFF
--- a/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
+++ b/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
@@ -72,6 +72,11 @@ export default defineComponent({
 
       resetTriggerFocus()
     })
+    useEventListener(popperElRef, 'wheel', () => {
+      if (overlayFocused.value) {
+        resetTriggerFocus()
+      }
+    })
 
     onMounted(() => {
       bindOverlayMonitor(overlayRef, overlayOpened)

--- a/packages/pro/tag-select/src/content/TagDataEditPanel.tsx
+++ b/packages/pro/tag-select/src/content/TagDataEditPanel.tsx
@@ -68,6 +68,13 @@ export default defineComponent({
       handleTagDataRemove(props.data)
     }
 
+    const handlePanelMousedown = (evt: MouseEvent) => {
+      if (!(evt.target instanceof HTMLInputElement)) {
+        evt.preventDefault()
+        evt.stopImmediatePropagation()
+      }
+    }
+
     const renderColorItem = (prefixCls: string, color: TagSelectColor) => {
       const isSelected = color.key === props.data.color.key
       const colorItemPrefixCls = `${prefixCls}-item`
@@ -113,7 +120,7 @@ export default defineComponent({
       const prefixCls = `${mergedPrefixCls.value}-edit-panel`
 
       return (
-        <div class={[prefixCls, globalHashId.value, hashId.value]}>
+        <div class={[prefixCls, globalHashId.value, hashId.value]} onMousedown={handlePanelMousedown}>
           <div class={`${prefixCls}-input`}>
             <IxFormItem
               messageTooltip


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当控件的浮层中有虚拟滚动时，聚焦到虚拟滚动中渲染的选择后，滚动面板使聚焦的选项不再被渲染，会导致浮层失焦从而浮层异常关闭

## What is the new behavior?
修复以上问题

影响组件：control-trigger, select, cascader, tree-select, date-picker, time-picker, pro-tag-select

## Other information
当聚焦在浮层中，并且触发了wheel事件后，将焦点重置到trigger上