### PR TITLE
fix(comp:table): alert row shouldn't render when alert slot returns empty node

### DIFF
--- a/packages/components/table/src/main/MainTable.tsx
+++ b/packages/components/table/src/main/MainTable.tsx
@@ -31,7 +31,15 @@ import {
   type VirtualRowRenderFn,
   type VirtualScrollRowData,
 } from '@idux/cdk/scroll'
-import { Logger, type VKey, callEmit, convertArray, convertElement, isVisibleElement } from '@idux/cdk/utils'
+import {
+  Logger,
+  type VKey,
+  callEmit,
+  convertArray,
+  convertElement,
+  isEmptyNode,
+  isVisibleElement,
+} from '@idux/cdk/utils'
 import { ɵEmpty } from '@idux/components/_private/empty'
 
 import ColGroup from './ColGroup'
@@ -186,13 +194,14 @@ export default defineComponent({
     }
 
     const renderAlert = (columns: TableColumnMerged[] | undefined) => {
-      if (!slots.alert) {
+      const alertNodes = slots.alert?.()
+      if (isEmptyNode(alertNodes)) {
         return
       }
 
       return (
         <BodyRowSingle class={`${mergedPrefixCls.value}-alert-row`} columns={columns}>
-          {slots.alert()}
+          {alertNodes}
         </BodyRowSingle>
       )
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当alert插槽返回一个空节点时，表格内依然会渲染一个row

## What is the new behavior?
判断alert插槽是否是空节点，只有非空节点时才会渲染aler 行

## Other information
