### PR TITLE
fix(comp:desc): ensure that the label and content are aligned at the top

### DIFF
--- a/packages/components/desc/style/index.less
+++ b/packages/components/desc/style/index.less
@@ -14,6 +14,7 @@
       text-align: end;
       white-space: nowrap;
       color: var(--ix-desc-label-color);
+      vertical-align: top;
 
       &::after {
         position: relative;
@@ -40,6 +41,7 @@
     display: table-cell;
     width: 100%;
     padding-right: 16px;
+    vertical-align: top;
   }
 
   &-sm &-item {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
如果 content 内容中有元素撑高了 content，例如图标设置比较大，或者有元素设置了 margin-top，都会使得 label 往下掉，这样就会跟其他的 desc-item 对不齐。

## What is the new behavior?
label 和 content 两个元素都能向上对齐。

## Other information
