### PR TITLE
feat(cdk:popper): popper visible supports fully controlled

### DIFF
--- a/packages/cdk/popper/__tests__/__snapshots__/popper.spec.ts.snap
+++ b/packages/cdk/popper/__tests__/__snapshots__/popper.spec.ts.snap
@@ -22,57 +22,57 @@ exports[`usePopper > options > offset work 2`] = `
 
 exports[`usePopper > options > placement work 1`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="top-start">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 2`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="top">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 3`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="top-end">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 4`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="right-start">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 5`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="right">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 6`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="right-end">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 7`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="bottom-start">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 8`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="bottom">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 9`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="bottom-end">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 10`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-start">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 11`] = `
 "<div id="trigger">Trigger</div>
-<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left-end">Popper</div>"
+<div id="overlay" style="position: absolute; left: 0px; top: 0px;" data-popper-reference-hidden="" data-popper-placement="left">Popper</div>"
 `;
 
 exports[`usePopper > options > placement work 12`] = `

--- a/packages/cdk/popper/__tests__/popper.spec.ts
+++ b/packages/cdk/popper/__tests__/popper.spec.ts
@@ -1,29 +1,60 @@
-import { flushPromises, mount } from '@vue/test-utils'
-import { onBeforeUnmount, onMounted } from 'vue'
+import { MountingOptions, flushPromises, mount } from '@vue/test-utils'
+import { PropType, Ref, UnwrapRef, defineComponent, onBeforeUnmount, onMounted, toRefs } from 'vue'
 
 import { wait } from '@tests'
+
+import { ExtractPublicPropTypes } from '@idux/cdk/utils'
 
 import { PopperOptions } from '../src/types'
 import { usePopper } from '../src/usePopper'
 
