### PR TITLE
fix(pro:search): segment input width measure is incorrect

### DIFF
--- a/packages/pro/search/src/components/segment/SegmentInput.tsx
+++ b/packages/pro/search/src/components/segment/SegmentInput.tsx
@@ -70,7 +70,7 @@ export default defineComponent({
       watch(
         displayedText,
         text => {
-          setTextWidth(measureTextWidth(text, segmentWrapperRef.value))
+          setTextWidth(measureTextWidth(text, segmentInputRef.value))
         },
         { immediate: true },
       )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
搜索项的input宽度计算不准确

## What is the new behavior?
修复以上问题

## Other information
计算的时候使用了input元素的父元素的样式，实际上应该使用input元素的样式进行计算