### PR TITLE
fix(cdk:popper): `update` shouldn't change ref option param

### DIFF
--- a/packages/cdk/popper/demo/Controlled.md
+++ b/packages/cdk/popper/demo/Controlled.md
@@ -1,0 +1,6 @@
+---
+order: 3
+title:
+  zh: 受控使用
+  en: Controlled usage
+---

--- a/packages/cdk/popper/demo/Controlled.vue
+++ b/packages/cdk/popper/demo/Controlled.vue
@@ -1,0 +1,58 @@
+<template>
+  <IxSpace align="center">
+    <IxButton ref="triggerRef" v-bind="triggerEvents">Trigger</IxButton>
+    <IxButton @click="toggleVisible">Toggle Visible</IxButton>
+    <IxRadioGroup v-model:value="trigger">
+      <IxRadio value="hover">hover</IxRadio>
+      <IxRadio value="click">click</IxRadio>
+      <IxRadio value="focus">focus</IxRadio>
+      <IxRadio value="contextmenu">contextmenu</IxRadio>
+    </IxRadioGroup>
+  </IxSpace>
+  <div v-if="visibility" ref="popperRef" class="popper" v-bind="popperEvents">
+    <div>Popper Element</div>
+    <br />
+    <IxButton @click="toggleLocked">{{ visibleLocked ? 'Unlock' : 'Lock' }}</IxButton>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { PopperTrigger, usePopper } from '@idux/cdk/popper'
+
+const visibleRef = ref(false)
+const trigger = ref<PopperTrigger>('hover')
+const visibleLocked = ref(false)
+
+const toggleLocked = () => {
+  visibleLocked.value = !visibleLocked.value
+}
+
+const onVisibleChange = (v: boolean) => {
+  if (visibleLocked.value) {
+    return
+  }
+
+  visibleRef.value = v
+}
+const toggleVisible = () => {
+  onVisibleChange(!visibleRef.value)
+}
+
+const { initialize, destroy, popperRef, popperEvents, triggerRef, triggerEvents, visibility } = usePopper({
+  visible: visibleRef,
+  trigger,
+  onVisibleChange,
+})
+onMounted(() => initialize())
+onBeforeUnmount(() => destroy())
+</script>
+
+<style lang="less" scoped>
+.popper {
+  padding: 8px;
+  color: #fff;
+  background: #7824ff;
+}
+</style>

--- a/packages/cdk/popper/demo/Placement.vue
+++ b/packages/cdk/popper/demo/Placement.vue
@@ -24,7 +24,7 @@
 <script lang="ts">
 import type { PopperPlacement } from '@idux/cdk/popper'
 
