### PR TITLE
feat(pro:search): add quickSelect item size theme tokens

### DIFF
--- a/packages/components/dark.full.css
+++ b/packages/components/dark.full.css
@@ -507,6 +507,9 @@
   --ix-date-picker-range-overlay-footer-padding: 8px 0;
   --ix-date-picker-range-overlay-separator-width: 32px;
   --ix-date-picker-range-overlay-separator-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-height: 32px;
+  --ix-date-picker-range-shortcuts-item-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-padding: 8px 12px;
   --ix-date-picker-panel-font-size: 12px;
   --ix-date-picker-panel-color: #f4f8ff;
   --ix-date-picker-panel-cell-width: 28px;

--- a/packages/components/date-picker/docs/Theme.zh.md
+++ b/packages/components/date-picker/docs/Theme.zh.md
@@ -37,4 +37,7 @@
 | `rangeOverlayPadding` |  | `string | number` | `16px 16px 0 16px` | `16px 16px 0 16px` |
 | `rangeOverlaySeparatorFontSize` |  | `number` | `12` | `12` |
 | `rangeOverlaySeparatorWidth` |  | `string | number` | `32` | `32` |
+| `rangeShortcutsItemFontSize` |  | `number` | `12` | `12` |
+| `rangeShortcutsItemHeight` |  | `number` | `32` | `32` |
+| `rangeShortcutsItemPadding` |  | `string` | `8px 12px` | `8px 12px` |
 | `separatorMarginHorizontal` |  | `string | number` | `16` | `16` |

--- a/packages/components/date-picker/theme/dark.css
+++ b/packages/components/date-picker/theme/dark.css
@@ -13,6 +13,9 @@
   --ix-date-picker-range-overlay-footer-padding: 8px 0;
   --ix-date-picker-range-overlay-separator-width: 32px;
   --ix-date-picker-range-overlay-separator-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-height: 32px;
+  --ix-date-picker-range-shortcuts-item-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-padding: 8px 12px;
   --ix-date-picker-panel-font-size: 12px;
   --ix-date-picker-panel-color: #f4f8ff;
   --ix-date-picker-panel-cell-width: 28px;

--- a/packages/components/date-picker/theme/default.css
+++ b/packages/components/date-picker/theme/default.css
@@ -13,6 +13,9 @@
   --ix-date-picker-range-overlay-footer-padding: 8px 0;
   --ix-date-picker-range-overlay-separator-width: 32px;
   --ix-date-picker-range-overlay-separator-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-height: 32px;
+  --ix-date-picker-range-shortcuts-item-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-padding: 8px 12px;
   --ix-date-picker-panel-font-size: 12px;
   --ix-date-picker-panel-color: #2f3540;
   --ix-date-picker-panel-cell-width: 28px;

--- a/packages/components/default.full.css
+++ b/packages/components/default.full.css
@@ -505,6 +505,9 @@
   --ix-date-picker-range-overlay-footer-padding: 8px 0;
   --ix-date-picker-range-overlay-separator-width: 32px;
   --ix-date-picker-range-overlay-separator-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-height: 32px;
+  --ix-date-picker-range-shortcuts-item-font-size: 12px;
+  --ix-date-picker-range-shortcuts-item-padding: 8px 12px;
   --ix-date-picker-panel-font-size: 12px;
   --ix-date-picker-panel-color: #2f3540;
   --ix-date-picker-panel-cell-width: 28px;

--- a/packages/pro/dark.full.css
+++ b/packages/pro/dark.full.css
@@ -64,8 +64,6 @@
   --ix-pro-search-container-padding-md: 4px;
   --ix-pro-search-tag-gap-sm: 2px;
   --ix-pro-search-tag-gap-md: 4px;
-  --ix-pro-search-quick-select-padding-sm: 8px;
-  --ix-pro-search-quick-select-padding-md: 12px;
   --ix-pro-search-tag-color: #f4f8ff;
   --ix-pro-search-tag-bg-color: #1f2329;
   --ix-pro-search-tag-color-disabled: #687080;
@@ -84,6 +82,12 @@
   --ix-pro-search-select-panel-min-width: 100px;
   --ix-pro-search-tree-select-panel-min-width: 200px;
   --ix-pro-search-tree-select-panel-max-width: 400px;
+  --ix-pro-search-quick-select-padding-sm: 8px;
+  --ix-pro-search-quick-select-padding-md: 12px;
+  --ix-pro-search-quick-select-item-min-width: 220px;
+  --ix-pro-search-quick-select-item-max-height: 345px;
+  --ix-pro-search-quick-select-select-panel-min-height: 230px;
+  --ix-pro-search-quick-select-tree-select-panel-min-height: 230px;
 }
 
 /* ------ pro-tag-select css variables ------ */

--- a/packages/pro/default.full.css
+++ b/packages/pro/default.full.css
@@ -54,8 +54,6 @@
   --ix-pro-search-container-padding-md: 4px;
   --ix-pro-search-tag-gap-sm: 2px;
   --ix-pro-search-tag-gap-md: 4px;
