### PR TITLE
fix(cdk:dnd): useDndMovable init doesn't work

### DIFF
--- a/packages/cdk/dnd/src/composables/useDndMovable/useMovablePosition.ts
+++ b/packages/cdk/dnd/src/composables/useDndMovable/useMovablePosition.ts
@@ -163,6 +163,8 @@ export function useMovablePosition(
       initPosition(element)
       initOffset(element, reset)
     }
+
+    updateMoveOffset({ x: 0, y: 0 })
   }
 
   watch([elementRef, strategy], () => init(), { immediate: true })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
useDndMovable 的初始化 init，调用之后不会重置移动的偏移量

## What is the new behavior?
修复以上问题

## Other information
