### PR TITLE
fix(pro:search): search item input text width measure incorrect

### DIFF
--- a/packages/pro/search/src/utils/measureTextWidth.ts
+++ b/packages/pro/search/src/utils/measureTextWidth.ts
@@ -8,11 +8,20 @@
 const measureElementStyle = {
   position: 'fixed',
   visibility: 'hidden',
-  whiteSpace: 'pre-wrap',
+  'white-space': 'pre-wrap',
   top: '-100px',
   left: '-100px',
 } as const
-const textWidthStyleProps = ['fontSize', 'letterSpacing'] as const
+const textWidthStyleProps = [
+  {
+    propertyKey: 'font-size',
+    computedStyleKey: 'fontSize',
+  },
+  {
+    propertyKey: 'letter-spacing',
+    computedStyleKey: 'letterSpacing',
+  },
+] as const
 
 export function measureTextWidth(text: string, parentEl?: HTMLElement): number {
   const _parentEl = parentEl as (HTMLElement & { __pro_search_measure_el: HTMLSpanElement }) | undefined
@@ -25,8 +34,8 @@ export function measureTextWidth(text: string, parentEl?: HTMLElement): number {
 
   if (parentEl) {
     const parentStyle = getComputedStyle(parentEl)
-    textWidthStyleProps.forEach(key => {
-      el.style.setProperty(key, parentStyle[key])
+    textWidthStyleProps.forEach(prop => {
+      el.style.setProperty(prop.propertyKey, parentStyle[prop.computedStyleKey])
     })
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
用于proSearch 的搜索项 Input 文字宽度测量的css属性名拼写不正确，导致测量结果不正确

## What is the new behavior?
修复以上问题

## Other information