-  --ix-pro-search-quick-select-padding-sm: 8px;
-  --ix-pro-search-quick-select-padding-md: 12px;
   --ix-pro-search-tag-color: #2f3540;
   --ix-pro-search-tag-bg-color: #edf1f7;
   --ix-pro-search-tag-color-disabled: #bec3cc;
@@ -74,6 +72,12 @@
   --ix-pro-search-select-panel-min-width: 100px;
   --ix-pro-search-tree-select-panel-min-width: 200px;
   --ix-pro-search-tree-select-panel-max-width: 400px;
+  --ix-pro-search-quick-select-padding-sm: 8px;
+  --ix-pro-search-quick-select-padding-md: 12px;
+  --ix-pro-search-quick-select-item-min-width: 220px;
+  --ix-pro-search-quick-select-item-max-height: 345px;
+  --ix-pro-search-quick-select-select-panel-min-height: 230px;
+  --ix-pro-search-quick-select-tree-select-panel-min-height: 230px;
 }
 
 /* ------ pro-tag-select css variables ------ */

--- a/packages/pro/search/docs/Theme.zh.md
+++ b/packages/pro/search/docs/Theme.zh.md
@@ -6,8 +6,12 @@
 | `heightSm` | sm 尺寸高度 | `number` | `24` | `24` |
 | `namePanelMinWidth` | 搜索项名称选择面板的最小宽度 | `number` | `160` | `160` |
 | `operatorPanelMinWidth` | 操作符选择面板的最小宽度 | `number` | `20` | `20` |
+| `quickSelectItemMaxHeight` | 快捷搜索面板中搜索项的最大高度 | `number` | `345` | `345` |
+| `quickSelectItemMinWidth` | 快捷搜索面板中搜索项的最小宽度 | `number` | `220` | `220` |
 | `quickSelectPaddingMd` | md 尺寸快捷搜索面板padding | `string | number` | `12` | `12` |
 | `quickSelectPaddingSm` | sm 尺寸快捷搜索面板padding | `string | number` | `8` | `8` |
+| `quickSelectSelectPanelMinHeight` | 快捷搜索面板中select面板的最小高度 | `number` | `230` | `230` |
+| `quickSelectTreeSelectPanelMinHeight` | 快捷搜索面板中treeSelect面板的最小高度 | `number` | `230` | `230` |
 | `searchBtnBgColor` | 搜索按钮背景颜色 | `string` | `#1c6eff` | `#4083E8` |
 | `searchBtnBgColorDisabled` | 搜索按钮禁用背景颜色 | `string` | `#bec3cc` | `#687080` |
 | `searchBtnBgColorHover` | 搜索按钮悬浮背景颜色 | `string` | `#458fff` | `#1B61DD` |

