### PR TITLE
fix(pro:search): component still interactable when disabled

### DIFF
--- a/packages/pro/search/src/ProSearch.tsx
+++ b/packages/pro/search/src/ProSearch.tsx
@@ -104,7 +104,7 @@ export default defineComponent({
       bindOverlayMonitor(quickSelectOverlayRef, quickSelectOverlayOpened)
     })
 
-    useControl(elementRef, activeSegmentContext, searchStateContext, focusStateContext)
+    useControl(props, elementRef, activeSegmentContext, searchStateContext, focusStateContext)
 
     const currentZIndex = useZIndex(toRef(props, 'zIndex'), toRef(componentCommon, 'overlayZIndex'), focused)
     const { isActive, overlayOpened, quickSelectActive, setTempActive, setOverlayOpened } = activeSegmentContext

--- a/packages/pro/search/src/composables/useActiveSegment.ts
+++ b/packages/pro/search/src/composables/useActiveSegment.ts
@@ -41,7 +41,7 @@ export function useActiveSegment(
   enableQuickSelect: ComputedRef<boolean>,
   isSegmentVisible: (key: VKey, name: string) => boolean,
 ): ActiveSegmentContext {
-  const [activeSegment, setActiveSegment] = useState<ActiveSegment | undefined>(undefined)
+  const [activeSegment, _setActiveSegment] = useState<ActiveSegment | undefined>(undefined)
   const [nameSelectActive, _setNameSelectActive] = useState<boolean>(false)
   const [quickSelectActive, _setQuickSelectActive] = useState<boolean>(false)
   const [overlayOpened, setOverlayOpened] = useState<boolean>(false)
@@ -56,6 +56,15 @@ export function useActiveSegment(
       segment => segment.itemKey === activeSegment.value?.itemKey && segment.name === activeSegment.value.name,
     ),
   )
+
+  const setActiveSegment = (segment: ActiveSegment | undefined) => {
+    if (props.disabled) {
+      _setActiveSegment(undefined)
+      return
+    }
+
+    _setActiveSegment(segment)
+  }
 
   const updateActiveSegment = (segment: ActiveSegment | undefined) => {
     if (

--- a/packages/pro/search/src/composables/useControl.ts
+++ b/packages/pro/search/src/composables/useControl.ts
@@ -8,12 +8,14 @@
 import type { ActiveSegmentContext } from './useActiveSegment'
 import type { FocusStateContext } from './useFocusedState'
 import type { SearchStateContext } from './useSearchStates'
+import type { ProSearchProps } from '../types'
 
 import { type Ref, onBeforeUnmount, watch } from 'vue'
 
 import { isFocusable, useEventListener } from '@idux/cdk/utils'
 
 export function useControl(
+  props: ProSearchProps,
   elementRef: Ref<HTMLElement | undefined>,
   activeSegmentContext: ActiveSegmentContext,
   searchStateContext: SearchStateContext,
@@ -45,6 +47,11 @@ export function useControl(
     }
   })([
     useEventListener(elementRef, 'mousedown', evt => {
+      if (props.disabled) {
+        evt.preventDefault()
+        return
+      }
+
       if (!focused.value) {
         return
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当 proSeaarch 被禁用的时候，组件依然可以操作，选择筛选条件

## What is the new behavior?
修复以上问题

## Other information
1. 禁用的时候，阻止mousedown事件触发
2. 禁用的时候，不设置任何激活的segment，全部设置为undefined