### PR TITLE
fix(comp:control-trigger): mousedown on overlay triggers blur

### DIFF
--- a/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
+++ b/packages/components/control-trigger/src/ControlTriggerOverlay.tsx
@@ -70,6 +70,8 @@ export default defineComponent({
         return
       }
 
+      evt.preventDefault()
+
       resetTriggerFocus()
     })
     useEventListener(popperElRef, 'wheel', () => {

--- a/packages/components/date-picker/src/content/Content.tsx
+++ b/packages/components/date-picker/src/content/Content.tsx
@@ -153,7 +153,7 @@ export default defineComponent({
       }
 
       const children = [
-        <div class={`${prefixCls}-body`} tabindex={-1}>
+        <div class={`${prefixCls}-body`}>
           {renderInputs(inputsCls)}
           <Panel v-slots={slots} {...paneProps} />
         </div>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当contro-trigger的浮层中不存在任何一个可聚焦的元素时，在浮层上触发的 mousedown 会触发 blur 事件并使浮层关闭

## What is the new behavior?
修复以上问题

## Other information