--- a/packages/pro/search/style/quick-select.less
+++ b/packages/pro/search/style/quick-select.less
@@ -67,8 +67,8 @@
     }
   }
   &-item {
-    min-width: 220px;
-    max-height: 345px;
+    min-width: var(--ix-pro-search-quick-select-item-min-width);
+    max-height: var(--ix-pro-search-quick-select-item-max-height);
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -134,7 +134,7 @@
       min-width: 252px;
     }
     .@{pro-search-prefix}-select-panel {
-      min-height: 230px;
+      min-height: var(--ix-pro-search-quick-select-select-panel-min-height);
       .@{select-option-prefix} {
         padding: var(--ix-padding-size-sm);
         &-selected:not(&-disabled) {
@@ -144,7 +144,7 @@
     }
 
     .@{pro-search-prefix}-tree-select-panel {
-      min-height: 230px;
+      min-height: var(--ix-pro-search-quick-select-tree-select-panel-min-height);
     }
     .@{pro-search-prefix}-date-picker-panel {
       width: 493px;

--- a/packages/pro/search/theme/dark.css
+++ b/packages/pro/search/theme/dark.css
@@ -6,8 +6,6 @@
   --ix-pro-search-container-padding-md: 4px;
   --ix-pro-search-tag-gap-sm: 2px;
   --ix-pro-search-tag-gap-md: 4px;
-  --ix-pro-search-quick-select-padding-sm: 8px;
-  --ix-pro-search-quick-select-padding-md: 12px;
   --ix-pro-search-tag-color: #f4f8ff;
   --ix-pro-search-tag-bg-color: #1f2329;
   --ix-pro-search-tag-color-disabled: #687080;
@@ -26,4 +24,10 @@
   --ix-pro-search-select-panel-min-width: 100px;
   --ix-pro-search-tree-select-panel-min-width: 200px;
   --ix-pro-search-tree-select-panel-max-width: 400px;
+  --ix-pro-search-quick-select-padding-sm: 8px;
+  --ix-pro-search-quick-select-padding-md: 12px;
+  --ix-pro-search-quick-select-item-min-width: 220px;
+  --ix-pro-search-quick-select-item-max-height: 345px;
+  --ix-pro-search-quick-select-select-panel-min-height: 230px;
+  --ix-pro-search-quick-select-tree-select-panel-min-height: 230px;
 }

--- a/packages/pro/search/theme/default.css
+++ b/packages/pro/search/theme/default.css
@@ -6,8 +6,6 @@
   --ix-pro-search-container-padding-md: 4px;
   --ix-pro-search-tag-gap-sm: 2px;
   --ix-pro-search-tag-gap-md: 4px;
-  --ix-pro-search-quick-select-padding-sm: 8px;
-  --ix-pro-search-quick-select-padding-md: 12px;
   --ix-pro-search-tag-color: #2f3540;
   --ix-pro-search-tag-bg-color: #edf1f7;
   --ix-pro-search-tag-color-disabled: #bec3cc;
@@ -26,4 +24,10 @@
   --ix-pro-search-select-panel-min-width: 100px;
   --ix-pro-search-tree-select-panel-min-width: 200px;
   --ix-pro-search-tree-select-panel-max-width: 400px;
+  --ix-pro-search-quick-select-padding-sm: 8px;
+  --ix-pro-search-quick-select-padding-md: 12px;
+  --ix-pro-search-quick-select-item-min-width: 220px;
+  --ix-pro-search-quick-select-item-max-height: 345px;
+  --ix-pro-search-quick-select-select-panel-min-height: 230px;
+  --ix-pro-search-quick-select-tree-select-panel-min-height: 230px;
 }

--- a/packages/pro/search/theme/default.ts
+++ b/packages/pro/search/theme/default.ts
@@ -32,8 +32,6 @@ export function getDefaultThemeTokens(tokens: GlobalThemeTokens): ProCertainThem
     containerPaddingMd: paddingSizeXs,
     tagGapSm: paddingSize2Xs,
     tagGapMd: paddingSizeXs,
-    quickSelectPaddingSm: paddingSizeSm,
-    quickSelectPaddingMd: paddingSizeMd,
 
     tagColor: colorText,
     tagBgColor: colorEmphasizedContainerBg,
@@ -57,5 +55,12 @@ export function getDefaultThemeTokens(tokens: GlobalThemeTokens): ProCertainThem
     selectPanelMinWidth: 100,
     treeSelectPanelMinWidth: 200,
     treeSelectPanelMaxWidth: 400,
+
+    quickSelectPaddingSm: paddingSizeSm,
+    quickSelectPaddingMd: paddingSizeMd,
+    quickSelectItemMinWidth: 220,
+    quickSelectItemMaxHeight: 345,
+    quickSelectSelectPanelMinHeight: 230,
+    quickSelectTreeSelectPanelMinHeight: 230,
   }
 }

--- a/packages/pro/search/theme/tokens.ts
+++ b/packages/pro/search/theme/tokens.ts
@@ -30,14 +30,6 @@ export interface ProSearchThemeTokens {
    * @desc md 尺寸标签间距
    */
   tagGapMd: number
-  /**
-   * @desc sm 尺寸快捷搜索面板padding
-   */
-  quickSelectPaddingSm: string | number
-  /**
-   * @desc md 尺寸快捷搜索面板padding
-   */
-  quickSelectPaddingMd: string | number
 
   /**
    * @desc 标签字体颜色
@@ -115,4 +107,29 @@ export interface ProSearchThemeTokens {
    * @desc treeSelect搜索项面板的最大宽度
    */
   treeSelectPanelMaxWidth: number
+
+  /**
+   * @desc sm 尺寸快捷搜索面板padding
+   */
+  quickSelectPaddingSm: string | number
+  /**
+   * @desc md 尺寸快捷搜索面板padding
+   */
+  quickSelectPaddingMd: string | number
+  /**
+   * @desc 快捷搜索面板中搜索项的最小宽度
+   */
+  quickSelectItemMinWidth: number
+  /**
+   * @desc 快捷搜索面板中搜索项的最大高度
+   */
+  quickSelectItemMaxHeight: number
+  /**
+   * @desc 快捷搜索面板中select面板的最小高度
+   */
+  quickSelectSelectPanelMinHeight: number
+  /**
+   * @desc 快捷搜索面板中treeSelect面板的最小高度
+   */
+  quickSelectTreeSelectPanelMinHeight: number
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
## What is the new behavior?
新增IxProSearch组件的快捷搜索元素宽高相关的主题TOKEN

 quickSelectItemMinWidth: 快捷搜索面板中搜索项的最小宽度
 quickSelectItemMaxHeight: 快捷搜索面板中搜索项的最大高度
 quickSelectSelectPanelMinHeight: 快捷搜索面板中select面板的最小高度
 quickSelectTreeSelectPanelMinHeight: 快捷搜索面板中treeSelect面板的最小高度

## Other information
