### PR TITLE
fix(pro:table): modify trigger padding of last column

### DIFF
--- a/packages/pro/table/style/index.less
+++ b/packages/pro/table/style/index.less
@@ -119,7 +119,7 @@
       .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-fixed-holder {
         table > thead > tr:first-child {
           th:nth-last-of-type(2) .@{table-prefix}-cell-triggers {
-            padding-right: 30px;
+            padding-right: calc(var(--ix-font-size-icon) + var(--ix-padding-size-sm) * 2 - var(--ix-scrollbar-width));
           }
         }
       }
@@ -130,7 +130,7 @@
       .@{pro-table-prefix}-layout-tool-trigger + .@{table-prefix}-fixed-holder {
         table > thead > tr:first-child {
           th:last-child > .@{table-prefix}-cell-triggers {
-            padding-right: 38px;
+            padding-right: calc(var(--ix-font-size-icon) + var(--ix-padding-size-sm) * 2);
           }
         }
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
最后一列的筛选、排序触发按钮的右padding没有根据实际尺寸进行计算，而是写死了尺寸

## What is the new behavior?
修复以上问题

## Other information
