### PR TITLE
fix(cdk:popper): placement option can't update if pass normal value

### DIFF
--- a/packages/cdk/popper/demo/Placement.vue
+++ b/packages/cdk/popper/demo/Placement.vue
@@ -32,7 +32,9 @@ export default defineComponent({
   setup() {
     const placement = ref<PopperPlacement>('top')
 
-    const { initialize, destroy, update, popperRef, triggerRef, popperEvents, triggerEvents, visibility } = usePopper()
+    const { initialize, destroy, update, popperRef, triggerRef, popperEvents, triggerEvents, visibility } = usePopper({
+      placement: placement.value,
+    })
 
     onMounted(() => initialize())
     onBeforeUnmount(() => destroy())

--- a/packages/cdk/popper/src/composables/useOptions.ts
+++ b/packages/cdk/popper/src/composables/useOptions.ts
@@ -20,17 +20,17 @@ export function usePopperOptions(options: PopperOptions): {
   const localOptions: PopperOptions = reactive({})
   const resolvedOptions = computed<ResolvedPopperOptions>(() => {
     return {
-      allowEnter: unref(options.allowEnter ?? localOptions.allowEnter) ?? true,
-      autoAdjust: unref(options.autoAdjust ?? localOptions.autoAdjust) ?? true,
-      delay: unref(options.delay ?? localOptions.delay) ?? defaultDelay,
-      disabled: unref(options.disabled ?? localOptions.disabled) ?? false,
-      offset: unref(options.offset ?? localOptions.offset) ?? [0, 0],
-      placement: unref(options.placement ?? localOptions.placement) ?? 'bottomStart',
-      trigger: unref(options.trigger ?? localOptions.trigger) ?? 'hover',
-      strategy: unref(options.strategy ?? localOptions.strategy) ?? 'absolute',
-      middlewares: unref(options.middlewares ?? localOptions.middlewares) ?? [],
-      visible: unref(options.visible ?? localOptions.visible),
-      onVisibleChange: options.onVisibleChange ?? localOptions.onVisibleChange,
+      allowEnter: unref(localOptions.allowEnter ?? options.allowEnter) ?? true,
+      autoAdjust: unref(localOptions.autoAdjust ?? options.autoAdjust) ?? true,
+      delay: unref(localOptions.delay ?? options.delay) ?? defaultDelay,
+      disabled: unref(localOptions.disabled ?? options.disabled) ?? false,
+      offset: unref(localOptions.offset ?? options.offset) ?? [0, 0],
+      placement: unref(localOptions.placement ?? options.placement) ?? 'bottomStart',
+      trigger: unref(localOptions.trigger ?? options.trigger) ?? 'hover',
+      strategy: unref(localOptions.strategy ?? options.strategy) ?? 'absolute',
+      middlewares: unref(localOptions.middlewares ?? options.middlewares) ?? [],
+      visible: unref(localOptions.visible ?? options.visible),
+      onVisibleChange: localOptions.onVisibleChange ?? options.onVisibleChange,
     }
   })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```ts
const { initialize, destroy, update, popperRef, triggerRef, popperEvents, triggerEvents, visibility } = usePopper({
      placement: placement.value,
 })
```

这样初始化的时候，当调用 update 更新 localOptions 的值，popper 的位置并不会改变。因为 resolvedOptions 的 placement 永远都是我们第一次传入的值。

## What is the new behavior?


## Other information
