### PR TITLE
fix(cdk:popper): visible shouldn't be updated when disabled

### DIFF
--- a/packages/cdk/popper/src/composables/useVisibility.ts
+++ b/packages/cdk/popper/src/composables/useVisibility.ts
@@ -18,7 +18,7 @@ export function useVisibility(options: ComputedRef<ResolvedPopperOptions>): {
   const mergedVisible = computed(() => !options.value.disabled && !!(options.value.visible ?? visible.value))
 
   const updateVisibility = (v: boolean) => {
-    if (v === mergedVisible.value) {
+    if (options.value.disabled || v === visible.value) {
       return
     }
 

--- a/packages/components/_private/overlay/src/composables/useVisible.ts
+++ b/packages/components/_private/overlay/src/composables/useVisible.ts
@@ -8,7 +8,7 @@
 import type { OverlayProps } from '../types'
 import type { PopperTrigger } from '@idux/cdk/popper'
 
-import { type ComputedRef, inject, nextTick, onMounted, watch } from 'vue'
+import { type ComputedRef, inject, nextTick, onBeforeUnmount, onMounted, watch } from 'vue'
 
 import { useControlledProp, useState } from '@idux/cdk/utils'
 
@@ -31,6 +31,10 @@ export function useVisible(
   const [visible, setVisible] = useControlledProp(props, 'visible', false)
   const [visibleLocked, setVisibleLocked] = useState(false)
   const lock = () => {
+    if (visibleLocked.value) {
+      return
+    }
+
     setVisibleLocked(true)
 
     if (parentLockContext?.lock) {
@@ -39,6 +43,10 @@ export function useVisible(
   }
 
   const unlock = () => {
+    if (!visibleLocked.value) {
+      return
+    }
+
     setVisibleLocked(false)
 
     if ((trigger.value === 'hover' && !isHovered.value) || (trigger.value === 'focus' && !isFocused.value)) {
@@ -67,6 +75,9 @@ export function useVisible(
     if (visible.value) {
       parentLockContext?.lock()
     }
+  })
+  onBeforeUnmount(() => {
+    parentLockContext?.unlock()
   })
 
   return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当popper禁用时，触发相应的事件，依然会触发visible为true的更新，但是并不会触发visible为false的更新，导致嵌套的内层浮层如果是禁用的，可能造成上层浮层永远被锁不能触发更新

## What is the new behavior?
修复以上问题

## Other information
