### PR TITLE
fix(pro:textarea): row number is `0` when value is undefined

### DIFF
--- a/packages/pro/textarea/src/composables/useLineRender.ts
+++ b/packages/pro/textarea/src/composables/useLineRender.ts
@@ -88,6 +88,10 @@ export function useErrorLineRender(
       currentTop += height
     }
 
+    if (lineTopIndex === -1) {
+      lineTopIndex = 0
+    }
+
     setRenderedErrors(newErrors)
     setRenderedLinesIndex({ start: lineTopIndex, end: lineBottomIndex })
     setRenderedTopOffset(offsetTop)

--- a/packages/pro/textarea/src/composables/useRowsCounts.ts
+++ b/packages/pro/textarea/src/composables/useRowsCounts.ts
@@ -7,7 +7,7 @@
 
 import type { ProTextareaProps } from '../types'
 
-import { type ComputedRef, type Ref, watch } from 'vue'
+import { type ComputedRef, type Ref, onMounted, watch } from 'vue'
 
 import { useResizeObserver } from '@idux/cdk/resize'
 import { useState } from '@idux/cdk/utils'
@@ -38,6 +38,7 @@ export function useRowCounts(
     const { rows } = props
     const currentRowCounts = rowCounts.value
     const currentRowHeights = rowHeights.value
+    const currentLineHeight = lineHeight.value
 
     const counts: number[] = []
     const heights: number[] = []
@@ -64,20 +65,23 @@ export function useRowCounts(
         true,
       )
 
-      counts[index] = Math.round(height / lineHeight.value)
+      counts[index] = Math.round(height / currentLineHeight)
       heights[index] = height
     })
 
     if (rows && lines.length < rows) {
       counts.push(...new Array(rows - lines.length).fill(1))
-      heights.push(...new Array(rows - lines.length).fill(lineHeight.value))
+      heights.push(...new Array(rows - lines.length).fill(currentLineHeight))
     }
 
     setRowCounts(counts)
     setRowHeights(heights)
   }
 
-  watch([valueRef, () => props.rows], calcRowCounts)
+  onMounted(() => {
+    watch([valueRef, () => props.rows], calcRowCounts, { immediate: true })
+  })
+
   useResizeObserver(textareaRef, ({ contentRect: { width } }) => {
     if (textareaWidth && textareaWidth !== width) {
       cachedRowCharLength = []


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当初始的value是undefined的时候，第一行的行号是0

## What is the new behavior?
修复以上问题，第一行的行号始终是1

## Other information
