### PR TITLE
fix(comp:control-trigger): padding right wtih suffix is incorrect

### DIFF
--- a/packages/components/_private/trigger/style/index.less
+++ b/packages/components/_private/trigger/style/index.less
@@ -15,7 +15,7 @@
       @horizontal-padding;
 
     &.@{trigger-prefix}-with-suffix {
-      padding-right: calc(var(--ix-padding-size-xs) + var(--ix-padding-size-sm) + var(--ix-font-size-icon));
+      padding-right: calc(var(--ix-padding-size-sm) + var(--ix-font-size-icon));
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
有后缀图表的 control-trigger 的右边距增加了一个 padding-size-xs 作为文字和图表的间距，实际上并不需要，而且会导致原组件中的比较短的控件文字位置不足

## What is the new behavior?
修复以上问题，去掉 padding-size-xs

## Other information