-describe('usePopper', () => {
-  const PopperTestMount = (options?: PopperOptions) =>
-    mount({
-      setup() {
-        const instance = usePopper(options)
-        onMounted(() => instance.initialize())
-        onBeforeUnmount(() => instance.destroy())
-        return instance
-      },
-      template: `
-      <div id="trigger" ref="triggerRef" v-bind="triggerEvents">Trigger</div>
-      <div v-if="visibility" id="overlay" ref="popperRef" v-bind="popperEvents">Popper</div>
-    `,
+const popperProps = {
+  allowEnter: { type: Boolean, default: undefined },
+  autoAdjust: { type: Boolean, default: undefined },
+  delay: { type: [Number, Array] as PropType<number | [number | null, number | null]>, default: undefined },
+  disabled: { type: Boolean, default: undefined },
+  offset: { type: Array as PropType<number[]>, default: undefined },
+  placement: { type: String as PropType<UnwrapRef<PopperOptions['placement']>>, default: undefined },
+  trigger: { type: String as PropType<UnwrapRef<PopperOptions['trigger']>>, default: undefined },
+  visible: { type: Boolean, default: undefined },
+  strategy: { type: String as PropType<UnwrapRef<PopperOptions['strategy']>>, default: undefined },
+  onVisibleChange: { type: Function as PropType<(visible: boolean) => void>, default: undefined },
+} as const
+
+type PopperProps = ExtractPublicPropTypes<typeof popperProps>
+
+const PopperComponent = defineComponent({
+  props: popperProps,
+  setup(props) {
+    const { allowEnter, autoAdjust, delay, disabled, offset, placement, trigger, visible, strategy } = toRefs(props)
+    const instance = usePopper({
+      allowEnter,
+      autoAdjust,
+      delay,
+      disabled,
+      offset: offset as Ref<[number, number] | undefined>,
+      placement,
+      trigger,
+      visible,
+      strategy,
+      onVisibleChange: props.onVisibleChange,
     })
+    onMounted(() => instance.initialize())
+    onBeforeUnmount(() => instance.destroy())
+    return instance
+  },
+  template: `
+  <div id="trigger" ref="triggerRef" v-bind="triggerEvents">Trigger</div>
+  <div v-if="visibility" id="overlay" ref="popperRef" v-bind="popperEvents">Popper</div>
+`,
+})
+
+describe('usePopper', () => {
+  const PopperTestMount = (options?: MountingOptions<Partial<PopperProps>>) => mount(PopperComponent, { ...options })
 
   describe('options', () => {
     test('allowEnter work', async () => {
-      const wrapper = PopperTestMount({ allowEnter: true, delay: 50 })
+      const wrapper = PopperTestMount({ props: { allowEnter: true, delay: 50 } })
       await flushPromises()
       await wrapper.find('#trigger').trigger('mouseenter')
       await wait(50)
@@ -42,7 +73,7 @@ describe('usePopper', () => {
       expect(wrapper.find('#overlay').exists()).toBe(false)
 
       // false
-      wrapper.vm.update({ allowEnter: false })
+      await wrapper.setProps({ allowEnter: false })
       await flushPromises()
       await wrapper.find('#trigger').trigger('mouseenter')
       await wait(50)
@@ -57,36 +88,36 @@ describe('usePopper', () => {
     })
 
     test('autoAdjust work', async () => {
-      const wrapper = PopperTestMount({ autoAdjust: true })
+      const wrapper = PopperTestMount({ props: { autoAdjust: true } })
       await flushPromises()
 
       expect(wrapper.html()).toMatchSnapshot()
 
-      wrapper.vm.update({ autoAdjust: false })
+      await wrapper.setProps({ autoAdjust: false })
       await flushPromises()
 
       expect(wrapper.html()).toMatchSnapshot()
     })
 
     test('disabled work', async () => {
-      const wrapper = PopperTestMount({ disabled: true, visible: true })
+      const wrapper = PopperTestMount({ props: { disabled: true, visible: true } })
       await flushPromises()
 
       expect(wrapper.find('#overlay').exists()).toBe(false)
 
-      wrapper.vm.update({ disabled: false })
+      await wrapper.setProps({ disabled: false })
       await flushPromises()
 
       expect(wrapper.find('#overlay').exists()).toBe(true)
     })
 
     test('offset work', async () => {
-      const wrapper = PopperTestMount({ offset: [4, 4], visible: true })
+      const wrapper = PopperTestMount({ props: { offset: [4, 4], visible: true } })
       await flushPromises()
 
       expect(wrapper.html()).toMatchSnapshot()
 
-      wrapper.vm.update({ offset: [8, 8] })
+      await wrapper.setProps({ offset: [8, 8] })
 
       await flushPromises()
 
@@ -94,7 +125,7 @@ describe('usePopper', () => {
     })
 
     test('placement work', async () => {
-      const wrapper = PopperTestMount({ visible: true })
+      const wrapper = PopperTestMount({ props: { visible: true } })
       const placements = [
         'topStart',
         'top',
@@ -110,58 +141,63 @@ describe('usePopper', () => {
         'leftEnd',
       ] as const
 
-      await Promise.all(
-        placements.map(async placement => {
-          wrapper.vm.update({ placement })
-
-          await flushPromises()
-
-          expect(wrapper.html()).toMatchSnapshot()
-        }),
-      )
+      for (const placement of placements) {
+        await wrapper.setProps({ placement })
+        await flushPromises()
+        expect(wrapper.html()).toMatchSnapshot()
+      }
     })
 
     test('trigger', async () => {
-      const wrapper = PopperTestMount()
+      const onVisibleChange = vi.fn()
+      const wrapper = PopperTestMount({ props: { onVisibleChange } })
 
       // hover
 
       await flushPromises()
       await wrapper.find('#trigger').trigger('mouseenter')
       expect(wrapper.find('#overlay').exists()).toBe(true)
+      expect(onVisibleChange).toBeCalledWith(true)
       await wrapper.find('#trigger').trigger('mouseleave')
       expect(wrapper.find('#overlay').exists()).toBe(false)
+      expect(onVisibleChange).toBeCalledWith(false)
 
       // focus
-      wrapper.vm.update({ trigger: 'focus' })
+      await wrapper.setProps({ trigger: 'focus' })
 
       await flushPromises()
       await wrapper.find('#trigger').trigger('focus')
       expect(wrapper.find('#overlay').exists()).toBe(true)
+      expect(onVisibleChange).toBeCalledWith(true)
       await wrapper.find('#trigger').trigger('blur')
       expect(wrapper.find('#overlay').exists()).toBe(false)
+      expect(onVisibleChange).toBeCalledWith(false)
 
       // click
-      wrapper.vm.update({ trigger: 'click' })
+      await wrapper.setProps({ trigger: 'click' })
 
       await flushPromises()
       await wrapper.find('#trigger').trigger('click')
       expect(wrapper.find('#overlay').exists()).toBe(true)
+      expect(onVisibleChange).toBeCalledWith(true)
       await wrapper.find('#trigger').trigger('click')
       expect(wrapper.find('#overlay').exists()).toBe(false)
+      expect(onVisibleChange).toBeCalledWith(false)
 
       // contextmenu
-      wrapper.vm.update({ trigger: 'contextmenu' })
+      await wrapper.setProps({ trigger: 'contextmenu' })
 
       await flushPromises()
       await wrapper.find('#trigger').trigger('contextmenu')
       expect(wrapper.find('#overlay').exists()).toBe(true)
+      expect(onVisibleChange).toBeCalledWith(true)
       await wrapper.find('#trigger').trigger('contextmenu')
       expect(wrapper.find('#overlay').exists()).toBe(true)
       await wrapper.find('#trigger').trigger('click')
       expect(wrapper.find('#overlay').exists()).toBe(false)
+      expect(onVisibleChange).toBeCalledWith(false)
 
-      wrapper.vm.update({ trigger: 'manual' })
+      await wrapper.setProps({ trigger: 'manual' })
       await flushPromises()
 
       expect(Object.keys(wrapper.vm.triggerEvents).length).toEqual(0)
@@ -169,19 +205,28 @@ describe('usePopper', () => {
     })
 
     test('visible work', async () => {
-      const wrapper = PopperTestMount({ visible: true })
+      const onVisibleChange = vi.fn()
+      const wrapper = PopperTestMount({ props: { visible: true, trigger: 'click', onVisibleChange } })
       await flushPromises()
 
       expect(wrapper.find('#overlay').exists()).toBe(true)
 
-      wrapper.vm.update({ visible: false })
+      await wrapper.find('#trigger').trigger('click')
+      expect(wrapper.find('#overlay').exists()).toBe(true)
+      expect(onVisibleChange).toBeCalledWith(false)
+
+      await wrapper.setProps({ visible: false })
       await flushPromises()
 
       expect(wrapper.find('#overlay').exists()).toBe(false)
+
+      await wrapper.find('#trigger').trigger('click')
+      expect(wrapper.find('#overlay').exists()).toBe(false)
+      expect(onVisibleChange).toBeCalledWith(true)
     })
 
     test('delay work', async () => {
-      const wrapper = PopperTestMount({ delay: 50 })
+      const wrapper = PopperTestMount({ props: { delay: 50 } })
       await flushPromises()
 
       await wrapper.find('#trigger').trigger('mouseenter')
@@ -194,7 +239,7 @@ describe('usePopper', () => {
 
       expect(wrapper.find('#overlay').exists()).toBe(false)
 
-      wrapper.vm.update({ delay: [100, 120] })
+      await wrapper.setProps({ delay: [100, 120] })
       await flushPromises()
       await wrapper.find('#trigger').trigger('mouseenter')
       await wait(50)

--- a/packages/cdk/popper/src/composables/useDelay.ts
+++ b/packages/cdk/popper/src/composables/useDelay.ts
@@ -5,13 +5,13 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { PopperOptions } from '../types'
+import type { ResolvedPopperOptions } from '../types'
 
 import { type ComputedRef, computed } from 'vue'
 
 import { defaultDelay } from './useOptions'
 
-export function useDelay(options: Required<PopperOptions>): ComputedRef<{ show: number; hide: number }> {
+export function useDelay(options: ComputedRef<ResolvedPopperOptions>): ComputedRef<{ show: number; hide: number }> {
   const convertDelay = (delay: number | [number | null, number | null]) => {
     if (Array.isArray(delay)) {
       const [show, hide] = delay
@@ -20,5 +20,5 @@ export function useDelay(options: Required<PopperOptions>): ComputedRef<{ show: 
     return { show: delay, hide: delay }
   }
 
-  return computed(() => convertDelay(options.delay))
+  return computed(() => convertDelay(options.value.delay))
 }

--- a/packages/cdk/popper/src/composables/usePlacement.ts
+++ b/packages/cdk/popper/src/composables/usePlacement.ts
@@ -5,21 +5,21 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { PopperOptions, PopperPlacement } from '../types'
+import type { PopperPlacement, ResolvedPopperOptions } from '../types'
 
 import { type ComputedRef, computed, ref, watch } from 'vue'
 
-export function usePlacement(options: Required<PopperOptions>): {
+export function usePlacement(options: ComputedRef<ResolvedPopperOptions>): {
   placement: ComputedRef<PopperPlacement>
   updatePlacement: (value: PopperPlacement) => void
 } {
-  const _placement = ref(options.placement)
+  const _placement = ref(options.value.placement)
 
   const updatePlacement = (value: PopperPlacement) => {
     _placement.value = value
   }
 
-  watch(() => options.placement, updatePlacement)
+  watch(() => options.value.placement, updatePlacement)
 
   const placement = computed(() => _placement.value)
 

--- a/packages/cdk/popper/src/composables/usePopperEvents.ts
+++ b/packages/cdk/popper/src/composables/usePopperEvents.ts
@@ -5,14 +5,14 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { PopperEvents, PopperOptions } from '../types'
+import type { PopperEvents, ResolvedPopperOptions } from '../types'
 
 import { type ComputedRef, computed } from 'vue'
 
 import { NoopObject } from '@idux/cdk/utils'
 
 export function usePopperEvents(
-  baseOptions: Required<PopperOptions>,
+  baseOptions: ComputedRef<ResolvedPopperOptions>,
   eventOptions: { show(): void; hide(): void },
 ): ComputedRef<PopperEvents> {
   const { show, hide } = eventOptions
@@ -28,5 +28,8 @@ export function usePopperEvents(
     manual: NoopObject,
   }
 
-  return computed(() => (baseOptions.allowEnter ? eventsMap[baseOptions.trigger] : NoopObject))
+  return computed(() => {
+    const { allowEnter, trigger } = baseOptions.value
+    return allowEnter ? eventsMap[trigger] : NoopObject
+  })
 }

--- a/packages/cdk/popper/src/composables/useTriggerEvents.ts
+++ b/packages/cdk/popper/src/composables/useTriggerEvents.ts
@@ -5,12 +5,12 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { PopperOptions, PopperTriggerEvents } from '../types'
+import type { PopperTriggerEvents, ResolvedPopperOptions } from '../types'
 
 import { type ComputedRef, computed } from 'vue'
 
 export function useTriggerEvents(
-  baseOptions: Required<PopperOptions>,
+  baseOptions: ComputedRef<ResolvedPopperOptions>,
   eventOptions: { visibility: ComputedRef<boolean>; show(): void; hide(): void },
 ): ComputedRef<PopperTriggerEvents> {
   const { visibility, show, hide } = eventOptions
@@ -21,7 +21,7 @@ export function useTriggerEvents(
   const onBlur = () => hide()
 
   const onClick = () => {
-    const { trigger } = baseOptions
+    const { trigger } = baseOptions.value
     if (trigger === 'click') {
       visibility.value ? hide() : show()
     } else if (trigger === 'contextmenu') {
@@ -42,5 +42,5 @@ export function useTriggerEvents(
     manual: {},
   }
 
-  return computed(() => eventsMap[baseOptions.trigger])
+  return computed(() => eventsMap[baseOptions.value.trigger])
 }

--- a/packages/cdk/popper/src/composables/useVisibility.ts
+++ b/packages/cdk/popper/src/composables/useVisibility.ts
@@ -5,11 +5,29 @@
  * found in the LICENSE file at https://github.com/IDuxFE/idux/blob/main/LICENSE
  */
 
-import type { PopperOptions } from '../types'
+import type { ResolvedPopperOptions } from '../types'
 import type { ComputedRef } from 'vue'
 
-import { computed } from 'vue'
+import { computed, shallowRef } from 'vue'
 
-export function useVisibility(options: Required<PopperOptions>): ComputedRef<boolean> {
-  return computed(() => !options.disabled && options.visible)
+export function useVisibility(options: ComputedRef<ResolvedPopperOptions>): {
+  visibility: ComputedRef<boolean>
+  updateVisibility: (visible: boolean) => void
+} {
+  const visible = shallowRef(!!options.value.visible)
+  const mergedVisible = computed(() => !options.value.disabled && !!(options.value.visible ?? visible.value))
+
+  const updateVisibility = (v: boolean) => {
+    if (v === mergedVisible.value) {
+      return
+    }
+
+    visible.value = v
+    options.value.onVisibleChange?.(v)
+  }
+
+  return {
+    visibility: mergedVisible,
+    updateVisibility,
+  }
 }

--- a/packages/cdk/popper/src/types.ts
+++ b/packages/cdk/popper/src/types.ts
@@ -6,7 +6,8 @@
  */
 
 import type { Middleware, Strategy } from '@floating-ui/dom'
-import type { ComponentPublicInstance, ComputedRef, Ref } from 'vue'
+import type { MaybeRef } from '@idux/cdk/utils'
+import type { ComponentPublicInstance, ComputedRef, Ref, UnwrapRef } from 'vue'
 
 export type PopperStrategy = Strategy
 export type PopperTrigger = 'click' | 'hover' | 'focus' | 'contextmenu' | 'manual'
@@ -44,12 +45,12 @@ export interface PopperOptions {
    * Whether to allow the mouse to enter the popper
    * * default is `true`
    */
-  allowEnter?: boolean
+  allowEnter?: MaybeRef<boolean | undefined>
   /**
    * Whether auto adjust when space is not enough
    * * default is `true`
    */
-  autoAdjust?: boolean
+  autoAdjust?: MaybeRef<boolean | undefined>
   /**
    * Delay in ms once a trigger event is fired before a tippy shows or hides
    *
@@ -59,37 +60,45 @@ export interface PopperOptions {
    * * [100, 200]: show delay is 100ms, hide delay is 200ms
    * * [100, null]: show delay is 100ms, hide delay is the default
    */
-  delay?: number | [number | null, number | null]
+  delay?: MaybeRef<number | [number | null, number | null] | undefined>
   /**
    * Disable the popper
    * * default is `false`
    */
-  disabled?: boolean
+  disabled?: MaybeRef<boolean | undefined>
   /**
    * Popper offset.
    * * [Horizontal axis offset, vertical axis offset]
    * * default is `[0, 0]`
    */
-  offset?: [number, number]
+  offset?: MaybeRef<[number, number] | undefined>
   /**
    * Alignment of popper
    * * default is `top`
    */
-  placement?: PopperPlacement
+  placement?: MaybeRef<PopperPlacement | undefined>
   /**
    * Trigger method
    * * default is `hover`
    */
-  trigger?: PopperTrigger
+  trigger?: MaybeRef<PopperTrigger | undefined>
   /**
    * Control the visibility of the popper
    * * default is `false`
    */
-  visible?: boolean
+  visible?: MaybeRef<boolean | undefined>
 
-  strategy?: PopperStrategy
-  middlewares?: Array<Middleware>
+  strategy?: MaybeRef<PopperStrategy | undefined>
+  middlewares?: MaybeRef<Array<Middleware> | undefined>
+
+  /**
+   * visible change event callback
+   */
+  onVisibleChange?: (visible: boolean) => void
 }
+
+export type ResolvedPopperOptions = Required<UnwrapRef<Omit<PopperOptions, 'onVisibleChange' | 'visible'>>> &
+  Pick<PopperOptions, 'onVisibleChange' | 'visible'>
 
 export interface PopperInstance<TE extends PopperElement = PopperElement, PE extends PopperElement = PopperElement> {
   /**

--- a/packages/cdk/popper/src/usePopper.ts
+++ b/packages/cdk/popper/src/usePopper.ts
@@ -30,25 +30,25 @@ export function usePopper<TE extends PopperElement = PopperElement, PE extends P
   const popperRef = ref<PE>()
   const arrowRef = ref<HTMLElement>()
 
-  const { popperOptions, updateOptions } = usePopperOptions(options)
-  const baseOptions = useBaseOptions(popperOptions)
+  const { resolvedOptions, updateOptions } = usePopperOptions(options)
+  const baseOptions = useBaseOptions(resolvedOptions)
   const convertedOptions = computed(() =>
     convertOptions(baseOptions.value, { arrowElement: convertElement(arrowRef), updatePlacement }),
   )
 
-  const visibility = useVisibility(popperOptions)
-  const { placement, updatePlacement } = usePlacement(popperOptions)
-  const delay = useDelay(popperOptions)
+  const { visibility, updateVisibility } = useVisibility(resolvedOptions)
+  const { placement, updatePlacement } = usePlacement(resolvedOptions)
+  const delay = useDelay(resolvedOptions)
 
   const { setTimer, clearTimer } = useTimer()
-  const triggerEvents = useTriggerEvents(popperOptions, { visibility, show, hide })
-  const popperEvents = usePopperEvents(popperOptions, { show, hide })
+  const triggerEvents = useTriggerEvents(resolvedOptions, { visibility, show, hide })
+  const popperEvents = usePopperEvents(resolvedOptions, { show, hide })
 
   function toggle(visible: boolean, delay: number): void {
     clearTimer()
 
     const action = () => {
-      popperOptions.visible = visible
+      updateVisibility(visible)
     }
     if (delay > 0) {
       setTimer(action, delay)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
1. popper的 visible 不支持受控
2. popper的所有配置不支持ref

## What is the new behavior?
1. 新增 onVisibleChange 属性，支持 visible 受控
2. 所有option，除onVisibleChange之外，支持传入Ref变量进行控制

## Other information
当前暂时保留options本身的reactive监听支持，后续会去掉