### PR TITLE
fix(cdk:popper): popper can't open when visible is updated by user

### DIFF
--- a/packages/cdk/popper/src/composables/useVisibility.ts
+++ b/packages/cdk/popper/src/composables/useVisibility.ts
@@ -18,7 +18,7 @@ export function useVisibility(options: ComputedRef<ResolvedPopperOptions>): {
   const mergedVisible = computed(() => !options.value.disabled && !!(options.value.visible ?? visible.value))
 
   const updateVisibility = (v: boolean) => {
-    if (options.value.disabled || v === visible.value) {
+    if (options.value.disabled || v === (options.value.visible ?? visible.value)) {
       return
     }
 

--- a/packages/cdk/popper/src/types.ts
+++ b/packages/cdk/popper/src/types.ts
@@ -98,7 +98,8 @@ export interface PopperOptions {
 }
 
 export type ResolvedPopperOptions = Required<UnwrapRef<Omit<PopperOptions, 'onVisibleChange' | 'visible'>>> &
-  Pick<PopperOptions, 'onVisibleChange' | 'visible'>
+  UnwrapRef<Pick<PopperOptions, 'visible'>> &
+  Pick<PopperOptions, 'onVisibleChange'>
 
 export interface PopperInstance<TE extends PopperElement = PopperElement, PE extends PopperElement = PopperElement> {
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当popper的visible被受控修改后，无法通过内部事件再次开启

## What is the new behavior?


## Other information