-import { defineComponent, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { defineComponent, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import { usePopper } from '@idux/cdk/popper'
 
@@ -32,14 +32,12 @@ export default defineComponent({
   setup() {
     const placement = ref<PopperPlacement>('top')
 
-    const { initialize, destroy, update, popperRef, triggerRef, popperEvents, triggerEvents, visibility } = usePopper()
+    const { initialize, destroy, popperRef, triggerRef, popperEvents, triggerEvents, visibility } = usePopper({
+      placement: placement.value,
+    })
 
     onMounted(() => initialize())
     onBeforeUnmount(() => destroy())
-
-    watch(placement, () => {
-      update({ placement: placement.value })
-    })
 
     return { placement, popperRef, popperEvents, triggerRef, triggerEvents, visibility }
   },

--- a/packages/cdk/popper/demo/Trigger.vue
+++ b/packages/cdk/popper/demo/Trigger.vue
@@ -4,7 +4,7 @@
     <IxButton ref="focusTriggerRef" v-bind="focusTriggerEvents">Focus</IxButton>
     <IxButton ref="clickTriggerRef" v-bind="clickTriggerEvents">Click</IxButton>
     <IxButton ref="contextmenuTriggerRef" v-bind="contextmenuTriggerEvents">Contextmenu</IxButton>
-    <IxButton ref="manualTriggerRef" @click="manualUpdate({ visible: !manualVisibility })">Manual</IxButton>
+    <IxButton ref="manualTriggerRef" @click="toggleManualVisible">Manual</IxButton>
   </IxSpace>
   <CdkPortal target=".ix-popper-container">
     <div v-if="hoverVisibility" ref="hoverPopperRef" class="popper popper-hover" v-bind="hoverPopperEvents">Hover</div>
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeUnmount, onMounted } from 'vue'
+import { defineComponent, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import { usePopper } from '@idux/cdk/popper'
 
@@ -28,6 +28,11 @@ export default defineComponent({
     const clickPopper = usePopper({ trigger: 'click' })
     const contextmenuPopper = usePopper({ trigger: 'contextmenu' })
     const manualPopper = usePopper({ trigger: 'manual' })
+
+    const manualVisible = ref(false)
+    const toggleManualVisible = () => {
+      manualVisible.value = !manualVisible.value
+    }
 
     const instances = [hoverPopper, focusPopper, clickPopper, contextmenuPopper, manualPopper]
 
@@ -64,7 +69,7 @@ export default defineComponent({
       manualTriggerRef: manualPopper.triggerRef,
       manualPopperRef: manualPopper.popperRef,
       manualVisibility: manualPopper.visibility,
-      manualUpdate: manualPopper.update,
+      toggleManualVisible,
     }
   },
 })

--- a/packages/cdk/popper/docs/Api.zh.md
+++ b/packages/cdk/popper/docs/Api.zh.md
@@ -11,15 +11,15 @@ export function usePopper(options?: PopperOptions): PopperInstance
 
 | 名称 | 说明 | 类型  | 默认值 | 全局配置 | 备注 |
 | --- | --- | --- | --- | --- | --- |
-| `autoAdjust` | 空间不足时是否自动调整位置 | `boolean` | `true` | - |- |
-| `delay` | 延迟显示或隐藏的时间 | `number \| [number \| null, number \| null]` | `0` | - | 为数组时，第一个元素是延迟显示的时间，第二个元素是延迟隐藏的时间 |
-| `disabled` | 是否禁用浮层 | `boolean` | `false` | - | - |
-| `offset` | 浮层相对目标元素的偏移量 | `[number, number]` | `[0, 0]` | - | 第一个元素是水平偏移量，第二个元素是垂直偏移量 |
-| `placement` | 浮层的位置 | `PopperPlacement` | `bottomStart` | - | - |
-| `trigger` | 浮层的触发方式 | `PopperTrigger` | `hover` | - | - |
-| `visible` | 是否显示浮层 | `boolean` | `false` | - | - |
-| `strategy` | 浮层的定位策略 | `'absolute' \| 'fixed'` | `absolute` | - | - |
-| `middleware` | 自定义浮层的 `middleware` | `Middleware[]` | `[]` | - | 参见[floating-ui](https://floating-ui.com/docs/middleware) |
+| `autoAdjust` | 空间不足时是否自动调整位置 | `boolean \| Ref<boolean>` | `true` | - |- |
+| `delay` | 延迟显示或隐藏的时间 | `number \| [number \| null, number \| null] \| Ref<number \| [number \| null, number \| null]>` | `0` | - | 为数组时，第一个元素是延迟显示的时间，第二个元素是延迟隐藏的时间 |
+| `disabled` | 是否禁用浮层 | `boolean \| Ref<boolean>` | `false` | - | - |
+| `offset` | 浮层相对目标元素的偏移量 | `[number, number] \| Ref<[number, number]>` | `[0, 0]` | - | 第一个元素是水平偏移量，第二个元素是垂直偏移量 |
+| `placement` | 浮层的位置 | `PopperPlacement \| Ref<PopperPlacement>` | `bottomStart` | - | - |
+| `trigger` | 浮层的触发方式 | `PopperTrigger \| Ref<PopperTrigger>` | `hover` | - | - |
+| `visible` | 是否显示浮层 | `boolean \| Ref<boolean>` | `false` | - | - |
+| `strategy` | 浮层的定位策略 | `'absolute' \| 'fixed' \| Ref<'absolute' \| 'fixed'>` | `absolute` | - | - |
+| `middleware` | 自定义浮层的 `middleware` | `Middleware[] \| Ref<Middleware[]>` | `[]` | - | 参见[floating-ui](https://floating-ui.com/docs/middleware) |
 
 ```ts
 export declare type PopperPlacement = 'topStart' | 'top' | 'topEnd' | 'rightStart' | 'right' | 'rightEnd' | 'bottomStart' | 'bottom' | 'bottomEnd' | 'leftStart' | 'left' | 'leftEnd'
@@ -34,7 +34,7 @@ export type PopperTrigger = 'click' | 'hover' | 'focus' | 'contextmenu' | 'manua
 | `initialize` | 初始化浮层 | `(): void` | - | - | 应该在组件被创建后调用 |
 | `show` | 显示浮层 | `(delay?: number): void` | - | - | `delay` 是延迟显示的时间 |
 | `hide` | 隐藏浮层 | `(delay?: number): void` | - | - | `delay` 是延迟隐藏的时间 |
-| `update` | 更新浮层 | `(options: Partial<PopperOptions>): void` | - | - | - |
+| `update` | 更新浮层 | `(): void` | - | - | - |
 | `destroy` | 销毁浮层 | `(): void` | - | - | - |
 | `visibility` | 浮层显示状态 | `ComputedRef<boolean>` | -| - | - |
 | `placement` | 浮层位置 | `ComputedRef<PopperPlacement>` | - | - | - |

--- a/packages/cdk/popper/src/composables/useTimer.ts
+++ b/packages/cdk/popper/src/composables/useTimer.ts
@@ -9,10 +9,11 @@ export function useTimer(): { setTimer: (action: () => void, delay: number) => v
   let timer: number | null = null
 
   const setTimer = (action: () => void, delay: number) => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-    timer = setTimeout(action, delay)
+    clearTimer()
+    timer = setTimeout(() => {
+      action()
+      timer = null
+    }, delay)
   }
 
   const clearTimer = () => {

--- a/packages/cdk/popper/src/convertOptions.ts
+++ b/packages/cdk/popper/src/convertOptions.ts
@@ -31,6 +31,8 @@ export function convertOptions(baseOptions: BaseOptions, extraOptions: ExtraOpti
   const { placement, strategy, middlewares, offset, autoAdjust } = baseOptions
   const { arrowElement, updatePlacement: _updatePlacement } = extraOptions
 
+  console.log(baseOptions)
+
   const { width } = arrowElement?.getBoundingClientRect() ?? {}
   const arrowSize = width ? width / 2 : 0
 

--- a/packages/cdk/popper/src/types.ts
+++ b/packages/cdk/popper/src/types.ts
@@ -74,7 +74,7 @@ export interface PopperOptions {
   offset?: MaybeRef<[number, number] | undefined>
   /**
    * Alignment of popper
-   * * default is `top`
+   * * default is `bottomStart`
    */
   placement?: MaybeRef<PopperPlacement | undefined>
   /**
@@ -84,7 +84,7 @@ export interface PopperOptions {
   trigger?: MaybeRef<PopperTrigger | undefined>
   /**
    * Control the visibility of the popper
-   * * default is `false`
+   * * default is `undefined`
    */
   visible?: MaybeRef<boolean | undefined>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/IDuxFE/idux/blob/main/packages/site/src/docs/Contributing.zh.md#commit)
- [x] Tests for the changes have been added/updated or not needed
- [x] Docs and demo have been added/updated or not needed

## What is the current behavior?
当初始的option传入了某项配置后，调用update方法对其进行修改，无法生效

## What is the new behavior?
如果传入的是ref变量，不支持update修改
如果传入的是非ref变量，可以通过update修改

## Other information
已经不推荐使用update方法修改option，建议均使用ref变量，文档中已经去掉了对update的参数