### PR TITLE
fix(comp:pagination): size select text shouldn't overflow at 100

### DIFF
--- a/packages/components/pagination/style/index.less
+++ b/packages/components/pagination/style/index.less
@@ -27,7 +27,7 @@
   &-sm,
   &-md {
     .@{pagination-prefix}-sizes > .@{select-prefix} {
-      width: 60px;
+      width: 64px;
     }
 
     .@{pagination-prefix}-item,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
分页器在选择了每页100条时，size选择器出现了文字溢出

## What is the new behavior?
加宽size选择框的宽度到64，避免该问题

## Other information
